### PR TITLE
fix(find): the find widget's tooltips stop being clipped away (#675)

### DIFF
--- a/scripts/exportFoldParity.test.ts
+++ b/scripts/exportFoldParity.test.ts
@@ -92,6 +92,12 @@ const NEVER_IN_PRINT =
 	/:(?:hover|focus|focus-visible|focus-within|active|target|before|after|marker|placeholder|selection|backdrop|first-line|first-letter)\b|::/;
 const NEEDS_SIBLINGS = /[+~]/;
 const STRUCTURAL = /:(?:first|last|only|nth)-[a-z-]+/;
+// `:has()` asks about a subtree, and only the ancestor chain is modelled. It is
+// stripped rather than refused for the same reason STRUCTURAL is: the rest of
+// the compound still answers most elements outright, and a rule keyed on a
+// class this element does not carry is decided without ever consulting the
+// subtree. Only a compound that otherwise matches has to admit it cannot tell.
+const RELATIONAL = /:has\([^()]*\)/;
 
 /** false: cannot match this element. 'unsupported': the matcher cannot tell. */
 function compoundMatches(compound: string, element: Element): boolean | 'unsupported' {
@@ -113,7 +119,7 @@ function compoundMatches(compound: string, element: Element): boolean | 'unsuppo
 	if (withoutNot.includes(':fails')) return false;
 	if (withoutNot.includes(':unsupported')) return 'unsupported';
 
-	const bare = withoutNot.replace(STRUCTURAL, '');
+	const bare = withoutNot.replace(STRUCTURAL, '').replace(RELATIONAL, '');
 	if (!/^\*?(?:[a-z][a-z0-9]*)?(?:\.[A-Za-z0-9_-]+)*$/i.test(bare)) return 'unsupported';
 
 	const classes = [...bare.matchAll(/\.([A-Za-z0-9_-]+)/g)].map((m) => m[1]);
@@ -121,7 +127,7 @@ function compoundMatches(compound: string, element: Element): boolean | 'unsuppo
 	if (tag && tag !== element.tag) return false;
 	if (!classes.every((cls) => element.classes.includes(cls))) return false;
 	// Only now, with everything else matching, does the unmodelled part bite.
-	return STRUCTURAL.test(withoutNot) ? 'unsupported' : true;
+	return STRUCTURAL.test(withoutNot) || RELATIONAL.test(withoutNot) ? 'unsupported' : true;
 }
 
 /** Right-to-left matching against an ancestor chain (root first). */

--- a/scripts/findWidgetTooltipClip.test.ts
+++ b/scripts/findWidgetTooltipClip.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource, sliceFrom } from './sourceTree.js';
+
+// #675: Monaco draws the find widget's button tooltips into a `.context-view`
+// it appends beside the editor, above the target, and the widget sits at the
+// top edge of the editor pane — so the tooltip lands in the strip the pane and
+// `.editor-outer` clip away, and behind the fixed title bar.
+//
+// Both halves of the fix are invisible to the compiler and to any test that
+// runs the app without a real layout: one is a CSS clip that has to be dropped
+// on *both* boxes, the other is a z-index that only works while it stays above
+// the title bar's. The second is a coupling between two rules in two files —
+// raise `.custom-title-bar`'s z-index and the tooltip silently goes back under
+// it, with nothing failing.
+
+const styles = readSource('src/styles.css');
+const titleBar = readSource('src/lib/components/TitleBar.svelte');
+
+const fixBlock = sliceFrom(styles, ".pane.editor-pane:has(.find-widget.visible)");
+
+function zIndexOf(source: string, selector: string): number {
+	// Line-anchored: `.context-view` is also named in the prose above the rule,
+	// and a loose match starts there and runs into the wrong declaration block.
+	const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const rule = source.match(new RegExp(`^\\s*${escaped}[^{}]*\\{([^}]*)\\}`, 'm'));
+	assert.ok(rule, `expected a rule for ${selector}`);
+	const declaration = rule[1].match(/(?<![\w-])z-index:\s*(\d+)/);
+	assert.ok(declaration, `expected a z-index on ${selector}`);
+	return Number(declaration[1]);
+}
+
+test('the find widget tooltip escapes both clips, and only while the widget is up', () => {
+	// Not `overflow: clip` with a margin: WebKit ships `clip` without
+	// `overflow-clip-margin`, so that spelling is a no-op on macOS and Linux.
+	assert.match(fixBlock, /\.pane\.editor-pane:has\(\.find-widget\.visible\),\s*\n\s*\.pane\.editor-pane:has\(\.find-widget\.visible\) \.editor-outer \{\s*\n\s*overflow: visible;/);
+});
+
+test('the tooltip outranks the title bar it now paints over', () => {
+	const contextView = zIndexOf(styles, '.context-view');
+	const titleBarZ = zIndexOf(titleBar, '.custom-title-bar');
+	assert.ok(
+		contextView > titleBarZ,
+		`.context-view (${contextView}) must stay above .custom-title-bar (${titleBarZ})`,
+	);
+	// Monaco writes `z-index: 2576` inline on the node, so the rule only lands
+	// if it is marked important.
+	assert.match(styles, /\.context-view \{\s*\n\s*z-index: \d+ !important;/);
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -1968,3 +1968,43 @@ body {
 .markdown-body .content-inner > .markdown-alert:first-child {
 	margin-top: 12px !important;
 }
+
+/*
+ * Monaco's find widget (Ctrl+F / Ctrl+H in the editor) draws its button
+ * tooltips through the hover service, which mounts them *outside* the editor
+ * proper — a `.context-view` appended to `.editor-container` — and puts them
+ * ABOVE the target. It only flips one below when the tooltip would leave the
+ * WINDOW (hoverWidget.js, adjustVerticalHoverPosition), and the widget sits a
+ * title bar's height down rather than at the window top, so the flip never
+ * fires and the tooltip lands in the strip `.pane` and `.editor-outer` clip
+ * away. That is #675: the first row of buttons showed a sliver of a tooltip or
+ * none, and the sliver that did reach the button flickered as the pointer
+ * crossed it. The second row was fine because its tooltip still fits inside
+ * the pane.
+ *
+ * So drop both clips while the widget is visible. Nothing else escapes: Monaco
+ * clips its own content — and the find widget itself, which lives in
+ * `.overlayWidgets` — inside `.overflow-guard`, leaving `.context-view` as the
+ * only child that can paint outside. `:has(.find-widget.visible)` still scopes
+ * it to when the widget is up, so the pane's flex/opacity transitions keep the
+ * clip they were written against.
+ *
+ * `overflow: clip` with an `overflow-clip-margin` would bound the escape more
+ * tightly, but WebKit ships `clip` without the margin property, so it would
+ * degrade to a plain clip — a silent no-op on the macOS and Linux builds.
+ * `clip-path: inset(-48px 0 0 0)` expresses it exactly and fails for a
+ * different reason: it creates a stacking context, which traps the tooltip
+ * below the title bar it has to paint over.
+ */
+.pane.editor-pane:has(.find-widget.visible),
+.pane.editor-pane:has(.find-widget.visible) .editor-outer {
+	overflow: visible;
+}
+
+/* Monaco writes `z-index: 2576` inline on this node, so only `!important`
+   reaches it, and the title bar it now has to clear is at 9999. Context menus
+   ride the same element and want the same thing: a menu opened near the top of
+   the editor belongs over the title bar, not under it. */
+.context-view {
+	z-index: 10000 !important;
+}


### PR DESCRIPTION
## What this is

Closes #675, reported by @khbbkhbk with two screenshots: hovering any button in the *first* row of the editor's find/replace bar (Ctrl+F / Ctrl+H) either showed a sliver of a tooltip or one that flickered while the pointer sat still. The second row was fine.

Tooltips on that row are now fully visible, drawn over the tab-bar strip the way VS Code draws them over its tabs, and they no longer overlap the button that summoned them.

## Mechanism

Monaco's find widget draws its button tooltips through the hover service, which appends a `.context-view` next to the editor and places it **above** the target. `hoverWidget.js`'s `adjustVerticalHoverPosition` flips one below only when the tooltip would leave the **window** — measured in viewport coordinates, not against the editor. The widget sits a title bar's height down (36px here, tooltip ~25px), so the check passes with ~10px to spare, the flip never fires, and the tooltip lands at y≈14–39: inside the strip `.pane` and `.editor-outer` clip with `overflow: hidden`, and behind `.custom-title-bar`, which is `position: fixed; z-index: 9999` against the inline `z-index: 2576` Monaco writes on the context view.

Both had to go, or the tooltip is clipped in one case and painted under the title bar in the other. The second row was never affected because its tooltip fits inside the pane.

Measured on the reporter's configuration (editor toolbar hidden, so the widget hugs the pane's top edge), by hit-testing the tooltip box with `elementFromPoint`:

| | tooltip top | middle | bottom |
|---|---|---|---|
| before | title bar | title bar | `hover-contents` |
| after | `hover-contents` | `hover-contents` | `hover-contents` |

"Close (Escape)" now renders on one line, 103×25 at y13–38, clear of its button at y41–63 — that overlap is what the reported flicker was: the tooltip covered the button, the pointer entered the tooltip, the button's `mouseleave` hid it, and the cycle repeated.

## Scope

`overflow: visible` rather than `overflow: clip` with an `overflow-clip-margin`, which would bound the escape more tightly: per MDN's compat data WebKit ships `clip` with `version_added: false` for the margin property, so that spelling degrades to a plain clip — a silent no-op on the macOS and Linux builds. `clip-path: inset(-48px 0 0 0)` expresses the intent exactly and fails differently: it creates a stacking context, trapping the tooltip below the title bar it has to paint over.

Letting the panes go `visible` unconditionally would risk content spilling sideways during the pane's flex/opacity transitions, when Monaco's layout lags the animation — hence `:has(.find-widget.visible)`. It turns out to be belt-and-braces: Monaco keeps its content *and the find widget itself* inside `.overflow-guard`, so `.context-view` is the only child that can paint outside at all.

Not touched: the preview's own find bar (`FindBar.svelte`), which has its own tooltips and never had this problem; and the underlying limitation, which is that standalone Monaco mounts hovers in the editor's container rather than at the document root. Replacing the editor's find UI with the app's own find bar would settle both, and is a feature, not this fix.

## Tests

`scripts/findWidgetTooltipClip.test.ts`, two source-shape assertions. Revert either half of the fix and both go red — checked by flipping `overflow: visible` back to `hidden` and dropping the z-index below the title bar's.

The first anchors the CSS declaration, including the `:has()` scoping. The second is the one worth having: it reads `.context-view`'s z-index out of `src/styles.css` and `.custom-title-bar`'s out of `TitleBar.svelte` and asserts the first is larger. That coupling spans two files and nothing else records it — raise the title bar and the tooltips silently go back under it.

`scripts/exportFoldParity.test.ts` needed one change to accept the new CSS: its hand-rolled selector matcher answered `'unsupported'` for any compound containing an unmodelled `:`, and three export-fold assertions turn `'unsupported'` into a failure. `:has()` now gets the treatment `:nth-*` already had — stripped before the shape check, so a rule keyed on classes this element doesn't carry is still decided outright, and only a compound that otherwise matches has to admit it can't tell. The existing `:has()` rules in the sheet were never hit by this because they all contain `[`, which the matcher rejects earlier.

## Verification

```
npm audit             0 vulnerabilities
npm run check         801 files, 0 errors, 0 warnings
npm test              924 pass, 0 fail
npm run test:vitest   41 files, 365 pass
cargo test            148 pass
```

Behaviour was measured in Chromium, against the dev server with `window.__TAURI_INTERNALS__` stubbed so the frontend boots outside Tauri — that covers the WebView2 build the report came from, and it is why `overflow-clip-margin` was ruled out by compat data rather than by running it.

Also run from a local release build on macOS 26.5 (WKWebView): first and second row, toolbar shown and hidden, split view. Not run on Linux/WebKitGTK, and not on Windows itself — the reporter's exact platform is covered by reasoning plus the Chromium measurements, not by a run.

