### PR TITLE
feat(export): Export as PDF gets a keyboard shortcut (#673)

### DIFF
--- a/scripts/renderedHtmlField.spec.ts
+++ b/scripts/renderedHtmlField.spec.ts
@@ -6,6 +6,7 @@ import { parse } from 'svelte/compiler';
 import ts from 'typescript';
 
 import { asRendererLine } from '../src/lib/utils/lineCoordinates.js';
+import { hasExportableDocument } from '../src/lib/utils/tabFileActions.js';
 import { readSource } from './sourceTree.js';
 
 /*
@@ -153,6 +154,10 @@ const exportsOffered = compileGate(
 		tabManager: () => tabManager,
 		// MarkdownViewer.svelte:229 — `$derived(tabManager.activeTab?.path ?? '')`.
 		currentFile: () => tabManager.activeTab?.path ?? '',
+		// The gate moved into a helper when the Export as PDF chord needed the
+		// same condition (#673). Supplied as the real function, so what these
+		// tests evaluate is still the shipped decision rather than a stand-in.
+		hasExportableDocument: () => hasExportableDocument,
 	},
 	'the export menu gate',
 );

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -22,7 +22,7 @@
 	import { exportAsHtml as _exportHtml, exportAsPdf as _exportPdf } from './utils/export';
 	import { askToOpenExportedFile } from './utils/openExportedFile.js';
 	import { isHomePath } from './utils/homeTab.js';
-	import { hasRealFilePath } from './utils/tabFileActions.js';
+	import { hasExportableDocument, hasRealFilePath } from './utils/tabFileActions.js';
 	import ZoomOverlay from './components/ZoomOverlay.svelte';
 import { processMarkdownHtml } from './utils/markdown';
 import { MARKDOWN_LINK_EXTENSIONS, sanitizeMarkdownHtml } from './utils/sanitize.js';
@@ -2230,6 +2230,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	}
 
 	async function exportAsPdf() {
+		// The gate belongs here rather than at each caller: the menu hides its
+		// item behind the same condition, but the chord reaches this function
+		// through two different layers — the document handler in reading mode
+		// and the editor's own action in edit mode — and a guard on one of them
+		// still printed a blank page from the other (#673).
+		if (!hasExportableDocument(currentFile, tabManager.activeTab?.rawContent)) return;
 		await syncPreviewForPrint();
 		const tab = tabManager.activeTab;
 		// Mermaid bakes the screen theme into the SVG it emits, so a dark
@@ -2913,6 +2919,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			case 'open-settings':
 				showSettings = true;
 				return;
+			case 'export-pdf':
+				return void exportAsPdf();
 			case 'find':
 				return triggerFindAction();
 		}
@@ -3626,6 +3634,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 								onopen={selectFile}
 								onclose={closeFile}
 								onreveal={openFileLocation}
+								onexportPdf={exportAsPdf}
 								ontoggleEdit={() => toggleEditView()}
 								ontoggleLive={toggleLiveMode}
 								ontoggleSplit={() => tabManager.activeTabId && toggleSplitView(tabManager.activeTabId)}

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -72,6 +72,7 @@
 		onopen,
 		onclose,
 		onreveal,
+		onexportPdf,
 		ontoggleEdit,
 		ontoggleLive,
 		ontoggleSplit,
@@ -93,6 +94,7 @@
 		onopen?: () => void;
 		onclose?: () => void;
 		onreveal?: () => void;
+		onexportPdf?: () => void;
 		ontoggleEdit?: () => void;
 		ontoggleLive?: () => void;
 		ontoggleSplit?: () => void;
@@ -1696,6 +1698,15 @@
 					monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyR,
 				],
 				run: () => onreveal?.(),
+			}),
+
+			editor.addAction({
+				id: "file-export-pdf",
+				label: t('menu.exportPdf', lang),
+				keybindings: [
+					monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyP,
+				],
+				run: () => onexportPdf?.(),
 			}),
 
 			editor.addAction({

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -13,7 +13,7 @@
 	import { modifierFor, shortcutLabel } from '../utils/shortcuts.js';
 	import { platformOf } from '../utils/platform.js';
 	import { hasMarkdownLinkExtension } from '../utils/markdownLinks.js';
-	import { hasRealFilePath } from '../utils/tabFileActions.js';
+	import { hasExportableDocument, hasRealFilePath } from '../utils/tabFileActions.js';
 	import { getVersion } from '@tauri-apps/api/app';
 
 	let currentLanguage = $state(settings.language);
@@ -582,7 +582,7 @@
 						buffer that has never been rendered, so gating on it hid an export
 						that would have produced a file.
 					-->
-					{#if currentFile !== '' || (tabManager.activeTab && tabManager.activeTab.rawContent)}
+					{#if hasExportableDocument(currentFile, tabManager.activeTab?.rawContent)}
 						<div class="home-menu-divider"></div>
 						<button
 						class="home-menu-item"
@@ -603,6 +603,7 @@
 						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
 							><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="9" y1="15" x2="15" y2="15"></line></svg>
 						{t('menu.exportPdf', currentLanguage)}
+						<span class="menu-shortcut">{shortcutLabel('file-export-pdf', modifier)}</span>
 					</button>
 					{/if}
 					<div class="home-menu-divider"></div>

--- a/src/lib/utils/shortcuts.ts
+++ b/src/lib/utils/shortcuts.ts
@@ -180,6 +180,19 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		documentCommands: ['close-file'],
 	},
 	{
+		id: 'file-export-pdf',
+		labelKey: 'menu.exportPdf',
+		// `Mod+Shift+E`, as #673 suggested, is Inline Code — bound since the
+		// formatting chords went in, and printed on the editor toolbar. `P` is
+		// the print mnemonic, and the app's `Mod+P` is the command palette, so
+		// the shifted spelling is both free and the nearest thing to what every
+		// other app calls Print.
+		chords: ['Mod+Shift+P'],
+		group: 'file',
+		editorAction: true,
+		documentCommands: ['export-pdf'],
+	},
+	{
 		id: 'file-reveal',
 		labelKey: 'menu.openFileLocation',
 		chords: ['Mod+Shift+R'],

--- a/src/lib/utils/tabFileActions.ts
+++ b/src/lib/utils/tabFileActions.ts
@@ -18,6 +18,22 @@ export function hasRealFilePath(path: string): boolean {
 	return path !== '' && !isHomePath(path);
 }
 
+/**
+ * True when there is a document worth exporting: a file on disk, or an untitled
+ * buffer someone has typed into.
+ *
+ * Shared by the Export menu items, which are hidden without it, and by the
+ * Export as PDF chord (#673), which would otherwise print a blank page for a
+ * document the menu says cannot be exported. Two spellings of one condition is
+ * how the menu and the keyboard come to disagree.
+ *
+ * `currentFile` rather than the tab's path because that is what both call
+ * sites already hold, and it is the same string.
+ */
+export function hasExportableDocument(currentFile: string, rawContent: string | undefined): boolean {
+	return currentFile !== '' || !!rawContent;
+}
+
 export function getTabFileActions(path: string): TabFileAction[] {
 	const disabled = !hasRealFilePath(path);
 

--- a/src/lib/utils/viewerKeymap.ts
+++ b/src/lib/utils/viewerKeymap.ts
@@ -69,6 +69,7 @@ export type ViewerCommand =
 	| 'zoom-out'
 	| 'zoom-reset'
 	| 'open-settings'
+	| 'export-pdf'
 	| 'find';
 
 /**
@@ -274,6 +275,12 @@ export function viewerCommandFor(e: KeyStroke, context: KeyContext): ViewerComma
 	if (mod && key === '-') return 'zoom-out';
 	if (mod && key === '0') return 'zoom-reset';
 	if (mod && key === ',') return 'open-settings';
+	// Export as PDF. Not the `Mod+Shift+E` the request asked for: Inline Code has
+	// held that since the formatting chords were added, and the editor toolbar
+	// prints it. `P` is the print mnemonic every app shares, and the unshifted
+	// `Mod+P` is already the command palette — the same place Obsidian puts it,
+	// which is where this app's users are coming from.
+	if (modShift && key === 'p') return 'export-pdf';
 	// Ctrl/Cmd+F: route to either Monaco's built-in find or the preview
 	// FindBar depending on focus and which panes are visible. The caller only
 	// preventDefaults when it takes the action itself — otherwise Monaco's own


### PR DESCRIPTION
## What this is

Closes #673, asked by @zhouchang3462: Export as PDF was menu-only, which is slow for anyone exporting repeatedly.

`Mod+Shift+P` now runs it, in reading mode and in edit mode, and the menu item prints the chord beside its label so it is discoverable from where people look today.

## Mechanism

Not the `Ctrl+Shift+E` the request suggested — Inline Code has held that chord since the formatting shortcuts went in, and the editor toolbar prints it, so taking it would break a documented binding to add a new one. `P` is the print mnemonic every desktop app shares, and Markpad's unshifted `Mod+P` is the command palette (where Obsidian also puts it), so the shifted spelling is both free and the nearest thing to Print. No other entry claims it on any platform, which `shortcutRegistry.test.ts` checks.

The chord is bound in both keyboard layers, because they are genuinely separate: outside the editor, `viewerKeymap.ts` maps the keystroke to an `export-pdf` command the viewer dispatches; inside it, Monaco resolves its own keybindings first and calls `stopPropagation`, so an `editor.addAction` entry is what makes the chord work in edit mode. Registering only one leaves it dead in the other mode.

The empty-document gate ended up mattering more than expected. The menu hides both Export items when there is nothing to export, and the first version of this repeated that condition at the chord's dispatch. Measured with the chord actually pressed, that guard held in reading mode and did nothing in edit mode — the editor's action calls the export function directly, one layer below the dispatcher. So the condition now lives at the top of `exportAsPdf` itself, and is the exported `hasExportableDocument` the menu gate also switched to, rather than a third spelling of it.

Measured by pressing the chord and watching the Tauri commands the frontend issues:

| document | mode | commands |
|---|---|---|
| empty untitled buffer | edit | *(none)* |
| `# Export me` | edit | `render_markdown`, `print_pdf` |
| `# Export me` | reading | `print_pdf` |

`render_markdown` appears only in edit mode because the export refreshes a preview that may be stale — the pre-existing `syncPreviewForPrint` step, unchanged here.

## Scope

Export as HTML keeps its menu-only route. The request was about PDF, the registry makes a second entry a few lines, and picking a chord for it is a decision nobody has asked for yet.

No new setting: the chord is fixed, like every other one in the app. If rebindable shortcuts arrive, this entry travels with the rest.

## Tests

No new test file. `shortcutRegistry.test.ts` already holds this shape and covers the entry as soon as it exists — changing the registry's chord to something unbound turns three of its assertions red (`every chord the registry advertises is the chord the editor really registers`, `…runs the command it names, outside the editor`, `every chord the document handler answers is advertised`). Checked by doing it.

`renderedHtmlField.spec.ts` needed one line: it parses the export menu's `{#if}` out of `TitleBar.svelte` and evaluates it against a supplied environment, so the helper the gate now calls has to be supplied. It is passed the real function, so what that suite evaluates is still the shipped decision.

## Verification

```
npm audit             0 vulnerabilities
npm run check         800 files, 0 errors, 0 warnings
npm test              922 pass, 0 fail
npm run test:vitest   41 files, 365 pass
cargo test            148 pass
```

The behaviour table above was measured in Chromium against the dev server, with `window.__TAURI_INTERNALS__` stubbed so the frontend boots outside Tauri and every `invoke` is recorded. That proves dispatch and gating; it does not prove the PDF itself, since `print_pdf` is answered by Rust — the export path underneath is unchanged and already covered by `editorPdfExport.test.ts` and `exportFoldParity.test.ts`.

Not verified: Windows and Linux. The chord is platform-independent here (`Mod` resolves per platform, and no branch is OS-specific), but nobody has pressed it there.
