### PR TITLE
feat(editor): the built-in themes colour Markdown (#676)

### DIFF
--- a/scripts/editorTheme.test.ts
+++ b/scripts/editorTheme.test.ts
@@ -28,16 +28,25 @@ function paletteColor(appearance: 'light' | 'dark', name: string): string {
 	return match[1].slice(1).toLowerCase();
 }
 
+test('every rule is scoped to Markdown', () => {
+	// Monaco's Markdown grammar appends `.md` to every token it emits, and a
+	// rule without that suffix sits at the root of the token trie — where it
+	// repaints Python, Rust and JSON inside fenced code blocks as well. That is
+	// not a hypothetical: the first version of this palette did exactly that.
+	for (const rule of markdownTokenRules('light')) {
+		assert.ok(rule.token.endsWith('.md'), `${rule.token} would leak into every other language`);
+	}
+});
+
 test('both themes get rules, and every rule is a real token', () => {
 	for (const appearance of ['light', 'dark'] as const) {
 		const rules = markdownTokenRules(appearance);
 		assert.ok(rules.length > 0, `${appearance} must not fall back to Monaco's source-code colours`);
 
 		for (const rule of rules) {
-			// `keyword.table` is the prefix Monaco's trie matches every
-			// `keyword.table.*` against; the grammar spells out the leaves.
-			const emitted = emittedTokens.has(rule.token)
-				|| [...emittedTokens].some((token) => token.startsWith(`${rule.token}.`));
+			// The grammar spells its tokens without the postfix it later appends.
+			const bare = rule.token.slice(0, -'.md'.length);
+			const emitted = emittedTokens.has(bare);
 			assert.ok(emitted, `no Markdown token is called \`${rule.token}\` — the rule would be inert`);
 			// Monaco's own parser reads these as `#rrggbb` once it prepends the
 			// hash; a `#` here, or a short form, resolves to no colour.
@@ -61,16 +70,31 @@ test('the colours are the app palette, not a second one', () => {
 
 	for (const appearance of ['light', 'dark'] as const) {
 		const byToken = new Map(markdownTokenRules(appearance).map((rule) => [rule.token, rule.foreground]));
-		assert.equal(byToken.get('keyword'), paletteColor(appearance, expected.accent));
-		assert.equal(byToken.get('string'), paletteColor(appearance, expected.code));
-		assert.equal(byToken.get('variable'), paletteColor(appearance, expected.code));
-		assert.equal(byToken.get('strong'), paletteColor(appearance, expected.emphasis));
-		assert.equal(byToken.get('emphasis'), paletteColor(appearance, expected.emphasis));
-		assert.equal(byToken.get('string.link'), paletteColor(appearance, expected.link));
-		assert.equal(byToken.get('comment'), paletteColor(appearance, expected.muted));
-		assert.equal(byToken.get('keyword.table'), paletteColor(appearance, expected.muted));
-		assert.equal(byToken.get('variable.source'), paletteColor(appearance, expected.text));
-		assert.equal(byToken.get('keyword.table.header'), paletteColor(appearance, expected.text));
+		assert.equal(byToken.get('keyword.md'), paletteColor(appearance, expected.accent));
+		assert.equal(byToken.get('string.md'), paletteColor(appearance, expected.code));
+		assert.equal(byToken.get('variable.md'), paletteColor(appearance, expected.code));
+		assert.equal(byToken.get('strong.md'), paletteColor(appearance, expected.emphasis));
+		assert.equal(byToken.get('emphasis.md'), paletteColor(appearance, expected.emphasis));
+		assert.equal(byToken.get('string.link.md'), paletteColor(appearance, expected.link));
+		assert.equal(byToken.get('escape.md'), paletteColor(appearance, expected.muted));
+		assert.equal(byToken.get('variable.source.md'), paletteColor(appearance, expected.text));
+		assert.equal(byToken.get('keyword.table.header.md'), paletteColor(appearance, expected.text));
+	}
+});
+
+test('the markup all reads as markup, and the content inside it does not', () => {
+	// The one line a reader actually scans by: is this the document, or the
+	// syntax around it? Every structural marker takes the same colour, and the
+	// two pieces of content that live inside markup take the text colour.
+	for (const appearance of ['light', 'dark'] as const) {
+		const byToken = new Map(markdownTokenRules(appearance).map((rule) => [rule.token, rule.foreground]));
+		const structure = ['keyword.md', 'keyword.table.left.md', 'keyword.table.middle.md', 'keyword.table.right.md', 'comment.md', 'meta.separator.md'];
+		for (const token of structure) {
+			assert.equal(byToken.get(token), byToken.get('keyword.md'), `${token} must read as markup`);
+		}
+		for (const token of ['keyword.table.header.md', 'variable.source.md']) {
+			assert.notEqual(byToken.get(token), byToken.get('keyword.md'), `${token} is content, not markup`);
+		}
 	}
 });
 
@@ -81,8 +105,8 @@ test('the two inheritance overrides are present, or a table and a code block are
 	// heading, every fenced block as inline code.
 	for (const appearance of ['light', 'dark'] as const) {
 		const byToken = new Map(markdownTokenRules(appearance).map((rule) => [rule.token, rule.foreground]));
-		assert.notEqual(byToken.get('keyword.table.header'), byToken.get('keyword'));
-		assert.notEqual(byToken.get('variable.source'), byToken.get('variable'));
+		assert.notEqual(byToken.get('keyword.table.header.md'), byToken.get('keyword.md'));
+		assert.notEqual(byToken.get('variable.source.md'), byToken.get('variable.md'));
 	}
 });
 

--- a/scripts/editorTheme.test.ts
+++ b/scripts/editorTheme.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { markdownTokenRules } from '../src/lib/utils/editorTheme.js';
+import { readSource } from './sourceTree.js';
+
+// The editor's Markdown colours. Two things can make a rule here do nothing at
+// all, and neither is visible to the compiler: a token name no grammar emits
+// (#676's defect, one layer over), and a colour that has drifted from the one
+// the rest of the app resolves through `--color-*`.
+
+const grammar = readSource('node_modules/monaco-editor/esm/vs/basic-languages/markdown/markdown.js');
+const styles = readSource('src/styles.css');
+
+/** Every token name this Monaco build's Markdown tokenizer can emit. */
+const emittedTokens = (() => {
+	const tokenizer = grammar.slice(grammar.indexOf('tokenizer:'));
+	return new Set([...tokenizer.matchAll(/"([a-z][\w.]*)"/g)].map((match) => match[1]));
+})();
+
+/** A `--color-*` value, read out of the block that defines the given appearance. */
+function paletteColor(appearance: 'light' | 'dark', name: string): string {
+	const block = appearance === 'dark'
+		? styles.slice(styles.indexOf(':root[data-theme="dark"] {'))
+		: styles.slice(styles.indexOf(':root {'));
+	const match = block.match(new RegExp(`--color-${name}:\\s*(#[0-9a-fA-F]{6})`));
+	assert.ok(match, `styles.css must define --color-${name} for ${appearance}`);
+	return match[1].slice(1).toLowerCase();
+}
+
+test('both themes get rules, and every rule is a real token', () => {
+	for (const appearance of ['light', 'dark'] as const) {
+		const rules = markdownTokenRules(appearance);
+		assert.ok(rules.length > 0, `${appearance} must not fall back to Monaco's source-code colours`);
+
+		for (const rule of rules) {
+			// `keyword.table` is the prefix Monaco's trie matches every
+			// `keyword.table.*` against; the grammar spells out the leaves.
+			const emitted = emittedTokens.has(rule.token)
+				|| [...emittedTokens].some((token) => token.startsWith(`${rule.token}.`));
+			assert.ok(emitted, `no Markdown token is called \`${rule.token}\` — the rule would be inert`);
+			// Monaco's own parser reads these as `#rrggbb` once it prepends the
+			// hash; a `#` here, or a short form, resolves to no colour.
+			assert.match(rule.foreground, /^[0-9a-f]{6}$/, `${rule.token} must be a bare six-digit hex`);
+		}
+	}
+});
+
+test('the colours are the app palette, not a second one', () => {
+	// One-way duplication: `defineTheme` takes hex strings and never sees the
+	// stylesheet, so the literals in editorTheme.ts have to be checked against
+	// the custom properties everything else in the app resolves.
+	const expected = {
+		accent: 'accent-fg',
+		code: 'success-fg',
+		emphasis: 'attention-fg',
+		link: 'done-fg',
+		muted: 'fg-muted',
+		text: 'fg-default',
+	};
+
+	for (const appearance of ['light', 'dark'] as const) {
+		const byToken = new Map(markdownTokenRules(appearance).map((rule) => [rule.token, rule.foreground]));
+		assert.equal(byToken.get('keyword'), paletteColor(appearance, expected.accent));
+		assert.equal(byToken.get('string'), paletteColor(appearance, expected.code));
+		assert.equal(byToken.get('variable'), paletteColor(appearance, expected.code));
+		assert.equal(byToken.get('strong'), paletteColor(appearance, expected.emphasis));
+		assert.equal(byToken.get('emphasis'), paletteColor(appearance, expected.emphasis));
+		assert.equal(byToken.get('string.link'), paletteColor(appearance, expected.link));
+		assert.equal(byToken.get('comment'), paletteColor(appearance, expected.muted));
+		assert.equal(byToken.get('keyword.table'), paletteColor(appearance, expected.muted));
+		assert.equal(byToken.get('variable.source'), paletteColor(appearance, expected.text));
+		assert.equal(byToken.get('keyword.table.header'), paletteColor(appearance, expected.text));
+	}
+});
+
+test('the two inheritance overrides are present, or a table and a code block are miscoloured', () => {
+	// Monaco resolves a token against a trie, so a rule on `keyword` also paints
+	// `keyword.table.header`, and one on `variable` also paints
+	// `variable.source`. Drop either override and every table header reads as a
+	// heading, every fenced block as inline code.
+	for (const appearance of ['light', 'dark'] as const) {
+		const byToken = new Map(markdownTokenRules(appearance).map((rule) => [rule.token, rule.foreground]));
+		assert.notEqual(byToken.get('keyword.table.header'), byToken.get('keyword'));
+		assert.notEqual(byToken.get('variable.source'), byToken.get('variable'));
+	}
+});
+
+test('bold and italic keep the font style the base theme gives them', () => {
+	// A rule with no `fontStyle` is `FontStyle.NotSet`, which Monaco merges by
+	// leaving what is already there — `vs`/`vs-dark` define `strong: bold` and
+	// `emphasis: italic`. Spelling `regular` here would flatten both.
+	for (const rule of markdownTokenRules('light')) {
+		assert.ok(!('fontStyle' in rule), `${rule.token} must not decide a font style`);
+	}
+});
+
+test('light and dark are actually different themes', () => {
+	const light = markdownTokenRules('light');
+	const dark = markdownTokenRules('dark');
+	assert.deepEqual(light.map((rule) => rule.token), dark.map((rule) => rule.token));
+	for (const [index, rule] of light.entries()) {
+		assert.notEqual(rule.foreground, dark[index].foreground, `${rule.token} is the same colour on both`);
+	}
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -15,6 +15,7 @@
 	import { listEnter, parseListItem } from '../utils/listEditing.js';
 	import { tableOperation, tableStep, type TableEdit, type TableOperation } from '../utils/tableEditing.js';
 	import { editorOptionsFromSettings } from '../utils/editorOptions.js';
+	import { markdownTokenRules } from '../utils/editorTheme.js';
 	import { getTabModel, lineEndingLabel, tabModelUri } from '../utils/tabModels.js';
 	import { installVimScrollCommands } from '../utils/vimScrollCommands.js';
 	import {
@@ -292,7 +293,7 @@
 			monaco.editor.defineTheme("app-theme-dark", {
 				base: "vs-dark",
 				inherit: true,
-				rules: [],
+				rules: markdownTokenRules('dark'),
 				colors: {
 					"editor.background": "#181818",
 					"menu.background": "#181818",
@@ -308,7 +309,7 @@
 			monaco.editor.defineTheme("app-theme-light", {
 				base: "vs",
 				inherit: true,
-				rules: [],
+				rules: markdownTokenRules('light'),
 				colors: {
 					"editor.background": "#FDFDFD",
 					"menu.background": "#FDFDFD",

--- a/src/lib/utils/editorTheme.ts
+++ b/src/lib/utils/editorTheme.ts
@@ -36,49 +36,54 @@ type Role = keyof (typeof PALETTE)['light'];
 /**
  * Monaco token → role.
  *
- * Only names this Monaco build's Markdown tokenizer actually emits are here.
- * A rule keyed on anything else is silently inert — the defect #676 was, one
- * layer over — so `editorTheme.test.ts` checks every token below against the
- * grammar itself.
+ * Every name carries the `.md` that Monaco's Markdown grammar appends to each
+ * token it emits (`tokenPostfix: ".md"`, applied in `monarchLexer.js`). The
+ * suffix is what keeps this palette inside Markdown: a rule on a bare
+ * `keyword` or `string` sits at the root of Monaco's token trie and repaints
+ * *every* language, so the first version of this file recoloured the Python,
+ * Rust and JSON inside fenced blocks — those are tokenized by their own
+ * grammar, under their own postfix, and Monaco's defaults for them are tuned
+ * for code in a way this six-colour palette is not.
  *
- * Two entries exist to *undo* an inheritance rather than to add a colour.
- * Monaco resolves a token against a trie, so `keyword.table.header` inherits
- * whatever `keyword` says: without a rule of its own, every header cell in
- * every table would be painted like a heading. `variable.source` is the same
- * story one token over — it is the body of a fenced code block, which inherits
- * inline code's colour and would turn whole blocks green.
+ * The postfix also means a prefix rule cannot stand in for its children:
+ * `keyword.table.left.md` walks `keyword` → `table` → …, so `keyword.md` never
+ * sees it. The four table tokens are therefore spelled out.
+ *
+ * Two entries exist to *undo* an inheritance rather than to add a colour. A
+ * table header cell and the body of a fenced block are content, not syntax,
+ * and both would otherwise arrive painted as the markup around them.
  */
 const MARKDOWN_TOKEN_ROLES: ReadonlyArray<readonly [token: string, role: Role]> = [
-	// `#`, the `=`/`-` of a setext heading, list bullets and numbers, and the
-	// `---|---` divider row. One token for all of them, so one colour: the
-	// tokenizer does not tell headings and lists apart, and a theme cannot
-	// invent a distinction the grammar never made.
-	['keyword', 'accent'],
-	// Table pipes are structure, not content — quiet, so the cells read.
-	['keyword.table', 'muted'],
-	// `text` rather than "leave it alone", which a Monaco rule cannot say: every
-	// rule must name a colour. The app's own foreground is the closest honest
-	// answer, so a header cell reads a hair off the body cells below it
-	// (#1f2328 against the base theme's #000000) and in step with the preview.
-	['keyword.table.header', 'text'],
-	// Blockquote markers.
-	['comment', 'muted'],
-	// Fences and indented code, then inline code: one family.
-	['string', 'code'],
-	['variable', 'code'],
-	['variable.source', 'text'],
+	// Block structure, one colour. `#`, the `=`/`-` of a setext heading, list
+	// bullets and numbers, the `---|---` divider, the table frame, `>` and a
+	// horizontal rule are all the same thing to a reader scanning a document:
+	// the markup, as opposed to what they wrote. Distinguishing *kinds* of
+	// markup matters less than distinguishing markup from prose, and the
+	// tokenizer cannot tell a heading from a list marker anyway — one bare
+	// `keyword` covers both.
+	['keyword.md', 'accent'],
+	['keyword.table.left.md', 'accent'],
+	['keyword.table.middle.md', 'accent'],
+	['keyword.table.right.md', 'accent'],
+	['comment.md', 'accent'],
+	['meta.separator.md', 'accent'],
+	// Content that sits inside markup, and must not read as markup.
+	['keyword.table.header.md', 'text'],
+	['variable.source.md', 'text'],
+	// Fences and inline code: one family, distinct from both.
+	['string.md', 'code'],
+	['variable.md', 'code'],
 	// `[text](target)`.
-	['string.link', 'link'],
-	// `***` / `---` on a line of its own.
-	['meta.separator', 'muted'],
-	// `\*` and `&amp;`: punctuation that is standing in for a character.
-	['escape', 'muted'],
-	['string.escape', 'muted'],
+	['string.link.md', 'link'],
+	// `\*` and `&amp;`: punctuation standing in for a character, and the one
+	// thing here quiet enough to recede.
+	['escape.md', 'muted'],
+	['string.escape.md', 'muted'],
 	// Bold and italic keep the font style the base theme gives them — no
 	// `fontStyle` here, which Monaco reads as "leave it alone" rather than as
 	// "regular", and both get a colour for the first time.
-	['strong', 'emphasis'],
-	['emphasis', 'emphasis'],
+	['strong.md', 'emphasis'],
+	['emphasis.md', 'emphasis'],
 ];
 
 export type EditorTokenRule = { token: string; foreground: string };

--- a/src/lib/utils/editorTheme.ts
+++ b/src/lib/utils/editorTheme.ts
@@ -1,0 +1,90 @@
+/**
+ * What the editor paints Markdown with.
+ *
+ * The two built-in themes shipped `rules: []` and inherited Monaco's `vs` /
+ * `vs-dark`, which were written for source code and know nothing about this
+ * document: headings, list markers and table pipes all arrived as one blue
+ * `keyword`, links and horizontal rules got no colour at all, and bold and
+ * italic got a font style and nothing else.
+ *
+ * The colours are the app's own, the same six the preview and the rest of the
+ * chrome resolve through `--color-*` in `styles.css`. Spelled as literals
+ * because `defineTheme` takes hex strings and never sees a stylesheet;
+ * `editorTheme.test.ts` holds the two copies equal.
+ */
+const PALETTE = {
+	light: {
+		text: '1f2328',
+		muted: '656d76',
+		accent: '0969da',
+		code: '1a7f37',
+		emphasis: '9a6700',
+		link: '8250df',
+	},
+	dark: {
+		text: 'e6edf3',
+		muted: '848d97',
+		accent: '4390fc',
+		code: '3fb950',
+		emphasis: 'd29922',
+		link: 'a371f7',
+	},
+} as const;
+
+type Role = keyof (typeof PALETTE)['light'];
+
+/**
+ * Monaco token → role.
+ *
+ * Only names this Monaco build's Markdown tokenizer actually emits are here.
+ * A rule keyed on anything else is silently inert — the defect #676 was, one
+ * layer over — so `editorTheme.test.ts` checks every token below against the
+ * grammar itself.
+ *
+ * Two entries exist to *undo* an inheritance rather than to add a colour.
+ * Monaco resolves a token against a trie, so `keyword.table.header` inherits
+ * whatever `keyword` says: without a rule of its own, every header cell in
+ * every table would be painted like a heading. `variable.source` is the same
+ * story one token over — it is the body of a fenced code block, which inherits
+ * inline code's colour and would turn whole blocks green.
+ */
+const MARKDOWN_TOKEN_ROLES: ReadonlyArray<readonly [token: string, role: Role]> = [
+	// `#`, the `=`/`-` of a setext heading, list bullets and numbers, and the
+	// `---|---` divider row. One token for all of them, so one colour: the
+	// tokenizer does not tell headings and lists apart, and a theme cannot
+	// invent a distinction the grammar never made.
+	['keyword', 'accent'],
+	// Table pipes are structure, not content — quiet, so the cells read.
+	['keyword.table', 'muted'],
+	// `text` rather than "leave it alone", which a Monaco rule cannot say: every
+	// rule must name a colour. The app's own foreground is the closest honest
+	// answer, so a header cell reads a hair off the body cells below it
+	// (#1f2328 against the base theme's #000000) and in step with the preview.
+	['keyword.table.header', 'text'],
+	// Blockquote markers.
+	['comment', 'muted'],
+	// Fences and indented code, then inline code: one family.
+	['string', 'code'],
+	['variable', 'code'],
+	['variable.source', 'text'],
+	// `[text](target)`.
+	['string.link', 'link'],
+	// `***` / `---` on a line of its own.
+	['meta.separator', 'muted'],
+	// `\*` and `&amp;`: punctuation that is standing in for a character.
+	['escape', 'muted'],
+	['string.escape', 'muted'],
+	// Bold and italic keep the font style the base theme gives them — no
+	// `fontStyle` here, which Monaco reads as "leave it alone" rather than as
+	// "regular", and both get a colour for the first time.
+	['strong', 'emphasis'],
+	['emphasis', 'emphasis'],
+];
+
+export type EditorTokenRule = { token: string; foreground: string };
+
+/** The `rules` for one of the two built-in themes. */
+export function markdownTokenRules(appearance: 'light' | 'dark'): EditorTokenRule[] {
+	const palette = PALETTE[appearance];
+	return MARKDOWN_TOKEN_ROLES.map(([token, role]) => ({ token, foreground: palette[role] }));
+}

--- a/src/lib/utils/editorTheme.ts
+++ b/src/lib/utils/editorTheme.ts
@@ -79,6 +79,15 @@ const MARKDOWN_TOKEN_ROLES: ReadonlyArray<readonly [token: string, role: Role]> 
 	// thing here quiet enough to recede.
 	['escape.md', 'muted'],
 	['string.escape.md', 'muted'],
+	// Inline HTML is the escape hatch: someone dropped a tag in because Markdown
+	// could not say it. Monaco's defaults paint it as source code — a maroon tag
+	// name, a red attribute — which makes the one thing in the document that is
+	// not Markdown the loudest thing on the line. It recedes instead.
+	['tag.md', 'muted'],
+	['attribute.name.html.md', 'muted'],
+	['delimiter.html.md', 'muted'],
+	['string.html.md', 'muted'],
+	['comment.content.md', 'muted'],
 	// Bold and italic keep the font style the base theme gives them — no
 	// `fontStyle` here, which Monaco reads as "leave it alone" rather than as
 	// "regular", and both get a colour for the first time.


### PR DESCRIPTION
## What this is

The editor's own two themes now colour Markdown. Follow-up to #678, which fixed imported VS Code themes and left the built-ins as they were.

Before, both `defineTheme` calls shipped `rules: []` and inherited Monaco's `vs` / `vs-dark` — palettes written for source code, which had never heard of this document. Measured against the base themes, that gave four colours, with the wrong things sharing them:

| construct | token | before (light) | after (light) |
|---|---|---|---|
| heading `#`, list marker, table divider | `keyword` | `#0000FF` | `#0969da` accent |
| table pipes | `keyword.table.*` | `#0000FF` — same as a heading | `#656d76` muted |
| table header cell | `keyword.table.header` | `#0000FF` — the whole row read as a heading | `#1f2328` text |
| blockquote `>` | `comment` | `#008000` | `#656d76` muted |
| fences, indented code | `string` | `#A31515` | `#1a7f37` code |
| inline code | `variable` | `#001188` | `#1a7f37` code |
| fenced block body | `variable.source` | inherited inline code's colour | `#1f2328` text |
| link | `string.link` | **none** | `#8250df` link |
| horizontal rule | `meta.separator` | **none** | `#656d76` muted |
| bold, italic | `strong`, `emphasis` | font style only | `#9a6700`, style kept |

The colours are the app's own six, the ones `styles.css` exposes as `--color-accent-fg`, `--color-success-fg`, `--color-attention-fg`, `--color-done-fg`, `--color-fg-muted` and `--color-fg-default`, so the editor now reads as part of the same app as the preview rather than as a code editor someone embedded.

## Mechanism

Monaco resolves a token against a trie, and that is what made two of the twelve rules necessary. `keyword.table.header` is the *text* of a header cell and inherits whatever `keyword` says — so colouring headings blue painted every table header blue too. `variable.source` is the body of a fenced block and inherits inline code's colour, which turned whole blocks green. Both rules exist to undo an inheritance rather than to add a colour, and `editorTheme.test.ts` fails if either is dropped.

Neither can say "leave it alone": a Monaco rule must name a colour, and `FontStyle.NotSet` has no foreground equivalent. They name the app's own `--color-fg-default`, which is why a header cell sits a hair off the body cells below it (`#1f2328` against the base theme's `#000000`) — in step with the preview instead of with Monaco.

Bold and italic carry no `fontStyle`, which Monaco reads as NotSet and merges by leaving the base theme's `strong: bold` / `emphasis: italic` standing. Spelling `regular` would have flattened them.

**Headings and list markers still share one colour.** The tokenizer emits a bare `keyword` for `#`, for setext underlines, for list bullets and for the `---|---` divider alike, so nothing downstream can tell them apart. That ceiling is the grammar, not the theme, and moving it means owning a fork of Monaco's Markdown monarch definition — a separate piece of work, and still only a regex's guess about what will render.

## Scope

Imported VS Code themes are untouched: they take their own `tokenColors` through `theme.ts`, including the scope renaming #678 added.

The editor's default text colour is left as Monaco's (`#000000` / `#D4D4D4`) rather than moved to `--color-fg-default`. Repainting every character of every document is a bigger change than colouring Markdown syntax, and the difference is under 3% luminance.

No new setting. The palette follows the light/dark theme the app is already on, the same as every other colour in the app.

## Tests

`scripts/editorTheme.test.ts`, five behaviour tests over `markdownTokenRules`:

- **Every token is one the grammar emits** — checked against `monaco-editor`'s own `markdown.js`, since a rule keyed on a name nothing emits is silently inert. That is exactly the defect #676 was, one layer over, and it is the failure mode this change is most exposed to.
- **The colours are the app palette** — each rule's hex is compared against the `--color-*` value parsed out of `styles.css` for that appearance. The duplication is one-way and unavoidable (`defineTheme` takes hex strings and never sees a stylesheet), so this is what keeps the two from drifting.
- The two inheritance overrides differ from what they override; bold and italic decide no font style; light and dark differ on every rule.

Revert `rules: markdownTokenRules(…)` to `rules: []` and the suite goes red on the first two.

## Verification

```
npm audit             0 vulnerabilities
npm run check         805 files, 0 errors, 0 warnings
npm test              936 pass, 0 fail
npm run test:vitest   42 files, 376 pass
cargo test            148 pass
```

The before/after table was measured in Chromium against the dev server with `window.__TAURI_INTERNALS__` stubbed, by typing a document that exercises every rule and reading `getComputedStyle().color` off the rendered token spans — light and dark. What that does not cover is how the palette reads on a real display at length; it is six colours that the rest of the app already uses on the same two backgrounds, but nobody has written a long document in it yet.


## Revised after review

Two defects in the first version, both found by looking at a real document side by side with the old build.

**The palette was leaking into every other language.** Monaco appends the grammar's `tokenPostfix` to every token (`monarchLexer.js`), so Markdown emits `keyword.md` / `string.md` / `comment.md` while Python emits `keyword.python` and so on. The rules were spelled bare, which places them at the *root* of the token trie — so a six-colour prose palette repainted the Python, Rust and JSON inside fenced code blocks, over Monaco's defaults which are tuned for code. Every rule is now `.md`-scoped, and a test fails on any rule that is not.

Measured after the fix, in a ```python block: the comment is back to `#608B4E`, `assert` to `#569CD6`, the string to `#CE9178` — Monaco's own vs-dark values, i.e. exactly what shipped before this PR.

**Muting the table frame cost more than it bought.** The first version made table pipes and `>` `--color-fg-muted`, on the theory that the frame is noise and the cells should read. Against the body text that is a step backwards, which is measurable — CIEDE2000 against the editor's text colour, light theme:

| marker | before this PR | first version | now |
|---|---|---|---|
| table pipes | `#0000FF`, ΔE 39.7 | `#656d76`, ΔE 33.0 | `#0969da`, ΔE 42.4 |
| `>` | `#008000`, ΔE 43.1 | `#656d76`, ΔE 33.0 | `#0969da`, ΔE 42.4 |
| `---` rule | uncoloured, ΔE 0 | `#656d76`, ΔE 33.0 | `#0969da`, ΔE 42.4 |

All block markup — `#`, list markers, the table frame and divider, `>`, horizontal rules — now takes one colour. Distinguishing *kinds* of markup matters less than distinguishing markup from prose, and the tokenizer cannot tell a heading from a list marker anyway.

Two constructs still move *closer* to the text colour, deliberately: a table header cell (ΔE 39.7 → 9.0) and the body of a fenced block (30.0 → 9.0). Both are content that the old theme painted as though it were syntax.

The four semantic families stay apart. Worst pair, CIEDE2000: structure↔link ΔE 17.8 light / 21.2 dark. For comparison the old palette's worst pair was link↔emphasis at ΔE **0.0** — both were simply the body text colour. (This is also why the editor's link colour stays purple rather than moving to the accent: that change would make the tightest pair zero.)
