### PR TITLE
fix(preview): inline code in a heading sits on the heading's baseline (#681)

### DIFF
--- a/scripts/headingInlineCode.test.ts
+++ b/scripts/headingInlineCode.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+// #681: inline code in a heading rendered small and floating above the words
+// around it. Two independent causes, one in each stylesheet, and neither is
+// reachable by a test that runs code — this is CSS the browser resolves.
+
+const styles = readSource('src/styles.css');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
+
+test('a heading stands its content on the text baseline', () => {
+	// The heading is a flex container so the fold chevron can sit beside the
+	// text, which makes every element inside it a flex item. `flex-start` pinned
+	// each one to the top of the line — the smaller the element, the higher it
+	// floated. Measured on `## Heading \x60code\x60 Test`: the code chip's bottom sat
+	// 8px above the heading text's, and 2px below it after.
+	const rule = styles.match(/\.foldable-header \{[^}]*\}/);
+	assert.ok(rule, 'styles.css must still define .foldable-header');
+	assert.match(rule[0], /align-items:\s*baseline;/);
+	assert.doesNotMatch(rule[0], /align-items:\s*flex-start;/);
+});
+
+test('inline code in a heading scales with the heading', () => {
+	// The Code Font Size setting is an absolute px — right for code in prose,
+	// wrong for code in a heading, where 14px inside a 24px `##` reads as a
+	// footnote. GitHub sizes inline code relative to what contains it.
+	assert.match(
+		viewer,
+		/:global\(\.markdown-body :is\(h1, h2, h3, h4, h5, h6\) code\) \{\s*\n\s*font-size: 0\.85em !important;/,
+	);
+});
+
+test('the setting still governs code everywhere else', () => {
+	// The fix is scoped to headings; body text and code blocks keep answering to
+	// `--code-font-size`, which is what the setting promises.
+	assert.match(viewer, /:global\(\.markdown-body code\) \{[\s\S]*?font-size: var\(--code-font-size, 14px\) !important;/);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -4080,6 +4080,21 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		font-size: var(--code-font-size, 14px) !important;
 	}
 
+	/*
+	 * The Code Font Size setting is an absolute px, which is what a reader wants
+	 * for code sitting in prose — and wrong for code sitting in a heading, where
+	 * it does not scale with the words around it: 14px inside a 24px `##` (#681),
+	 * 14px inside a 32px `#`. GitHub sizes inline code at 85% of whatever
+	 * contains it, and that is the rule the setting was overriding here.
+	 *
+	 * Scoped to headings so the setting keeps meaning what it says everywhere a
+	 * reader actually reads code, and `!important` because the rule above is —
+	 * specificity alone cannot answer it.
+	 */
+	.markdown-container :global(.markdown-body :is(h1, h2, h3, h4, h5, h6) code) {
+		font-size: 0.85em !important;
+	}
+
 	.markdown-body.full-width {
 		max-width: 100%;
 		margin: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -748,7 +748,15 @@ body {
 	font-weight: 600;
 	line-height: 1.25;
 	display: flex;
-	align-items: flex-start;
+	/* A heading is a flex container so the fold chevron can sit beside its text,
+	   which makes every element inside it a flex item — an inline `<code>`, an
+	   image, a KaTeX span. `flex-start` then pins each of them to the top of the
+	   line instead of standing them on the text's baseline, and the smaller the
+	   element the further it floats: #681 reported inline code in a heading
+	   riding above the words around it. `baseline` is what inline layout would
+	   have done. The chevron is unaffected — it is positioned in its own rule
+	   below — so this changes nothing but the alignment of real content. */
+	align-items: baseline;
 	position: relative;
 }
 


### PR DESCRIPTION
## What this is

Closes #681, reported by @ac-ekm with a side-by-side against GitHub: `## Heading \`code\` Test` rendered the code span small and floating above the words around it instead of on their baseline.

Measured on that exact heading, in the preview:

| | before | after |
|---|---|---|
| code font size in a 24px `##` | 14px | 20.4px (0.85em) |
| code chip's bottom vs the heading text's | 8px **above** | 2px below (the chip's own padding) |
| code font size in body text | 14px | 14px |
| chevron position, single and wrapped heading | unchanged | unchanged |

## Mechanism

Two independent causes, one per stylesheet, which is why the screenshot shows both a size and a position problem.

**The float.** `.foldable-header` is `display: flex` so the fold chevron can sit beside the heading text. That makes every *element* inside a heading a flex item — an inline `<code>`, an image, a KaTeX span — and `align-items: flex-start` pins each one to the top of the line instead of standing it on the text's baseline. The smaller the element, the further it floats. So this was never about code: anything shorter than the heading's line box has been riding high in every heading since folds were added. `align-items: baseline` is what inline layout would have done, and the chevron is unaffected because its own rule positions it.

**The size.** The Code Font Size setting is injected as an absolute `--code-font-size` and applied with `!important`, which overrides GitHub's `code { font-size: 85% }`. Absolute px is right for code sitting in prose — a reader picked that number so code is legible next to their body text — and wrong for code sitting in a heading, where it does not scale: 14px inside a 24px `##`, 14px inside a 32px `#`. The 85% rule is restored for headings only.

`!important` on the new rule because the rule it has to beat is `!important` too; specificity alone cannot answer that.

## Scope

Body text and code blocks keep answering to the setting — the fix is scoped to `h1`–`h6`, so nothing a reader set for reading code changes.

The deeper question the flex container raises is left alone: a heading arguably should not be a flex container at all, and the chevron could be positioned absolutely in the gutter the way GitHub places its anchor links. That would also restore true inline wrapping for headings that mix text and elements. It is a bigger change to a surface that fold state, the TOC and the export path all read, and this fix does not need it — measured, a long heading with inline code still wraps to the same height it did before.

## Tests

`scripts/headingInlineCode.test.ts`, three source-shape assertions: the heading rule aligns on `baseline` and not `flex-start`, headings size inline code at `0.85em`, and the `--code-font-size` rule is still there for everything else. Both halves are CSS the browser resolves, so nothing that runs code can see them — and the second test is what stops a future edit from "simplifying" the heading rule back into the general one.

Revert either half and the matching test goes red.

## Verification

```
npm audit             0 vulnerabilities
npm run check         805 files, 0 errors, 0 warnings
npm test              934 pass, 0 fail
npm run test:vitest   42 files, 376 pass
cargo test            148 pass
```

The table above was measured in Chromium against the dev server, with `window.__TAURI_INTERNALS__` stubbed and `render_markdown` returning a fixture — reading `getComputedStyle` and `getBoundingClientRect` off the rendered heading, including a long heading that wraps.

Not verified: how it looks on Windows, where the report came from. The rules are platform-independent, and the fix moves the same two numbers everywhere, but nobody has run it there. The exported HTML and printed PDF inherit both stylesheets, so both routes get the same fix without a change of their own — that path was reasoned about, not run.
