### PR TITLE
feat(editor): colour Markdown from the renderer, not from a regex

### DIFF
--- a/scripts/semanticTokens.test.ts
+++ b/scripts/semanticTokens.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { semanticTokenRules } from '../src/lib/utils/editorTheme.js';
+import { TOKEN_MODIFIERS, TOKEN_TYPES, encodeSemanticTokens } from '../src/lib/utils/semanticTokens.js';
+import { readRustBackend, readSource } from './sourceTree.js';
+
+// The layer that colours from the renderer's answer instead of the grammar's
+// guess. Three seams, each invisible to the compiler: the kinds Rust emits
+// against the legend the encoder indexes, the legend against the theme rules
+// that style it, and the delta encoding Monaco decodes.
+
+test('every kind Rust emits is in the legend', () => {
+	// A kind the legend does not know is dropped by the encoder — silently, and
+	// only for that construct, which is exactly the kind of gap nobody notices.
+	const rust = readRustBackend();
+	const emitted = new Set(
+		[...rust.matchAll(/"([a-z]+)(?:\.(marker))?"\s*,?\s*out\s*\)/g)].map((match) => match[1]),
+	);
+	assert.ok(emitted.size > 0, 'the extractor must still name its kinds as literals');
+	for (const kind of emitted) {
+		assert.ok(
+			(TOKEN_TYPES as readonly string[]).includes(kind),
+			`semantic.rs emits \`${kind}\`, which the legend does not list`,
+		);
+	}
+});
+
+test('the legend and the theme agree on what can be styled', () => {
+	// A rule for a type the legend lacks styles nothing; a type with no rule
+	// paints whatever the grammar left, which for a construct the grammar has
+	// never heard of means no colour at all.
+	const styled = new Set(semanticTokenRules('light').map((rule) => rule.token.split('.')[0]));
+	for (const type of TOKEN_TYPES) {
+		assert.ok(styled.has(type), `no theme rule styles \`${type}\``);
+	}
+	for (const rule of semanticTokenRules('light')) {
+		const [type, modifier] = rule.token.split('.');
+		assert.ok((TOKEN_TYPES as readonly string[]).includes(type), `rule \`${rule.token}\` names no legend type`);
+		if (modifier) {
+			assert.ok(
+				(TOKEN_MODIFIERS as readonly string[]).includes(modifier),
+				`rule \`${rule.token}\` names no legend modifier`,
+			);
+		}
+	}
+});
+
+test('a semantic rule spells out every font style it wants', () => {
+	// `getTokenStyleMetadata` reports bold and italic as booleans rather than
+	// "not set", so a semantic token claims those bits whatever the rule says.
+	// A rule that stays silent about bold therefore switches it OFF for the
+	// range it covers — the opposite of the grammar rules, where silence means
+	// "leave it alone".
+	const byToken = new Map(semanticTokenRules('light').map((rule) => [rule.token, rule.fontStyle]));
+	assert.equal(byToken.get('strong.marker'), 'bold');
+	assert.equal(byToken.get('emph.marker'), 'italic');
+	assert.equal(byToken.get('heading'), 'bold');
+	assert.equal(byToken.get('strike'), 'strikethrough');
+});
+
+test('the encoder writes deltas Monaco can decode', () => {
+	const data = encodeSemanticTokens([
+		{ kind: 'heading.marker', line: 0, start: 0, len: 3 },
+		{ kind: 'heading', line: 0, start: 3, len: 5 },
+		{ kind: 'strong.marker', line: 2, start: 4, len: 2 },
+	]);
+
+	assert.deepEqual(
+		[...data],
+		[
+			// deltaLine, deltaStart, length, type, modifiers
+			0, 0, 3, TOKEN_TYPES.indexOf('heading'), 1,
+			0, 3, 5, TOKEN_TYPES.indexOf('heading'), 0,
+			2, 4, 2, TOKEN_TYPES.indexOf('strong'), 1,
+		],
+	);
+});
+
+test('an unknown kind is dropped rather than mapped to another construct', () => {
+	// Index arithmetic on an unknown name would paint some other construct's
+	// colour, which is worse than leaving the grammar's.
+	const data = encodeSemanticTokens([
+		{ kind: 'nonesuch', line: 0, start: 0, len: 2 },
+		{ kind: 'code', line: 0, start: 4, len: 6 },
+	]);
+	assert.equal(data.length, 5);
+	assert.equal(data[1], 4, 'the surviving token still measures from the start of the line');
+});
+
+test('the editor turns the layer on, because the default is off', () => {
+	// `StandaloneTheme.semanticHighlighting` is hard-coded false, so
+	// `'configuredByTheme'` cannot reach it and the provider is never asked.
+	const editor = readSource('src/lib/components/Editor.svelte');
+	assert.match(editor, /'semanticHighlighting\.enabled': true/);
+	assert.match(editor, /registerDocumentSemanticTokensProvider\(/);
+});

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -219,6 +219,7 @@ pub fn run() {
             commands::clipboard_read_image,
             commands::open_markdown_preview,
             commands::render_markdown,
+            commands::markdown_semantic_spans,
             commands::list_heading_anchors,
             window_runtime::send_markdown_path,
             commands::read_file_content_checked,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -112,7 +112,9 @@ pub async fn list_heading_anchors(markdown: String) -> Result<Vec<HeadingAnchor>
 /// document and 24 ms for a 1.7 MB one, which is small but not nothing, and
 /// Monaco asks for this on every edit.
 #[tauri::command]
-pub async fn markdown_semantic_spans(content: String) -> Result<Vec<crate::semantic::SemanticSpan>, String> {
+pub async fn markdown_semantic_spans(
+    content: String,
+) -> Result<Vec<crate::semantic::SemanticSpan>, String> {
     tauri::async_runtime::spawn_blocking(move || Ok(crate::semantic::semantic_spans(&content)))
         .await
         .unwrap_or_else(|e| Err(e.to_string()))

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -106,6 +106,18 @@ pub async fn list_heading_anchors(markdown: String) -> Result<Vec<HeadingAnchor>
         .unwrap_or_else(|e| Err(e.to_string()))
 }
 
+/// The ranges the editor should colour, from the same parse the preview uses.
+///
+/// Off the main thread like `render_markdown`: measured at 0.7 ms for a 500-line
+/// document and 24 ms for a 1.7 MB one, which is small but not nothing, and
+/// Monaco asks for this on every edit.
+#[tauri::command]
+pub async fn markdown_semantic_spans(content: String) -> Result<Vec<crate::semantic::SemanticSpan>, String> {
+    tauri::async_runtime::spawn_blocking(move || Ok(crate::semantic::semantic_spans(&content)))
+        .await
+        .unwrap_or_else(|e| Err(e.to_string()))
+}
+
 #[tauri::command]
 pub async fn render_markdown(content: String) -> Result<String, String> {
     tauri::async_runtime::spawn_blocking(move || Ok(convert_markdown(&content)))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod commands;
 mod error;
 mod fs_safety;
 mod markdown;
+mod semantic;
 mod tab_transfer;
 mod window_runtime;
 

--- a/src-tauri/src/markdown.rs
+++ b/src-tauri/src/markdown.rs
@@ -94,7 +94,7 @@ fn escape_html_attribute(value: &str) -> String {
 /// the editor's link completion — has to parse it the same way the renderer
 /// does, or it reports ids for headings the renderer never made and misses the
 /// ones it did.
-fn markdown_options<'a>() -> Options<'a> {
+pub(crate) fn markdown_options<'a>() -> Options<'a> {
     let mut options = Options::default();
     options.extension.strikethrough = true;
     options.extension.table = true;
@@ -268,7 +268,7 @@ fn wikilink_file_destination(path: &str) -> Option<String> {
 /// a second pass afterwards, which left the vector unsorted for any document
 /// containing both, and made a single `sort_unstable()` call the only thing
 /// standing between the search and a wrong answer.
-fn code_region_ranges(content: &str) -> Vec<(usize, usize)> {
+pub(crate) fn code_region_ranges(content: &str) -> Vec<(usize, usize)> {
     let len = content.len();
     let mut regions: Vec<(usize, usize)> = Vec::new();
     // (fence char, opener run length, region start)
@@ -986,7 +986,7 @@ fn line_bounds(content: &str, at: usize) -> (usize, usize) {
 /// Recognising a span here that the frontend will not render would strip the
 /// Markdown out of ordinary prose; recognising less would leave the formula
 /// mangled — so the rules have to be the same rules.
-fn find_math_spans(content: &str, regions: &[(usize, usize)]) -> Vec<(usize, usize)> {
+pub(crate) fn find_math_spans(content: &str, regions: &[(usize, usize)]) -> Vec<(usize, usize)> {
     let bytes = content.as_bytes();
     let mut spans: Vec<(usize, usize)> = Vec::new();
     let mut barrier = 0usize;

--- a/src-tauri/src/semantic.rs
+++ b/src-tauri/src/semantic.rs
@@ -1,0 +1,566 @@
+//! What the editor should colour, decided by the renderer rather than guessed.
+//!
+//! Monaco colours Markdown with a Monarch grammar: line-oriented regexes with a
+//! dozen token names between them. It cannot tell a heading's `#` from the words
+//! after it, calls a task checkbox a link, and has never heard of `==highlight==`,
+//! `++insert++`, `$math$`, wikilinks or footnotes — all of which this app renders.
+//! Worse, it guesses: `snake_case_word` matches its emphasis rule, and comrak
+//! renders no emphasis there at all.
+//!
+//! So the editor asks the renderer. Every span here comes from the same comrak
+//! parse the preview is built from, which makes the rule behind the colours
+//! exact: **if it is coloured, it renders.**
+//!
+//! Two things are deliberate and easy to get wrong later.
+//!
+//! **The raw buffer, not the preprocessed one.** `convert_markdown` rewrites
+//! wikilinks, internal embeds and parenthesized autolinks before comrak sees the
+//! text, and those rewrites change the *length* of a line (`[[a]]` becomes
+//! `[a](a.md)`). Line numbers survive — that contract is what `data-sourcepos`
+//! and the task-checkbox toggle rest on — but columns do not, and columns are
+//! the whole point here. Parsing the raw buffer keeps every column exact; the
+//! cost is that comrak does not see the app's own syntaxes, which is why
+//! `app_syntax_spans` scans for them separately.
+//!
+//! **Columns are converted to UTF-16.** comrak reports 1-based *byte* offsets
+//! within a line; Monaco counts UTF-16 code units. For `# 标题` those disagree
+//! from the first character on, and a span computed in bytes lands in the middle
+//! of a character — where Monaco silently drops it.
+
+use comrak::nodes::{AstNode, ListType, NodeValue};
+
+use crate::markdown::markdown_options;
+
+/// One coloured range, in the coordinates Monaco's semantic tokens speak:
+/// zero-based line, zero-based UTF-16 column, length in UTF-16 code units.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct SemanticSpan {
+    /// A legend entry in `utils/semanticTokens.ts`. `kind.marker` there is a
+    /// token type plus its `marker` modifier, which is how Monaco's theme
+    /// lookup spells it (`tokenTheme._match("heading.marker")`).
+    pub kind: &'static str,
+    pub line: u32,
+    pub start: u32,
+    pub len: u32,
+}
+
+/// A half-open byte range inside one line, before the UTF-16 conversion.
+#[derive(Debug, Clone, Copy)]
+struct ByteSpan {
+    line: usize,
+    start: usize,
+    end: usize,
+}
+
+/// The spans for `content`, sorted by position and non-overlapping.
+///
+/// Non-overlapping is a requirement, not a nicety: Monaco's semantic tokens are
+/// delta-encoded from one token to the next, and two tokens covering the same
+/// character produce a negative delta that the decoder reads as a new line.
+pub fn semantic_spans(content: &str) -> Vec<SemanticSpan> {
+    let lines: Vec<&str> = content.split('\n').collect();
+    let mut raw: Vec<(ByteSpan, &'static str)> = Vec::new();
+
+    let arena = comrak::Arena::new();
+    let options = markdown_options();
+    let root = comrak::parse_document(&arena, content, &options);
+    for node in root.descendants() {
+        collect_node(node, &lines, &mut raw);
+    }
+    app_syntax_spans(&lines, &mut raw);
+
+    // Sort, then keep the first claim on any character. The order matters: an
+    // inline construct nested in another (`**bold `code`**`) has both claiming
+    // the same run, and the narrower one is pushed later by `descendants()`.
+    raw.sort_by_key(|(span, _)| (span.line, span.start, std::cmp::Reverse(span.end)));
+
+    let mut spans: Vec<SemanticSpan> = Vec::new();
+    let mut claimed: Option<(usize, usize)> = None; // (line, end byte)
+    for (span, kind) in raw {
+        let start = match claimed {
+            Some((line, end)) if line == span.line && end > span.start => end,
+            _ => span.start,
+        };
+        if start >= span.end {
+            continue;
+        }
+        claimed = Some((span.line, span.end));
+        let line = lines.get(span.line).copied().unwrap_or("");
+        let (Some(start_utf16), Some(end_utf16)) = (utf16_column(line, start), utf16_column(line, span.end))
+        else {
+            continue;
+        };
+        if end_utf16 <= start_utf16 {
+            continue;
+        }
+        spans.push(SemanticSpan {
+            kind,
+            line: span.line as u32,
+            start: start_utf16 as u32,
+            len: (end_utf16 - start_utf16) as u32,
+        });
+    }
+    spans
+}
+
+/// The UTF-16 offset of a byte offset, or `None` if it is not a char boundary.
+fn utf16_column(line: &str, byte: usize) -> Option<usize> {
+    if byte > line.len() {
+        return Some(line.encode_utf16().count());
+    }
+    if !line.is_char_boundary(byte) {
+        return None;
+    }
+    Some(line[..byte].encode_utf16().count())
+}
+
+/// The node's own range, as `(line, start_byte, end_byte)` per line touched.
+fn node_lines(node: &AstNode, lines: &[&str]) -> Vec<ByteSpan> {
+    let sp = node.data.borrow().sourcepos;
+    let mut out = Vec::new();
+    for line_no in sp.start.line..=sp.end.line {
+        let Some(text) = lines.get(line_no.saturating_sub(1)) else {
+            continue;
+        };
+        let start = if line_no == sp.start.line { sp.start.column.saturating_sub(1) } else { 0 };
+        let end = if line_no == sp.end.line { sp.end.column.min(text.len()) } else { text.len() };
+        if end > start {
+            out.push(ByteSpan { line: line_no - 1, start, end });
+        }
+    }
+    out
+}
+
+fn collect_node<'a>(node: &'a AstNode<'a>, lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
+    let value = node.data.borrow().value.clone();
+    match value {
+        NodeValue::Heading(_) => {
+            // The `#` run and the space after it, then the words. Splitting them
+            // is the thing Monarch cannot do — it emits one `keyword` for the
+            // whole line, markup and prose alike.
+            emit_gaps(node, lines, "heading.marker", out);
+            emit_text_children(node, lines, "heading", out);
+        }
+        NodeValue::Item(item) => {
+            emit_item_marker(node, lines, item.list_type, out);
+        }
+        NodeValue::TaskItem(_) => {
+            // A task item *replaces* the Item node rather than nesting inside
+            // it, so the bullet has to be emitted here too — the `Item` arm
+            // above never sees a checklist.
+            emit_item_marker(node, lines, ListType::Bullet, out);
+            // Monarch reads the brackets as a link, which is why a checklist is
+            // currently purple.
+            emit_task_marker(node, lines, out);
+        }
+        NodeValue::BlockQuote => emit_line_prefix(node, lines, '>', "quote.marker", out),
+        NodeValue::ThematicBreak => emit_whole_lines(node, lines, "rule", out),
+        NodeValue::CodeBlock(ref block) => {
+            if block.fenced {
+                emit_fence_lines(node, lines, out);
+            }
+        }
+        NodeValue::FrontMatter(_) => emit_whole_lines(node, lines, "frontmatter", out),
+        NodeValue::Table(_) => {
+            // The `|---|---|` row is not a `TableRow` — it belongs to the table
+            // itself — so its pipes have to be picked up here or the frame
+            // breaks at exactly one line.
+            let sp = node.data.borrow().sourcepos;
+            emit_pipes_on_line(lines, sp.start.line + 1, out);
+        }
+        NodeValue::TableRow(_) => emit_pipes(node, lines, out),
+        NodeValue::Code(ref code) => {
+            // Not `emit_gaps`: inline code keeps its text in the node's own
+            // value rather than in a child, so the gap arithmetic would call the
+            // whole span markup. The backtick runs are a known length instead.
+            emit_delimited(node, lines, code.num_backticks, "code", out);
+        }
+        NodeValue::Strong => emit_gaps(node, lines, "strong.marker", out),
+        NodeValue::Emph => emit_gaps(node, lines, "emph.marker", out),
+        NodeValue::Strikethrough => {
+            emit_gaps(node, lines, "strike.marker", out);
+            emit_text_children(node, lines, "strike", out);
+        }
+        NodeValue::Insert | NodeValue::Underline => {
+            emit_gaps(node, lines, "insert.marker", out);
+            emit_text_children(node, lines, "insert", out);
+        }
+        NodeValue::Highlight => {
+            emit_gaps(node, lines, "highlight.marker", out);
+            emit_text_children(node, lines, "highlight", out);
+        }
+        NodeValue::Link(_) => {
+            emit_gaps(node, lines, "link.marker", out);
+            emit_text_children(node, lines, "link", out);
+        }
+        NodeValue::Image(_) => {
+            emit_gaps(node, lines, "image.marker", out);
+            emit_text_children(node, lines, "image", out);
+        }
+        NodeValue::FootnoteReference(_) | NodeValue::FootnoteDefinition(_) => {
+            emit_self(node, lines, "footnote", out);
+        }
+        NodeValue::Math(ref math) => {
+            emit_delimited(node, lines, if math.display_math { 2 } else { 1 }, "math", out);
+        }
+        NodeValue::WikiLink(_) => {
+            emit_gaps(node, lines, "wikilink.marker", out);
+            emit_text_children(node, lines, "wikilink", out);
+        }
+        NodeValue::HtmlInline(_) | NodeValue::HtmlBlock(_) => emit_self(node, lines, "html", out),
+        _ => {}
+    }
+}
+
+/// The parts of `node`'s range no child covers — the markup characters.
+fn emit_gaps<'a>(
+    node: &'a AstNode<'a>,
+    lines: &[&str],
+    kind: &'static str,
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
+    let mut child_ranges: Vec<ByteSpan> = Vec::new();
+    for child in node.children() {
+        child_ranges.extend(node_lines(child, lines));
+    }
+    for own in node_lines(node, lines) {
+        let mut cursor = own.start;
+        let mut covering: Vec<&ByteSpan> = child_ranges.iter().filter(|c| c.line == own.line).collect();
+        covering.sort_by_key(|c| c.start);
+        for child in covering {
+            if child.start > cursor {
+                out.push((ByteSpan { line: own.line, start: cursor, end: child.start.min(own.end) }, kind));
+            }
+            cursor = cursor.max(child.end);
+        }
+        if cursor < own.end {
+            out.push((ByteSpan { line: own.line, start: cursor, end: own.end }, kind));
+        }
+    }
+}
+
+/// A construct whose delimiters are a known number of characters at each end,
+/// and whose content is not a child node — inline code, and `$math$`.
+fn emit_delimited<'a>(
+    node: &'a AstNode<'a>,
+    lines: &[&str],
+    delimiter: usize,
+    kind: &'static str,
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
+    let marker: &'static str = match kind {
+        "code" => "code.marker",
+        "math" => "math.marker",
+        _ => "code.marker",
+    };
+    let ranges = node_lines(node, lines);
+    let (Some(first), Some(last)) = (ranges.first(), ranges.last()) else {
+        return;
+    };
+    if first.line == last.line && first.end - first.start <= delimiter * 2 {
+        out.push((*first, marker));
+        return;
+    }
+    out.push((ByteSpan { line: first.line, start: first.start, end: first.start + delimiter }, marker));
+    out.push((ByteSpan { line: last.line, start: last.end.saturating_sub(delimiter), end: last.end }, marker));
+    for (index, range) in ranges.iter().enumerate() {
+        let start = if index == 0 { range.start + delimiter } else { range.start };
+        let end = if index == ranges.len() - 1 { range.end.saturating_sub(delimiter) } else { range.end };
+        if end > start {
+            out.push((ByteSpan { line: range.line, start, end }, kind));
+        }
+    }
+}
+
+/// The direct `Text` children — the words, as opposed to the markup.
+fn emit_text_children<'a>(
+    node: &'a AstNode<'a>,
+    lines: &[&str],
+    kind: &'static str,
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
+    for child in node.children() {
+        if matches!(child.data.borrow().value, NodeValue::Text(_)) {
+            out.extend(node_lines(child, lines).into_iter().map(|span| (span, kind)));
+        }
+    }
+}
+
+fn emit_self<'a>(
+    node: &'a AstNode<'a>,
+    lines: &[&str],
+    kind: &'static str,
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
+    out.extend(node_lines(node, lines).into_iter().map(|span| (span, kind)));
+}
+
+fn emit_whole_lines<'a>(
+    node: &'a AstNode<'a>,
+    lines: &[&str],
+    kind: &'static str,
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
+    emit_self(node, lines, kind, out);
+}
+
+/// The bullet or number that opens a list item, and nothing after it.
+fn emit_item_marker<'a>(
+    node: &'a AstNode<'a>,
+    lines: &[&str],
+    list_type: ListType,
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
+    let sp = node.data.borrow().sourcepos;
+    let Some(text) = lines.get(sp.start.line.saturating_sub(1)) else {
+        return;
+    };
+    let start = sp.start.column.saturating_sub(1);
+    let rest = &text[start.min(text.len())..];
+    let marker_len = match list_type {
+        ListType::Bullet => rest.chars().next().filter(|c| "-+*".contains(*c)).map(|c| c.len_utf8()),
+        ListType::Ordered => {
+            let digits = rest.chars().take_while(|c| c.is_ascii_digit()).count();
+            let delimiter = rest[digits..].chars().next().filter(|c| *c == '.' || *c == ')');
+            delimiter.map(|c| digits + c.len_utf8()).filter(|_| digits > 0)
+        }
+    };
+    if let Some(len) = marker_len {
+        out.push((ByteSpan { line: sp.start.line - 1, start, end: start + len }, "list.marker"));
+    }
+}
+
+/// `[ ]` or `[x]`, which Monarch reads as a link.
+fn emit_task_marker<'a>(node: &'a AstNode<'a>, lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
+    let sp = node.data.borrow().sourcepos;
+    let Some(text) = lines.get(sp.start.line.saturating_sub(1)) else {
+        return;
+    };
+    let from = sp.start.column.saturating_sub(1);
+    let Some(open) = text[from.min(text.len())..].find('[') else {
+        return;
+    };
+    let start = from + open;
+    let Some(close) = text[start..].find(']') else {
+        return;
+    };
+    out.push((ByteSpan { line: sp.start.line - 1, start, end: start + close + 1 }, "task.marker"));
+}
+
+/// The `>` run at the head of every line the quote covers.
+fn emit_line_prefix<'a>(
+    node: &'a AstNode<'a>,
+    lines: &[&str],
+    marker: char,
+    kind: &'static str,
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
+    let sp = node.data.borrow().sourcepos;
+    for line_no in sp.start.line..=sp.end.line {
+        let Some(text) = lines.get(line_no.saturating_sub(1)) else {
+            continue;
+        };
+        let mut end = 0;
+        for (index, ch) in text.char_indices() {
+            if ch == marker {
+                end = index + ch.len_utf8();
+            } else if ch != ' ' && ch != '\t' {
+                break;
+            }
+        }
+        if end > 0 {
+            out.push((ByteSpan { line: line_no - 1, start: 0, end }, kind));
+        }
+    }
+}
+
+/// The ``` lines, not the code between them — that keeps its own colouring.
+fn emit_fence_lines<'a>(node: &'a AstNode<'a>, lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
+    let sp = node.data.borrow().sourcepos;
+    for line_no in [sp.start.line, sp.end.line] {
+        let Some(text) = lines.get(line_no.saturating_sub(1)) else {
+            continue;
+        };
+        let trimmed = text.trim_start();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            out.push((ByteSpan { line: line_no - 1, start: 0, end: text.len() }, "fence"));
+        }
+    }
+}
+
+/// Every `|` on a table row's lines.
+fn emit_pipes<'a>(node: &'a AstNode<'a>, lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
+    let sp = node.data.borrow().sourcepos;
+    for line_no in sp.start.line..=sp.end.line {
+        emit_pipes_on_line(lines, line_no, out);
+    }
+}
+
+fn emit_pipes_on_line(lines: &[&str], line_no: usize, out: &mut Vec<(ByteSpan, &'static str)>) {
+    let Some(text) = lines.get(line_no.saturating_sub(1)) else {
+        return;
+    };
+    for (index, ch) in text.char_indices() {
+        if ch == '|' {
+            out.push((ByteSpan { line: line_no - 1, start: index, end: index + 1 }, "table.marker"));
+        }
+    }
+}
+
+/// The syntaxes this app renders that comrak does not see in the raw buffer.
+///
+/// `convert_markdown` rewrites these into standard Markdown before parsing, so
+/// the parse above cannot report them — see the note at the top of this module
+/// for why it is handed the raw buffer anyway. Both are scanned the same way the
+/// rewriter scans them, and both are line-local.
+fn app_syntax_spans(lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
+    math_spans(lines, out);
+    for (index, text) in lines.iter().enumerate() {
+        let bytes = text.as_bytes();
+        let mut at = 0;
+        while at + 1 < bytes.len() {
+            if bytes[at] == b'[' && bytes[at + 1] == b'[' {
+                if let Some(close) = text[at..].find("]]") {
+                    let end = at + close + 2;
+                    out.push((ByteSpan { line: index, start: at, end: at + 2 }, "wikilink.marker"));
+                    out.push((ByteSpan { line: index, start: at + 2, end: end - 2 }, "wikilink"));
+                    out.push((ByteSpan { line: index, start: end - 2, end }, "wikilink.marker"));
+                    at = end;
+                    continue;
+                }
+            }
+            at += 1;
+        }
+    }
+}
+
+/// `$…$` and `$$…$$`, found the way the renderer finds them.
+///
+/// Not a second scanner: `find_math_spans` is the one `mask_math_spans` uses to
+/// decide what the frontend will typeset, so the editor colours exactly what
+/// KaTeX will render — including the code regions it refuses to look inside.
+fn math_spans(lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
+    let content = lines.join("\n");
+    let regions = crate::markdown::code_region_ranges(&content);
+    let mut line_starts = Vec::with_capacity(lines.len());
+    let mut at = 0usize;
+    for line in lines {
+        line_starts.push(at);
+        at += line.len() + 1;
+    }
+
+    for (start, end) in crate::markdown::find_math_spans(&content, &regions) {
+        let Some(line) = line_starts.iter().rposition(|&begin| begin <= start) else {
+            continue;
+        };
+        // A math span never crosses a line: `find_math_spans` scans line by line
+        // because the renderer's `hardbreaks` put every source line in its own
+        // text node.
+        let base = line_starts[line];
+        let (start, end) = (start - base, end - base);
+        let delimiter = if lines[line][start..end].starts_with("$$") { 2 } else { 1 };
+        out.push((ByteSpan { line, start, end: start + delimiter }, "math.marker"));
+        out.push((ByteSpan { line, start: start + delimiter, end: end - delimiter }, "math"));
+        out.push((ByteSpan { line, start: end - delimiter, end }, "math.marker"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spans(text: &str) -> Vec<(String, u32, u32, u32)> {
+        semantic_spans(text)
+            .into_iter()
+            .map(|s| (s.kind.to_string(), s.line, s.start, s.len))
+            .collect()
+    }
+
+    fn kinds_on(text: &str, line: u32) -> Vec<String> {
+        spans(text).into_iter().filter(|s| s.1 == line).map(|s| s.0).collect()
+    }
+
+    #[test]
+    fn a_heading_separates_its_hashes_from_its_words() {
+        // The distinction Monarch cannot express: it emits one `keyword` for the
+        // whole line, markup and prose alike.
+        let found = spans("## Title\n");
+        assert!(found.contains(&("heading.marker".into(), 0, 0, 3)), "{found:?}");
+        assert!(found.contains(&("heading".into(), 0, 3, 5)), "{found:?}");
+    }
+
+    #[test]
+    fn columns_are_utf16_not_bytes() {
+        // comrak reports byte offsets; Monaco counts UTF-16. `中文 ` is 7 bytes
+        // and 3 units, so an unconverted span would start four characters late
+        // and land mid-character, where Monaco drops it.
+        let found = spans("中文 **粗体**\n");
+        assert!(found.contains(&("strong.marker".into(), 0, 3, 2)), "{found:?}");
+        assert!(found.contains(&("strong.marker".into(), 0, 7, 2)), "{found:?}");
+    }
+
+    #[test]
+    fn an_emoji_line_still_lands_on_character_boundaries() {
+        // An astral character is two UTF-16 units and four bytes: three counting
+        // systems, and only one of them is Monaco's.
+        let found = spans("🎉 `code`\n");
+        assert!(found.iter().any(|s| s.0 == "code" && s.1 == 0), "{found:?}");
+        let code = found.iter().find(|s| s.0 == "code").unwrap();
+        assert_eq!(code.2, 4, "the backtick sits after an emoji (2) and a space (1), plus its own tick");
+    }
+
+    #[test]
+    fn a_task_checkbox_is_not_a_link() {
+        let kinds = kinds_on("- [x] done\n", 0);
+        assert!(kinds.contains(&"task.marker".to_string()), "{kinds:?}");
+        assert!(!kinds.iter().any(|k| k.starts_with("link")), "{kinds:?}");
+    }
+
+    #[test]
+    fn the_syntaxes_monarch_cannot_see_are_reported() {
+        for (text, kind) in [
+            ("~~gone~~\n", "strike"),
+            ("==lit==\n", "highlight"),
+            ("++new++\n", "insert"),
+            ("[[a page]]\n", "wikilink"),
+        ] {
+            let kinds = kinds_on(text, 0);
+            assert!(kinds.contains(&kind.to_string()), "{kind} missing in {kinds:?}");
+        }
+    }
+
+    #[test]
+    fn emphasis_that_does_not_render_is_not_reported() {
+        // Monarch's `\b_[^_]+_\b` matches inside `snake_case_word`; CommonMark
+        // does not emphasise intraword underscores, so neither does this.
+        let kinds = kinds_on("snake_case_word here\n", 0);
+        assert!(kinds.is_empty(), "{kinds:?}");
+        // And an unclosed run is not emphasis either.
+        assert!(kinds_on("**unclosed\n", 0).is_empty());
+    }
+
+    #[test]
+    fn spans_never_overlap() {
+        let text = "# Head `code` **bold _mixed_**\n\n> quote with `tick`\n\n| a | b |\n|---|---|\n| 1 | 2 |\n";
+        let mut seen: Vec<(u32, u32, u32)> = semantic_spans(text)
+            .into_iter()
+            .map(|s| (s.line, s.start, s.len))
+            .collect();
+        seen.sort();
+        for pair in seen.windows(2) {
+            let (line, start, len) = pair[0];
+            let (next_line, next_start, _) = pair[1];
+            if line == next_line {
+                assert!(start + len <= next_start, "overlap at line {line}: {:?} then {:?}", pair[0], pair[1]);
+            }
+        }
+    }
+
+    #[test]
+    fn a_fenced_block_marks_its_fences_and_leaves_the_code_alone() {
+        let found = spans("```rust\nlet x = 1;\n```\n");
+        assert!(found.iter().any(|s| s.0 == "fence" && s.1 == 0));
+        assert!(found.iter().any(|s| s.0 == "fence" && s.1 == 2));
+        assert!(!found.iter().any(|s| s.1 == 1), "the code itself keeps its own colouring: {found:?}");
+    }
+}

--- a/src-tauri/src/semantic.rs
+++ b/src-tauri/src/semantic.rs
@@ -86,7 +86,8 @@ pub fn semantic_spans(content: &str) -> Vec<SemanticSpan> {
         }
         claimed = Some((span.line, span.end));
         let line = lines.get(span.line).copied().unwrap_or("");
-        let (Some(start_utf16), Some(end_utf16)) = (utf16_column(line, start), utf16_column(line, span.end))
+        let (Some(start_utf16), Some(end_utf16)) =
+            (utf16_column(line, start), utf16_column(line, span.end))
         else {
             continue;
         };
@@ -122,16 +123,32 @@ fn node_lines(node: &AstNode, lines: &[&str]) -> Vec<ByteSpan> {
         let Some(text) = lines.get(line_no.saturating_sub(1)) else {
             continue;
         };
-        let start = if line_no == sp.start.line { sp.start.column.saturating_sub(1) } else { 0 };
-        let end = if line_no == sp.end.line { sp.end.column.min(text.len()) } else { text.len() };
+        let start = if line_no == sp.start.line {
+            sp.start.column.saturating_sub(1)
+        } else {
+            0
+        };
+        let end = if line_no == sp.end.line {
+            sp.end.column.min(text.len())
+        } else {
+            text.len()
+        };
         if end > start {
-            out.push(ByteSpan { line: line_no - 1, start, end });
+            out.push(ByteSpan {
+                line: line_no - 1,
+                start,
+                end,
+            });
         }
     }
     out
 }
 
-fn collect_node<'a>(node: &'a AstNode<'a>, lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
+fn collect_node<'a>(
+    node: &'a AstNode<'a>,
+    lines: &[&str],
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
     let value = node.data.borrow().value.clone();
     match value {
         NodeValue::Heading(_) => {
@@ -201,7 +218,13 @@ fn collect_node<'a>(node: &'a AstNode<'a>, lines: &[&str], out: &mut Vec<(ByteSp
             emit_self(node, lines, "footnote", out);
         }
         NodeValue::Math(ref math) => {
-            emit_delimited(node, lines, if math.display_math { 2 } else { 1 }, "math", out);
+            emit_delimited(
+                node,
+                lines,
+                if math.display_math { 2 } else { 1 },
+                "math",
+                out,
+            );
         }
         NodeValue::WikiLink(_) => {
             emit_gaps(node, lines, "wikilink.marker", out);
@@ -225,16 +248,31 @@ fn emit_gaps<'a>(
     }
     for own in node_lines(node, lines) {
         let mut cursor = own.start;
-        let mut covering: Vec<&ByteSpan> = child_ranges.iter().filter(|c| c.line == own.line).collect();
+        let mut covering: Vec<&ByteSpan> =
+            child_ranges.iter().filter(|c| c.line == own.line).collect();
         covering.sort_by_key(|c| c.start);
         for child in covering {
             if child.start > cursor {
-                out.push((ByteSpan { line: own.line, start: cursor, end: child.start.min(own.end) }, kind));
+                out.push((
+                    ByteSpan {
+                        line: own.line,
+                        start: cursor,
+                        end: child.start.min(own.end),
+                    },
+                    kind,
+                ));
             }
             cursor = cursor.max(child.end);
         }
         if cursor < own.end {
-            out.push((ByteSpan { line: own.line, start: cursor, end: own.end }, kind));
+            out.push((
+                ByteSpan {
+                    line: own.line,
+                    start: cursor,
+                    end: own.end,
+                },
+                kind,
+            ));
         }
     }
 }
@@ -261,13 +299,42 @@ fn emit_delimited<'a>(
         out.push((*first, marker));
         return;
     }
-    out.push((ByteSpan { line: first.line, start: first.start, end: first.start + delimiter }, marker));
-    out.push((ByteSpan { line: last.line, start: last.end.saturating_sub(delimiter), end: last.end }, marker));
+    out.push((
+        ByteSpan {
+            line: first.line,
+            start: first.start,
+            end: first.start + delimiter,
+        },
+        marker,
+    ));
+    out.push((
+        ByteSpan {
+            line: last.line,
+            start: last.end.saturating_sub(delimiter),
+            end: last.end,
+        },
+        marker,
+    ));
     for (index, range) in ranges.iter().enumerate() {
-        let start = if index == 0 { range.start + delimiter } else { range.start };
-        let end = if index == ranges.len() - 1 { range.end.saturating_sub(delimiter) } else { range.end };
+        let start = if index == 0 {
+            range.start + delimiter
+        } else {
+            range.start
+        };
+        let end = if index == ranges.len() - 1 {
+            range.end.saturating_sub(delimiter)
+        } else {
+            range.end
+        };
         if end > start {
-            out.push((ByteSpan { line: range.line, start, end }, kind));
+            out.push((
+                ByteSpan {
+                    line: range.line,
+                    start,
+                    end,
+                },
+                kind,
+            ));
         }
     }
 }
@@ -281,7 +348,11 @@ fn emit_text_children<'a>(
 ) {
     for child in node.children() {
         if matches!(child.data.borrow().value, NodeValue::Text(_)) {
-            out.extend(node_lines(child, lines).into_iter().map(|span| (span, kind)));
+            out.extend(
+                node_lines(child, lines)
+                    .into_iter()
+                    .map(|span| (span, kind)),
+            );
         }
     }
 }
@@ -318,20 +389,40 @@ fn emit_item_marker<'a>(
     let start = sp.start.column.saturating_sub(1);
     let rest = &text[start.min(text.len())..];
     let marker_len = match list_type {
-        ListType::Bullet => rest.chars().next().filter(|c| "-+*".contains(*c)).map(|c| c.len_utf8()),
+        ListType::Bullet => rest
+            .chars()
+            .next()
+            .filter(|c| "-+*".contains(*c))
+            .map(|c| c.len_utf8()),
         ListType::Ordered => {
             let digits = rest.chars().take_while(|c| c.is_ascii_digit()).count();
-            let delimiter = rest[digits..].chars().next().filter(|c| *c == '.' || *c == ')');
-            delimiter.map(|c| digits + c.len_utf8()).filter(|_| digits > 0)
+            let delimiter = rest[digits..]
+                .chars()
+                .next()
+                .filter(|c| *c == '.' || *c == ')');
+            delimiter
+                .map(|c| digits + c.len_utf8())
+                .filter(|_| digits > 0)
         }
     };
     if let Some(len) = marker_len {
-        out.push((ByteSpan { line: sp.start.line - 1, start, end: start + len }, "list.marker"));
+        out.push((
+            ByteSpan {
+                line: sp.start.line - 1,
+                start,
+                end: start + len,
+            },
+            "list.marker",
+        ));
     }
 }
 
 /// `[ ]` or `[x]`, which Monarch reads as a link.
-fn emit_task_marker<'a>(node: &'a AstNode<'a>, lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
+fn emit_task_marker<'a>(
+    node: &'a AstNode<'a>,
+    lines: &[&str],
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
     let sp = node.data.borrow().sourcepos;
     let Some(text) = lines.get(sp.start.line.saturating_sub(1)) else {
         return;
@@ -344,7 +435,14 @@ fn emit_task_marker<'a>(node: &'a AstNode<'a>, lines: &[&str], out: &mut Vec<(By
     let Some(close) = text[start..].find(']') else {
         return;
     };
-    out.push((ByteSpan { line: sp.start.line - 1, start, end: start + close + 1 }, "task.marker"));
+    out.push((
+        ByteSpan {
+            line: sp.start.line - 1,
+            start,
+            end: start + close + 1,
+        },
+        "task.marker",
+    ));
 }
 
 /// The `>` run at the head of every line the quote covers.
@@ -369,13 +467,24 @@ fn emit_line_prefix<'a>(
             }
         }
         if end > 0 {
-            out.push((ByteSpan { line: line_no - 1, start: 0, end }, kind));
+            out.push((
+                ByteSpan {
+                    line: line_no - 1,
+                    start: 0,
+                    end,
+                },
+                kind,
+            ));
         }
     }
 }
 
 /// The ``` lines, not the code between them — that keeps its own colouring.
-fn emit_fence_lines<'a>(node: &'a AstNode<'a>, lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
+fn emit_fence_lines<'a>(
+    node: &'a AstNode<'a>,
+    lines: &[&str],
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
     let sp = node.data.borrow().sourcepos;
     for line_no in [sp.start.line, sp.end.line] {
         let Some(text) = lines.get(line_no.saturating_sub(1)) else {
@@ -383,7 +492,14 @@ fn emit_fence_lines<'a>(node: &'a AstNode<'a>, lines: &[&str], out: &mut Vec<(By
         };
         let trimmed = text.trim_start();
         if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
-            out.push((ByteSpan { line: line_no - 1, start: 0, end: text.len() }, "fence"));
+            out.push((
+                ByteSpan {
+                    line: line_no - 1,
+                    start: 0,
+                    end: text.len(),
+                },
+                "fence",
+            ));
         }
     }
 }
@@ -402,7 +518,14 @@ fn emit_pipes_on_line(lines: &[&str], line_no: usize, out: &mut Vec<(ByteSpan, &
     };
     for (index, ch) in text.char_indices() {
         if ch == '|' {
-            out.push((ByteSpan { line: line_no - 1, start: index, end: index + 1 }, "table.marker"));
+            out.push((
+                ByteSpan {
+                    line: line_no - 1,
+                    start: index,
+                    end: index + 1,
+                },
+                "table.marker",
+            ));
         }
     }
 }
@@ -422,9 +545,30 @@ fn app_syntax_spans(lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
             if bytes[at] == b'[' && bytes[at + 1] == b'[' {
                 if let Some(close) = text[at..].find("]]") {
                     let end = at + close + 2;
-                    out.push((ByteSpan { line: index, start: at, end: at + 2 }, "wikilink.marker"));
-                    out.push((ByteSpan { line: index, start: at + 2, end: end - 2 }, "wikilink"));
-                    out.push((ByteSpan { line: index, start: end - 2, end }, "wikilink.marker"));
+                    out.push((
+                        ByteSpan {
+                            line: index,
+                            start: at,
+                            end: at + 2,
+                        },
+                        "wikilink.marker",
+                    ));
+                    out.push((
+                        ByteSpan {
+                            line: index,
+                            start: at + 2,
+                            end: end - 2,
+                        },
+                        "wikilink",
+                    ));
+                    out.push((
+                        ByteSpan {
+                            line: index,
+                            start: end - 2,
+                            end,
+                        },
+                        "wikilink.marker",
+                    ));
                     at = end;
                     continue;
                 }
@@ -450,18 +594,78 @@ fn math_spans(lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
     }
 
     for (start, end) in crate::markdown::find_math_spans(&content, &regions) {
-        let Some(line) = line_starts.iter().rposition(|&begin| begin <= start) else {
-            continue;
+        // Display math spans lines: `$$` opens on one and closes on another,
+        // with the formula in between. Every range here is therefore cut at the
+        // line boundaries rather than assumed to sit inside one line.
+        let delimiter = if content[start..].starts_with("$$") {
+            2
+        } else {
+            1
         };
-        // A math span never crosses a line: `find_math_spans` scans line by line
-        // because the renderer's `hardbreaks` put every source line in its own
-        // text node.
+        if end < start + 2 * delimiter {
+            continue;
+        }
+        emit_byte_range(
+            lines,
+            &line_starts,
+            start,
+            start + delimiter,
+            "math.marker",
+            out,
+        );
+        emit_byte_range(
+            lines,
+            &line_starts,
+            start + delimiter,
+            end - delimiter,
+            "math",
+            out,
+        );
+        emit_byte_range(
+            lines,
+            &line_starts,
+            end - delimiter,
+            end,
+            "math.marker",
+            out,
+        );
+    }
+}
+
+/// A byte range over the whole document, as one `ByteSpan` per line it covers.
+fn emit_byte_range(
+    lines: &[&str],
+    line_starts: &[usize],
+    start: usize,
+    end: usize,
+    kind: &'static str,
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
+    if end <= start {
+        return;
+    }
+    let first = line_starts
+        .partition_point(|&begin| begin <= start)
+        .saturating_sub(1);
+    for line in first..lines.len() {
         let base = line_starts[line];
-        let (start, end) = (start - base, end - base);
-        let delimiter = if lines[line][start..end].starts_with("$$") { 2 } else { 1 };
-        out.push((ByteSpan { line, start, end: start + delimiter }, "math.marker"));
-        out.push((ByteSpan { line, start: start + delimiter, end: end - delimiter }, "math"));
-        out.push((ByteSpan { line, start: end - delimiter, end }, "math.marker"));
+        if base >= end {
+            break;
+        }
+        let (from, to) = (
+            start.max(base) - base,
+            end.min(base + lines[line].len()) - base,
+        );
+        if to > from {
+            out.push((
+                ByteSpan {
+                    line,
+                    start: from,
+                    end: to,
+                },
+                kind,
+            ));
+        }
     }
 }
 
@@ -477,7 +681,11 @@ mod tests {
     }
 
     fn kinds_on(text: &str, line: u32) -> Vec<String> {
-        spans(text).into_iter().filter(|s| s.1 == line).map(|s| s.0).collect()
+        spans(text)
+            .into_iter()
+            .filter(|s| s.1 == line)
+            .map(|s| s.0)
+            .collect()
     }
 
     #[test]
@@ -485,7 +693,10 @@ mod tests {
         // The distinction Monarch cannot express: it emits one `keyword` for the
         // whole line, markup and prose alike.
         let found = spans("## Title\n");
-        assert!(found.contains(&("heading.marker".into(), 0, 0, 3)), "{found:?}");
+        assert!(
+            found.contains(&("heading.marker".into(), 0, 0, 3)),
+            "{found:?}"
+        );
         assert!(found.contains(&("heading".into(), 0, 3, 5)), "{found:?}");
     }
 
@@ -495,8 +706,14 @@ mod tests {
         // and 3 units, so an unconverted span would start four characters late
         // and land mid-character, where Monaco drops it.
         let found = spans("中文 **粗体**\n");
-        assert!(found.contains(&("strong.marker".into(), 0, 3, 2)), "{found:?}");
-        assert!(found.contains(&("strong.marker".into(), 0, 7, 2)), "{found:?}");
+        assert!(
+            found.contains(&("strong.marker".into(), 0, 3, 2)),
+            "{found:?}"
+        );
+        assert!(
+            found.contains(&("strong.marker".into(), 0, 7, 2)),
+            "{found:?}"
+        );
     }
 
     #[test]
@@ -506,7 +723,10 @@ mod tests {
         let found = spans("🎉 `code`\n");
         assert!(found.iter().any(|s| s.0 == "code" && s.1 == 0), "{found:?}");
         let code = found.iter().find(|s| s.0 == "code").unwrap();
-        assert_eq!(code.2, 4, "the backtick sits after an emoji (2) and a space (1), plus its own tick");
+        assert_eq!(
+            code.2, 4,
+            "the backtick sits after an emoji (2) and a space (1), plus its own tick"
+        );
     }
 
     #[test]
@@ -525,8 +745,28 @@ mod tests {
             ("[[a page]]\n", "wikilink"),
         ] {
             let kinds = kinds_on(text, 0);
-            assert!(kinds.contains(&kind.to_string()), "{kind} missing in {kinds:?}");
+            assert!(
+                kinds.contains(&kind.to_string()),
+                "{kind} missing in {kinds:?}"
+            );
         }
+    }
+
+    #[test]
+    fn display_math_is_cut_at_its_line_ends() {
+        // `$$…$$` opens on one line and closes on another, so its range is not
+        // an offset into any single line — slicing it out of the opening line
+        // panics, and the release profile aborts on panic.
+        let found = spans("$$\nE=mc^2\n$$\n");
+        assert_eq!(
+            found,
+            vec![
+                ("math.marker".into(), 0, 0, 2),
+                ("math".into(), 1, 0, 6),
+                ("math.marker".into(), 2, 0, 2),
+            ],
+            "{found:?}"
+        );
     }
 
     #[test]
@@ -551,7 +791,12 @@ mod tests {
             let (line, start, len) = pair[0];
             let (next_line, next_start, _) = pair[1];
             if line == next_line {
-                assert!(start + len <= next_start, "overlap at line {line}: {:?} then {:?}", pair[0], pair[1]);
+                assert!(
+                    start + len <= next_start,
+                    "overlap at line {line}: {:?} then {:?}",
+                    pair[0],
+                    pair[1]
+                );
             }
         }
     }
@@ -561,6 +806,9 @@ mod tests {
         let found = spans("```rust\nlet x = 1;\n```\n");
         assert!(found.iter().any(|s| s.0 == "fence" && s.1 == 0));
         assert!(found.iter().any(|s| s.0 == "fence" && s.1 == 2));
-        assert!(!found.iter().any(|s| s.1 == 1), "the code itself keeps its own colouring: {found:?}");
+        assert!(
+            !found.iter().any(|s| s.1 == 1),
+            "the code itself keeps its own colouring: {found:?}"
+        );
     }
 }

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -15,7 +15,8 @@
 	import { listEnter, parseListItem } from '../utils/listEditing.js';
 	import { tableOperation, tableStep, type TableEdit, type TableOperation } from '../utils/tableEditing.js';
 	import { editorOptionsFromSettings } from '../utils/editorOptions.js';
-	import { markdownTokenRules } from '../utils/editorTheme.js';
+	import { markdownTokenRules, semanticTokenRules } from '../utils/editorTheme.js';
+	import { createMarkdownSemanticTokensProvider } from '../utils/semanticTokens.js';
 	import { getTabModel, lineEndingLabel, tabModelUri } from '../utils/tabModels.js';
 	import { installVimScrollCommands } from '../utils/vimScrollCommands.js';
 	import {
@@ -293,7 +294,7 @@
 			monaco.editor.defineTheme("app-theme-dark", {
 				base: "vs-dark",
 				inherit: true,
-				rules: markdownTokenRules('dark'),
+				rules: [...markdownTokenRules('dark'), ...semanticTokenRules('dark')],
 				colors: {
 					"editor.background": "#181818",
 					"menu.background": "#181818",
@@ -309,7 +310,7 @@
 			monaco.editor.defineTheme("app-theme-light", {
 				base: "vs",
 				inherit: true,
-				rules: markdownTokenRules('light'),
+				rules: [...markdownTokenRules('light'), ...semanticTokenRules('light')],
 				colors: {
 					"editor.background": "#FDFDFD",
 					"menu.background": "#FDFDFD",
@@ -365,6 +366,10 @@
 			theme: getTheme(),
 			dragAndDrop: true,
 			automaticLayout: true,
+			// Off by default, and `'configuredByTheme'` cannot turn it on here:
+			// `StandaloneTheme.semanticHighlighting` is hard-coded false, so the
+			// switch has to be explicit or the provider above is never asked.
+			'semanticHighlighting.enabled': true,
 			// The settings-derived options, shared with the updateOptions
 			// effect below. Zoom is 100 here and not `zoomLevel`: that is
 			// what this literal has always passed, and the effect re-applies
@@ -617,6 +622,15 @@
 		}
 	}
 
+	// The colours that come from the renderer rather than from the grammar's
+	// regexes (`utils/semanticTokens.ts`). Registered once per editor, beside the
+	// completion provider, and disposed with it.
+	const { provider: semanticTokensProvider } = createMarkdownSemanticTokensProvider(monaco);
+	const semanticTokens = monaco.languages.registerDocumentSemanticTokensProvider(
+		MARKDOWN_LANGUAGE_ID,
+		semanticTokensProvider,
+	);
+
 	const completionProvider = monaco.languages.registerCompletionItemProvider(
 			"markdown",
 			{
@@ -837,6 +851,7 @@
 			mediaQuery.removeEventListener("change", updateTheme);
 			container.removeEventListener("wheel", wheelListener, { capture: true });
 			completionProvider.dispose();
+			semanticTokens.dispose();
 			// The keybinding rules are global to the Monaco module, not to this
 			// editor, so they are disposed with it rather than left to pile up one
 			// copy per mount — this component is rebuilt every time a tab goes to

--- a/src/lib/utils/editorTheme.ts
+++ b/src/lib/utils/editorTheme.ts
@@ -95,10 +95,73 @@ const MARKDOWN_TOKEN_ROLES: ReadonlyArray<readonly [token: string, role: Role]> 
 	['emphasis.md', 'emphasis'],
 ];
 
-export type EditorTokenRule = { token: string; foreground: string };
+/**
+ * The semantic layer's rules (`utils/semanticTokens.ts`).
+ *
+ * Two things differ from the grammar rules above, both forced by how Monaco
+ * styles a semantic token. `standaloneThemeService.getTokenStyleMetadata`
+ * reports bold and italic as booleans rather than "not set", so a semantic
+ * token always *claims* those bits — a rule without `fontStyle` would switch
+ * off the bold the base theme gives `strong`. Every rule covering something
+ * bold, italic or struck through therefore says so.
+ *
+ * And the names are the construct's, not the grammar's: `heading.marker` is the
+ * token type `heading` plus its `marker` modifier, joined with a dot the way
+ * Monaco joins them before matching.
+ */
+const SEMANTIC_TOKEN_ROLES: ReadonlyArray<readonly [token: string, role: Role, style?: string]> = [
+	// Markup characters. The same colour the grammar gives block markup, so the
+	// two layers agree while a parse is in flight and nothing shifts under the
+	// reader when the answer arrives.
+	['heading.marker', 'accent'],
+	['list.marker', 'accent'],
+	['task.marker', 'accent'],
+	['quote.marker', 'accent'],
+	['table.marker', 'accent'],
+	['rule', 'accent'],
+	['fence', 'code'],
+	['frontmatter', 'muted'],
+	['code.marker', 'code'],
+	['strong.marker', 'emphasis', 'bold'],
+	['emph.marker', 'emphasis', 'italic'],
+	['strike.marker', 'muted'],
+	['highlight.marker', 'emphasis'],
+	['insert.marker', 'emphasis'],
+	['link.marker', 'link'],
+	['image.marker', 'link'],
+	['math.marker', 'code'],
+	['wikilink.marker', 'link'],
+	// The content the markup is about.
+	['heading', 'accent', 'bold'],
+	['code', 'code'],
+	['strike', 'muted', 'strikethrough'],
+	['highlight', 'emphasis'],
+	['insert', 'emphasis', 'underline'],
+	['link', 'link'],
+	['image', 'link'],
+	['math', 'code'],
+	['wikilink', 'link'],
+	['footnote', 'link'],
+	['html', 'muted'],
+];
+
+export type EditorTokenRule = { token: string; foreground: string; fontStyle?: string };
 
 /** The `rules` for one of the two built-in themes. */
 export function markdownTokenRules(appearance: 'light' | 'dark'): EditorTokenRule[] {
 	const palette = PALETTE[appearance];
 	return MARKDOWN_TOKEN_ROLES.map(([token, role]) => ({ token, foreground: palette[role] }));
+}
+
+/**
+ * The `rules` for the semantic layer, kept apart from the grammar's because the
+ * two answer to different contracts — `.md`-scoped names and inherited font
+ * styles there, construct names and explicit font styles here — and a test that
+ * holds one to the other's rules would have to be weakened to pass both.
+ */
+export function semanticTokenRules(appearance: 'light' | 'dark'): EditorTokenRule[] {
+	const palette = PALETTE[appearance];
+	return SEMANTIC_TOKEN_ROLES.map(([token, role, fontStyle]) =>
+		fontStyle ? { token, foreground: palette[role], fontStyle } : { token, foreground: palette[role] },
+	);
 }

--- a/src/lib/utils/semanticTokens.ts
+++ b/src/lib/utils/semanticTokens.ts
@@ -1,0 +1,135 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * The editor's second colouring layer: what the renderer says is really there.
+ *
+ * Monaco paints Markdown with a Monarch grammar — line-oriented regexes, a dozen
+ * token names, one `keyword` covering a heading's `#` and its words alike, a
+ * task checkbox mistaken for a link, and no idea that `==highlight==`,
+ * `++insert++`, `$math$`, wikilinks or footnotes exist. It also guesses wrong in
+ * the other direction: `snake_case_word` matches its emphasis rule.
+ *
+ * This layer answers from `src-tauri/src/semantic.rs`, which walks the same
+ * comrak parse the preview is rendered from. The grammar stays underneath and
+ * keeps painting instantly on every keystroke; these spans arrive a tick later
+ * and refine it. Monaco merges the two per *attribute*
+ * (`sparseTokensStore.js`): a semantic token replaces only the attributes its
+ * theme rule names, and any range it says nothing about keeps the grammar's
+ * colour entirely. That is what makes the layer additive rather than a second
+ * source of truth to keep in sync.
+ */
+
+/** Construct names, in the order the encoder refers to them by index. */
+export const TOKEN_TYPES = [
+	'heading',
+	'list',
+	'task',
+	'quote',
+	'rule',
+	'fence',
+	'frontmatter',
+	'table',
+	'code',
+	'strong',
+	'emph',
+	'strike',
+	'highlight',
+	'insert',
+	'link',
+	'image',
+	'math',
+	'wikilink',
+	'footnote',
+	'html',
+] as const;
+
+/**
+ * `marker` is the only modifier: it separates the characters that *are* the
+ * markup from the words the markup is about — `##` from the title, `**` from
+ * the bold run. Monaco resolves the pair by joining them with a dot, so a rule
+ * on `heading.marker` styles the hashes and one on `heading` styles the title
+ * (`standaloneThemeService.getTokenStyleMetadata`).
+ */
+export const TOKEN_MODIFIERS = ['marker'] as const;
+
+export type SemanticSpan = { kind: string; line: number; start: number; len: number };
+
+const typeIndex = new Map<string, number>(TOKEN_TYPES.map((name, index) => [name, index]));
+
+/**
+ * Spans as Monaco's delta encoding: five integers per token, each line and
+ * column relative to the token before it.
+ *
+ * Anything the legend does not know is dropped rather than guessed at: an
+ * unknown index would paint some *other* construct's colour, which is worse
+ * than leaving the grammar's.
+ */
+export function encodeSemanticTokens(spans: readonly SemanticSpan[]): Uint32Array {
+	const data: number[] = [];
+	let lastLine = 0;
+	let lastStart = 0;
+
+	for (const span of spans) {
+		const [name, modifier] = span.kind.split('.');
+		const type = typeIndex.get(name);
+		if (type === undefined || span.len <= 0) continue;
+
+		const deltaLine = span.line - lastLine;
+		const deltaStart = deltaLine === 0 ? span.start - lastStart : span.start;
+		// The encoding cannot express a token that starts before the one in
+		// front of it; Rust sorts and de-overlaps, and this is the guard that
+		// says so out loud if that ever stops being true.
+		if (deltaLine < 0 || deltaStart < 0) continue;
+
+		data.push(deltaLine, deltaStart, span.len, type, modifier === 'marker' ? 1 : 0);
+		lastLine = span.line;
+		lastStart = span.start;
+	}
+
+	return new Uint32Array(data);
+}
+
+/**
+ * The provider Monaco asks, with one parse cached per document version.
+ *
+ * Monaco calls a range provider on scroll as well as on edit, so without the
+ * cache a long document would be re-parsed several times for the same text. The
+ * cache is one entry deep because the only version that matters is the current
+ * one — an edit invalidates it by definition.
+ */
+export function createMarkdownSemanticTokensProvider(monaco: typeof import('monaco-editor')) {
+	const legend = { tokenTypes: [...TOKEN_TYPES], tokenModifiers: [...TOKEN_MODIFIERS] };
+	let cache: { uri: string; version: number; tokens: Uint32Array } | null = null;
+
+	const tokensFor = async (model: import('monaco-editor').editor.ITextModel) => {
+		const uri = model.uri.toString();
+		const version = model.getVersionId();
+		if (cache && cache.uri === uri && cache.version === version) return cache.tokens;
+
+		const spans = (await invoke('markdown_semantic_spans', { content: model.getValue() })) as SemanticSpan[];
+		// The model can have moved on while Rust was parsing. Returning tokens
+		// for text that is no longer there would paint the wrong ranges, so the
+		// stale answer is cached against its own version and Monaco asks again.
+		const tokens = encodeSemanticTokens(spans);
+		cache = { uri, version, tokens };
+		return tokens;
+	};
+
+	return {
+		legend,
+		provider: {
+			getLegend: () => legend,
+			provideDocumentSemanticTokens: async (model: import('monaco-editor').editor.ITextModel) => {
+				try {
+					return { data: await tokensFor(model) };
+				} catch (error) {
+					// A failed parse must cost the colours from this layer, not
+					// the editor: the grammar underneath keeps painting.
+					console.error('Failed to read semantic spans', error);
+					return null;
+				}
+			},
+			releaseDocumentSemanticTokens: () => {},
+		} satisfies import('monaco-editor').languages.DocumentSemanticTokensProvider,
+	};
+}


### PR DESCRIPTION
**Stacked on #684** — that PR is the base branch, and it should merge first. This one only adds the second layer; the palette and its `.md` scoping come from there.

## What this is

The editor's colours now come from the same comrak parse the preview is rendered from, instead of from Monaco's Markdown grammar alone. The rule behind them becomes exact: **if it is coloured, it renders.**

What that fixes, measured by typing the line and reading the rendered tokens back:

| source | before | after |
|---|---|---|
| `- [x] task` | `[x]` purple — the grammar reads the brackets as a link | `[x]` blue, as markup |
| `~~gone~~` `==lit==` `++new++` | no colour at all — the grammar has never heard of them | struck / highlighted / underlined |
| `[[a page]]`, `$E=mc^2$` | no colour | wikilink and math, delimiters apart from content |
| `snake_case_word` | italic — the grammar's `\b_[^_]+_\b` matches inside the word | plain, because CommonMark renders no emphasis there |
| `**unclosed` | not coloured (correct by luck) | not coloured (correct by construction) |
| `## Title` | one `keyword` for the whole line | `##` as markup, `Title` as bold content |

## Mechanism

Monaco merges the two layers **per attribute**, not per range (`sparseTokensStore.js:136`): a semantic token declares which of foreground/bold/italic/underline/strikethrough it owns, the grammar keeps the rest, and any range the parse says nothing about is left entirely alone. That is what makes this additive rather than a second source of truth — the grammar still paints instantly on every keystroke, and these spans refine it a tick later.

Three things the parse forced, each a defect if missed:

**The raw buffer is parsed, not the preprocessed one.** `convert_markdown` rewrites wikilinks, internal embeds and parenthesized autolinks before comrak sees the text, and those rewrites change a line's *length* (`[[a]]` → `[a](a.md)`). Line numbers survive — that is the contract `data-sourcepos` and the task-checkbox toggle rest on — but columns do not, and columns are the whole point. The cost is that comrak cannot see the app's own syntaxes in the raw text, so wikilinks are scanned separately and math reuses `find_math_spans`, the same scanner `mask_math_spans` uses to decide what KaTeX will typeset.

**Columns are converted to UTF-16 in Rust.** comrak reports 1-based byte offsets; Monaco counts UTF-16 code units. For `中文 **粗体**` the strong marker is at byte 7 and unit 3, and a span computed in bytes lands mid-character, where Monaco drops it silently. Emoji make it three counting systems.

**Semantic rules spell out their font styles.** `standaloneThemeService.getTokenStyleMetadata` returns bold and italic as booleans rather than "not set", so a semantic token always claims those bits — a rule that stays silent about bold switches it *off* for its range. That is the opposite of the grammar rules, where silence means "leave it alone", and it is why `SEMANTIC_TOKEN_ROLES` names a `fontStyle` wherever one matters.

Also: `'semanticHighlighting.enabled': true` is set explicitly. `StandaloneTheme.semanticHighlighting` is hard-coded `false`, so `'configuredByTheme'` cannot reach it and the provider would never be asked.

## Scope

The grammar keeps its rules. Deleting them would leave text unpainted for the tick between a keystroke and the parse; keeping them costs nothing, because the semantic layer overrides where it has an opinion.

One parse is cached per model version, because Monaco asks on scroll as well as on edit. Measured on this machine, release build, median of 20: 0.67 ms for a 527-line document, 2.06 ms for 3337 lines, 24 ms for 1.7 MB — of which the AST walk is 1–4%; the rest is the parse the preview already pays for. If the 1.7 MB case ever matters, `registerDocumentRangeSemanticTokensProvider` asks only for the visible range and is a drop-in.

Not covered by the parse, so not coloured: nothing in a fenced code block (the embedded language grammar keeps it), and reference-style link definitions.

## Tests

`src-tauri/src/semantic.rs` — 8 unit tests over the extractor: the heading split, UTF-16 columns for CJK and for an astral character, the task checkbox not being a link, the four syntaxes the grammar cannot see, `snake_case_word` and `**unclosed` producing nothing, fences marked without touching the code between them, and — the one that guards the encoding — spans never overlapping, since Monaco's delta encoding turns an overlap into a token on the wrong line.

`scripts/semanticTokens.test.ts` — 6 tests over the three seams the compiler cannot see: every kind `semantic.rs` emits is in the legend, every legend type has a theme rule and vice versa, the font styles are spelled out, the delta encoding, an unknown kind being dropped rather than mapped to whatever construct sits at that index, and the enable switch being present.

## Verification

```
npm audit             0 vulnerabilities
npm run check         808 files, 0 errors, 0 warnings
npm test              944 pass, 0 fail
npm run test:vitest   42 files, 376 pass
cargo test            156 pass
```

The before/after table was measured in Chromium against the dev server with `window.__TAURI_INTERNALS__` stubbed, feeding the provider the exact spans the real extractor prints for that text, then reading `getComputedStyle` off the rendered tokens: `##` and its title blue at weight 700, `[x]` blue rather than purple, `~~删除~~` muted and struck, `==高亮==` amber, `snake_case_word` plain.

What that does not cover: the IPC hop itself. In the browser the command is a stub — the extractor is verified by its own tests and by running it over fixtures, but nobody has yet watched Monaco ask Rust and repaint in a real window. That is what the desktop build is for.
