### PR TITLE
feat(editor): a formula reads as markup around operands

### DIFF
--- a/scripts/editorTheme.test.ts
+++ b/scripts/editorTheme.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { markdownTokenRules } from '../src/lib/utils/editorTheme.js';
+import { markdownTokenRules, semanticTokenRules } from '../src/lib/utils/editorTheme.js';
 import { readSource } from './sourceTree.js';
 
 // The editor's Markdown colours. Two things can make a rule here do nothing at
@@ -125,5 +125,21 @@ test('light and dark are actually different themes', () => {
 	assert.deepEqual(light.map((rule) => rule.token), dark.map((rule) => rule.token));
 	for (const [index, rule] of light.entries()) {
 		assert.notEqual(rule.foreground, dark[index].foreground, `${rule.token} is the same colour on both`);
+	}
+});
+
+test('a formula reads as markup around content, not as one flat run', () => {
+	// Both math rules used to resolve to the same colour, which made the split
+	// between the delimiters and the body invisible on screen. The `$` and every
+	// control sequence inside now read as markup, like every other marker; the
+	// operands keep the code colour and take the italics TeX would give them.
+	for (const appearance of ['light', 'dark'] as const) {
+		const byToken = new Map(semanticTokenRules(appearance).map((rule) => [rule.token, rule]));
+		const marker = byToken.get('math.marker');
+		const body = byToken.get('math');
+		assert.equal(marker?.foreground, byToken.get('heading.marker')?.foreground, 'markup colour');
+		assert.notEqual(marker?.foreground, body?.foreground, 'delimiters must not vanish into the body');
+		assert.equal(body?.foreground, byToken.get('code')?.foreground, 'a formula is code-coloured');
+		assert.equal(body?.fontStyle, 'italic');
 	}
 });

--- a/scripts/semanticTokens.test.ts
+++ b/scripts/semanticTokens.test.ts
@@ -57,6 +57,7 @@ test('a semantic rule spells out every font style it wants', () => {
 	assert.equal(byToken.get('emph.marker'), 'italic');
 	assert.equal(byToken.get('heading'), 'bold');
 	assert.equal(byToken.get('strike'), 'strikethrough');
+	assert.equal(byToken.get('math'), 'italic');
 });
 
 test('the encoder writes deltas Monaco can decode', () => {

--- a/src-tauri/src/semantic.rs
+++ b/src-tauri/src/semantic.rs
@@ -583,6 +583,9 @@ fn app_syntax_spans(lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
 /// Not a second scanner: `find_math_spans` is the one `mask_math_spans` uses to
 /// decide what the frontend will typeset, so the editor colours exactly what
 /// KaTeX will render — including the code regions it refuses to look inside.
+///
+/// comrak's own math extension is off (`markdown_options`), so nothing else
+/// claims these ranges and the spans below are the only ones a formula gets.
 fn math_spans(lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
     let content = lines.join("\n");
     let regions = crate::markdown::code_region_ranges(&content);
@@ -613,12 +616,12 @@ fn math_spans(lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
             "math.marker",
             out,
         );
-        emit_byte_range(
+        emit_math_body(
             lines,
             &line_starts,
+            &content,
             start + delimiter,
             end - delimiter,
-            "math",
             out,
         );
         emit_byte_range(
@@ -630,6 +633,60 @@ fn math_spans(lines: &[&str], out: &mut Vec<(ByteSpan, &'static str)>) {
             out,
         );
     }
+}
+
+/// The formula between the delimiters, control sequences apart from operands.
+///
+/// A control sequence is the markup *inside* a formula: `\frac` is to `a` and
+/// `b` what `##` is to a title, so it takes the same `marker` modifier and the
+/// same colour as the `$` around it. Braces, `_` and `^` deliberately stay with
+/// the operands. They are markup too, but colouring them as well leaves almost
+/// nothing in the operand colour and the command names stop standing out —
+/// which is where VS Code's `md-math` grammar lands too, by way of a default
+/// theme that gives its bracket and operator scopes no colour at all.
+///
+/// Every byte between the delimiters is covered, blanks included. That is not
+/// tidiness: a range no semantic token claims keeps the Monarch grammar's
+/// colour, and the grammar has never heard of `$` — it reads the `_` in
+/// `x_i + y_j` as an emphasis run and italicises the middle of the formula.
+/// Covering the body is what keeps Markdown syntax out of the maths.
+fn emit_math_body(
+    lines: &[&str],
+    line_starts: &[usize],
+    content: &str,
+    start: usize,
+    end: usize,
+    out: &mut Vec<(ByteSpan, &'static str)>,
+) {
+    let bytes = content.as_bytes();
+    let mut at = start;
+    let mut operand = start;
+    while at < end {
+        if bytes[at] != b'\\' {
+            at += char_len(content, at);
+            continue;
+        }
+        // `\` and its letters (`\frac`, `\alpha`), or `\` and one other
+        // character — `\,` is a thin space and `\\` a line break, as much
+        // markup as the named ones.
+        let mut close = at + 1;
+        while close < end && bytes[close].is_ascii_alphabetic() {
+            close += 1;
+        }
+        if close == at + 1 && close < end {
+            close += char_len(content, close);
+        }
+        emit_byte_range(lines, line_starts, operand, at, "math", out);
+        emit_byte_range(lines, line_starts, at, close, "math.marker", out);
+        at = close;
+        operand = close;
+    }
+    emit_byte_range(lines, line_starts, operand, end, "math", out);
+}
+
+/// The length of the character at `byte`, which is always a boundary here.
+fn char_len(content: &str, byte: usize) -> usize {
+    content[byte..].chars().next().map_or(1, char::len_utf8)
 }
 
 /// A byte range over the whole document, as one `ByteSpan` per line it covers.
@@ -767,6 +824,52 @@ mod tests {
             ],
             "{found:?}"
         );
+    }
+
+    #[test]
+    fn a_control_sequence_is_the_markup_inside_a_formula() {
+        // `\frac` is to `a` and `b` what `##` is to a title, so it carries the
+        // same modifier. `\,` counts too: one non-letter after the backslash is
+        // a control sequence as much as a named one.
+        let found = spans("$\\frac{a}{b}\\,c$\n");
+        assert!(
+            found.contains(&("math.marker".into(), 0, 1, 5)),
+            "\\frac: {found:?}"
+        );
+        assert!(
+            found.contains(&("math".into(), 0, 6, 6)),
+            "braces: {found:?}"
+        );
+        assert!(
+            found.contains(&("math.marker".into(), 0, 12, 2)),
+            "thin space: {found:?}"
+        );
+    }
+
+    #[test]
+    fn braces_and_scripts_stay_with_the_operands() {
+        // Deliberate: they are markup too, but marking them as well leaves
+        // almost nothing in the operand colour and the command names stop
+        // standing out. Only the `$` is a marker on this line.
+        let found = spans("$x_i + y^{2}$\n");
+        let markers: Vec<_> = found.iter().filter(|s| s.0 == "math.marker").collect();
+        assert_eq!(markers.len(), 2, "{found:?}");
+        assert!(markers.iter().all(|s| s.3 == 1), "{found:?}");
+    }
+
+    #[test]
+    fn the_formula_body_is_covered_whole() {
+        // A range no semantic token claims keeps the Monarch grammar's colour,
+        // and the grammar reads the two `_` in `x_i + y_j` as an emphasis run.
+        // Gapless coverage is what keeps Markdown syntax out of the maths.
+        let line = "$x_i + y_j \\alpha {z}$";
+        let found = spans(&format!("{line}\n"));
+        let mut at = 0;
+        for (kind, _, start, len) in &found {
+            assert_eq!(*start, at, "gap before {kind} at {start}: {found:?}");
+            at = start + len;
+        }
+        assert_eq!(at as usize, line.encode_utf16().count(), "{found:?}");
     }
 
     #[test]

--- a/src/lib/utils/editorTheme.ts
+++ b/src/lib/utils/editorTheme.ts
@@ -129,7 +129,10 @@ const SEMANTIC_TOKEN_ROLES: ReadonlyArray<readonly [token: string, role: Role, s
 	['insert.marker', 'emphasis'],
 	['link.marker', 'link'],
 	['image.marker', 'link'],
-	['math.marker', 'code'],
+	// `$`, `$$` and every control sequence between them. `\frac` is the markup
+	// inside a formula the way `##` is the markup on a heading, so `math_spans`
+	// gives it the same modifier and it lands here.
+	['math.marker', 'accent'],
 	['wikilink.marker', 'link'],
 	// The content the markup is about.
 	['heading', 'accent', 'bold'],
@@ -139,7 +142,12 @@ const SEMANTIC_TOKEN_ROLES: ReadonlyArray<readonly [token: string, role: Role, s
 	['insert', 'emphasis', 'underline'],
 	['link', 'link'],
 	['image', 'link'],
-	['math', 'code'],
+	// A formula body is set in italics, which is the one thing about it a colour
+	// cannot say: TeX typesets variables italic, so the source and the rendered
+	// output agree at a glance. Obsidian does the same, and adds a monospace
+	// family — `ITokenThemeRule` has no `fontFamily`, so that half is out of
+	// reach here.
+	['math', 'code', 'italic'],
 	['wikilink', 'link'],
 	['footnote', 'link'],
 	['html', 'muted'],


### PR DESCRIPTION
Two changes to how a formula looks in the editor, one in the theme and one in the extractor. Stacked on nothing — #686 is merged and this sits on `master`.

## What was wrong

`math.marker` and `math` both resolved to the `code` role, so the split the semantic layer exists to make was invisible: the `$` and the formula were the same green. And the body was one flat span, so `\frac` and the `a` it applies to arrived identical.

| source | before | after |
|---|---|---|
| `$…$`, `$$…$$` | same green as the body | markup blue, like `##` and `>` |
| formula body | green, upright | green, **italic** |
| `\frac`, `\alpha`, `\,`, `\\` | body green | markup blue |
| `{`, `}`, `_`, `^`, `+`, `=` | body green | body green, deliberately |

## Why those choices

**A control sequence is markup.** `\frac` is to `a` and `b` what `##` is to a title, so it takes the `marker` modifier and lands on the rule that already exists. No new legend entry, no new palette colour.

**Braces and scripts stay with the operands.** They are markup too, and marking them was the first thing I tried: `\frac{\sqrt{\pi}}{2}` comes out almost entirely blue, with `\pi` and `2` the only green left, and the command names stop standing out. VS Code's `md-math` grammar ends up in the same place from the other direction — it scopes braces and operators, and the default themes give those scopes no colour at all.

**The body is italic.** The one thing about a formula a colour cannot say. TeX typesets variables italic, so the source and the rendered output agree at a glance. Obsidian pairs the italic with a monospace family; `ITokenThemeRule` has no `fontFamily` and Monaco's `mtkN` class is a per-style index rather than a per-construct one, so only half of that is reachable from a theme.

**The body is covered with no gaps.** A requirement, not tidiness: a range no semantic token claims keeps the Monarch grammar's colour, and the grammar has never heard of `$`. It reads the two underscores in `x_i + y_j` as an emphasis run and italicises the middle of the formula — the defect [Zettlr#276](https://github.com/Zettlr/Zettlr/issues/276) describes. `the_formula_body_is_covered_whole` is the test that holds it.

comrak's own math extension is off in `markdown_options`, so `math_spans` is the only thing that claims these ranges and nothing competes with the finer spans.

## Cost

Two dense inline formulas on every one of 500 lines — a document far past anything real:

| | spans | median parse |
|---|---|---|
| before | 3000 | 3.40 ms |
| after | 12000 | 4.44 ms |

Prose is unchanged at 1.3 ms, and one parse is still cached per model version.

## Tests

`semantic.rs` — a control sequence carrying the marker modifier, including the single-character `\,`; braces and scripts staying with the operands; the body covered with no gaps.

`editorTheme.test.ts` — the delimiters resolving to the same colour as every other marker and *not* to the body's, the body keeping the code colour, and the italic being spelled out.

## Verification

```
npm run check         809 files, 0 errors, 0 warnings
npm test              948 pass
npm run test:vitest   376 pass
cargo test            160 pass
cargo fmt --check     clean
cargo clippy          -D warnings, clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)