### PR TITLE
fix(editor): an emphasis keeps its colour inside a link or a heading

### DIFF
--- a/scripts/semanticTokens.test.ts
+++ b/scripts/semanticTokens.test.ts
@@ -57,6 +57,8 @@ test('a semantic rule spells out every font style it wants', () => {
 	assert.equal(byToken.get('emph.marker'), 'italic');
 	assert.equal(byToken.get('heading'), 'bold');
 	assert.equal(byToken.get('strike'), 'strikethrough');
+	assert.equal(byToken.get('strong'), 'bold');
+	assert.equal(byToken.get('emph'), 'italic');
 	assert.equal(byToken.get('math'), 'italic');
 });
 

--- a/src-tauri/src/semantic.rs
+++ b/src-tauri/src/semantic.rs
@@ -192,8 +192,21 @@ fn collect_node<'a>(
             // whole span markup. The backtick runs are a known length instead.
             emit_delimited(node, lines, code.num_backticks, "code", out);
         }
-        NodeValue::Strong => emit_gaps(node, lines, "strong.marker", out),
-        NodeValue::Emph => emit_gaps(node, lines, "emph.marker", out),
+        // The words as well as the `**`, which matters only when something else
+        // has already claimed the line. Monaco's grammar paints `**bold**` on
+        // its own, but its link rule (`markdown.js`, the `["string.link", "",
+        // "string.link"]` action) swallows a link's text under an *empty*
+        // token, and its heading rule takes the whole line as one `keyword`.
+        // Inside either, an emphasis the parse can see would otherwise arrive
+        // with no colour of its own.
+        NodeValue::Strong => {
+            emit_gaps(node, lines, "strong.marker", out);
+            emit_text_children(node, lines, "strong", out);
+        }
+        NodeValue::Emph => {
+            emit_gaps(node, lines, "emph.marker", out);
+            emit_text_children(node, lines, "emph", out);
+        }
         NodeValue::Strikethrough => {
             emit_gaps(node, lines, "strike.marker", out);
             emit_text_children(node, lines, "strike", out);
@@ -870,6 +883,35 @@ mod tests {
             at = start + len;
         }
         assert_eq!(at as usize, line.encode_utf16().count(), "{found:?}");
+    }
+
+    #[test]
+    fn an_emphasis_keeps_its_own_colour_whatever_encloses_it() {
+        // Standing alone, `**bold**` needs nothing from here — the Monarch
+        // grammar paints it. Nested is where it showed: the grammar's link rule
+        // hands a link's text an *empty* token and its heading rule takes the
+        // whole line as one `keyword`, so a bold run inside either arrived with
+        // no colour of its own while its `**` sat there in the bold colour.
+        for text in [
+            "**b**",
+            "[**b**](u)",
+            "![**b**](u)",
+            "# **b** t",
+            "~~**b**~~",
+            "==**b**==",
+            "++**b**++",
+            "> **b**",
+            // `***bi***` is an Emph wrapping a Strong: the words belong to the
+            // inner one, and the outer contributes its `*` and nothing else.
+            "***bi***",
+        ] {
+            let found = spans(&format!("{text}\n"));
+            assert!(found.iter().any(|s| s.0 == "strong"), "{text}: {found:?}");
+        }
+        for text in ["*i*", "[*i*](u)", "# *i*", "~~*i*~~"] {
+            let found = spans(&format!("{text}\n"));
+            assert!(found.iter().any(|s| s.0 == "emph"), "{text}: {found:?}");
+        }
     }
 
     #[test]

--- a/src/lib/utils/editorTheme.ts
+++ b/src/lib/utils/editorTheme.ts
@@ -140,6 +140,12 @@ const SEMANTIC_TOKEN_ROLES: ReadonlyArray<readonly [token: string, role: Role, s
 	['strike', 'muted', 'strikethrough'],
 	['highlight', 'emphasis'],
 	['insert', 'emphasis', 'underline'],
+	// Bold and italic words. The same colours their `**` and `*` already carry,
+	// so an emphasis reads the same whether it stands in prose — where the
+	// grammar would have painted it anyway — or inside a link or heading, where
+	// the grammar leaves its text with no colour of its own.
+	['strong', 'emphasis', 'bold'],
+	['emph', 'emphasis', 'italic'],
 	['link', 'link'],
 	['image', 'link'],
 	// A formula body is set in italics, which is the one thing about it a colour


### PR DESCRIPTION
#687 is merged; this now sits on `master`.

## The symptom

`[**粗体链接文字**](https://example.com)` in the editor: the two `**` in the bold colour, the six characters between them in no colour at all.

## Two mechanisms meet

Monaco's Markdown grammar paints `**bold**` where it stands alone, so the semantic layer never claimed a Strong's *words* — only its `**`. That was fine until something else consumed the line first:

```js
// markdown.js — the link rule
[/(!?\[)((?:[^\]\\]|@escapes)*)(\]\([^\)]+\))/, ["string.link", "", "string.link"]]
//        └────── the link text ──────┘          ↑ an empty token: no colour
```

The rule matches at the `[` and swallows the whole `[...](...)`, `**` included, handing the text an empty token. The heading rule does the same thing a different way — `["white", "keyword", "keyword", "keyword"]` over the entire line, never entering `linecontent`.

So the same slot came out in two colours for a reason a reader cannot see:

| source | before | after |
|---|---|---|
| `[plain](url)` | link colour | unchanged |
| `[**bold**](url)` | **no colour** | bold colour |
| `[*it*](url)` | **no colour** | italic colour |
| `# **bold** title` | heading colour, not bold | bold colour |
| `**bold**` in prose | bold colour | unchanged |

## The fix

`Strong` and `Emph` claim their words, the way `Strikethrough`, `Highlight`, `Insert`, `Link` and `Image` already did. Where the grammar was already painting them the result is byte-identical — the same palette entry arriving from the other layer — so the visible change is confined to links, images and headings. Cost is one span per emphasis run.

`strong` and `emph` were already in `TOKEN_TYPES`; they had no theme rule, which is what left them unusable as content types.

## The rest of the class

Audited by asking, for each nesting, which bytes of the line no span claims:

```
link+strong      [**b**](u)      空洞 -> [   b]          ← this bug
link+emph        [*i*](u)        空洞 -> [  i]           ← this bug
image+strong     ![**b**](u)     空洞 -> [    b]         ← this bug
heading+strong   # **b** t       空洞 -> [    b]         ← this bug
heading+emph     # *i*           空洞 -> [   i]          ← this bug
strike+strong    ~~**b**~~       空洞 -> [    b]         ← this bug
highlight+strong ==**b**==       空洞 -> [    b]         ← this bug
insert+strong    ++**b**++       空洞 -> [    b]         ← this bug
link+strike      [~~s~~](u)      全覆盖
link+highlight   [==h==](u)      全覆盖
link+insert      [++n++](u)      全覆盖
link+code        [`c`](u)        全覆盖
heading+code     # `c` t         全覆盖
heading+link     # t [l](u)      全覆盖
strong outer     **[l](u)**      全覆盖
wikilink         [[w]]           全覆盖
autolink         <https://e.com> 全覆盖
```

Every hole traced to the one cause. The words left bare in a quote, a list item, a table cell or between `<kbd>` tags are prose, which this layer leaves alone on purpose.

One case reads oddly and is correct: `***bi***` is an Emph wrapping a Strong, so the words belong to the inner one and the outer contributes its `*` and nothing else.

## Tests

`an_emphasis_keeps_its_own_colour_whatever_encloses_it` — a `strong` span in all eight enclosing contexts and an `emph` span in four, so a future change that stops claiming the words fails rather than going quiet in the two places the grammar cannot cover.

`semanticTokens.test.ts` — the two new rules spell out their font styles, which the semantic layer requires because a silent rule switches the bit *off*.

## Verification

```
npm run check         809 files, 0 errors, 0 warnings
npm test              948 pass
npm run test:vitest   376 pass
cargo test            161 pass
cargo fmt --check     clean
cargo clippy          -D warnings, clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
