### PR TITLE
fix(toc): the outline shows the document it is looking at

### DIFF
--- a/scripts/foldStatePerDocument.spec.ts
+++ b/scripts/foldStatePerDocument.spec.ts
@@ -192,7 +192,7 @@ function tocEntries(body: HTMLElement, folds: Set<string>): string[] {
 
 	const component = mount(Toc, {
 		target,
-		props: { markdownBody: body, htmlContent: body.innerHTML, foldOverrides: new Set(folds) },
+		props: { markdownBody: body, previewRevision: 1, foldOverrides: new Set(folds) },
 	});
 	flushSync();
 	const entries = Array.from(target.querySelectorAll('.toc-link')).map((el) => el.textContent!.trim());

--- a/scripts/tocDocumentPasses.spec.ts
+++ b/scripts/tocDocumentPasses.spec.ts
@@ -46,7 +46,7 @@ beforeAll(() => {
 
 interface Harness {
 	body: HTMLElement;
-	props: { markdownBody: HTMLElement; htmlContent: string };
+	props: { markdownBody: HTMLElement; previewRevision: number };
 	/** Selectors the outline ran over the whole article since the last reset. */
 	passes: string[];
 	render(html: string): void;
@@ -74,7 +74,7 @@ function harness(html: string): Harness {
 		return queryAll(selector);
 	};
 
-	const props = runeProps({ markdownBody: body, htmlContent: html });
+	const props = runeProps({ markdownBody: body, previewRevision: 1 });
 	const component = mount(Toc, { target, props });
 	flushSync();
 
@@ -83,9 +83,11 @@ function harness(html: string): Harness {
 		props,
 		passes,
 		render(next: string) {
+			// The order the app does it in: the patch writes the DOM, and only
+			// then does the revision say so. Bumping first would model the bug
+			// this signal replaced.
 			body.innerHTML = next;
-			// The same dependency the preview changes: a new sanitized document.
-			props.htmlContent = next;
+			props.previewRevision += 1;
 			passes.length = 0;
 			flushSync();
 		},

--- a/scripts/tocOverlay.test.ts
+++ b/scripts/tocOverlay.test.ts
@@ -104,3 +104,25 @@ test('the outline collapses itself only when it is in the way', () => {
 	// Click-outside must not fight the toggle button, which owns its own click.
 	assert.match(viewer, /tocToggleEl\?\.contains\(target\)/);
 });
+
+test('the outline\'s toggle drops the editor toolbar\'s offset once it is over the outline', () => {
+	// Collapsed, the button floats over the editor pane and `--pane-top-chrome`
+	// is what keeps it clear of the toolbar. Expanded it floats over the OUTLINE,
+	// which has no toolbar — and the offset pushed it onto the outline's first
+	// entry instead. This is an absence, and an absence in CSS is not reachable
+	// from a runtime test in this suite: jsdom applies no stylesheet.
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
+
+	const base = viewer.match(/\.toc-toggle-floating \{([^}]*)\}/);
+	assert.ok(base, 'the floating toggle rule moved or was renamed');
+	assert.match(base[1], /top:\s*calc\([^)]*--pane-top-chrome/);
+
+	const expanded = viewer.match(/\.toc-toggle-floating\.expanded \{([^}]*)\}/);
+	assert.ok(expanded, 'the expanded rule moved or was renamed');
+	assert.match(expanded[1], /top:\s*\d+px/);
+	assert.equal(
+		/--pane-top-chrome/.test(expanded[1]),
+		false,
+		'the expanded toggle is over the outline, which has no editor toolbar to clear',
+	);
+});

--- a/scripts/tocRenderSignal.spec.ts
+++ b/scripts/tocRenderSignal.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+
+import Toc from '../src/lib/components/Toc.svelte';
+import { readSource } from './sourceTree.js';
+import { runeProps } from './runeProps.svelte.js';
+
+/**
+ * The outline reads the preview's DOM, so it has to be told when that DOM holds
+ * the document — not when the document was rendered.
+ *
+ * Those are one step apart on a mount, and the step is not a race that usually
+ * lands the right way round: Svelte runs a child component's effects BEFORE its
+ * parent's, so `<Toc>` always scanned the article before the parent effect that
+ * fills it. Keyed on the rendered string, the outline came up empty and nothing
+ * changed that string again, so it stayed empty for the life of the component.
+ *
+ * A floating outline hid it by closing itself whenever it covered the text: the
+ * next open built a new component against a DOM that was complete by then. A
+ * pinned one never gets that remount, so it showed "no headings found" over a
+ * document full of them until it was collapsed and expanded by hand.
+ */
+
+const DOCUMENT = '<h1 id="one">One</h1><h2 id="two">Two</h2>';
+
+function harness() {
+	const body = document.createElement('div');
+	const target = document.createElement('div');
+	document.body.replaceChildren(body, target);
+
+	// Mount time: the article exists and is still empty, which is exactly what
+	// the component sees in the flush the preview is first patched in.
+	const props = runeProps({ markdownBody: body, previewRevision: 0 });
+	const component = mount(Toc, { target, props });
+	flushSync();
+
+	return {
+		props,
+		entries: () => Array.from(target.querySelectorAll('.toc-link')).map((el) => el.textContent!.trim()),
+		stop: () => unmount(component),
+	};
+}
+
+test('a document that reaches the article after the first scan still reaches the outline', () => {
+	const toc = harness();
+	expect(toc.entries()).toEqual([]);
+
+	// What the patch effect does, in its order: DOM first, then say so.
+	toc.props.markdownBody!.innerHTML = DOCUMENT;
+	toc.props.previewRevision = 1;
+	flushSync();
+
+	expect(toc.entries()).toEqual(['One', 'Two']);
+	toc.stop();
+});
+
+test('the revision is published by the patch, not by the render', () => {
+	// The guard on the fix: a signal derived from the rendered string rather
+	// than from the write to the DOM is the bug, spelled differently.
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
+
+	const patchEffect = viewer.slice(viewer.indexOf('const patch = patchPreviewBlocks('));
+	const bump = patchEffect.indexOf('previewRevision = ++previewPatches;');
+	expect(bump).toBeGreaterThan(-1);
+	expect(bump).toBeLessThan(patchEffect.indexOf('\n\t});'));
+
+	// And the outline no longer receives the document string it never read.
+	const toc = readSource('src/lib/components/Toc.svelte');
+	expect(/htmlContent/.test(toc.split('It used to be')[0])).toBe(false);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -4657,8 +4657,20 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		padding: 0;
 	}
 
+	/**
+	 * Expanded, the button floats over the OUTLINE, which has no editor toolbar
+	 * on it — so the offset that clears one has nothing to clear and pushes the
+	 * button down onto the outline's first entry instead. 48px puts it back in
+	 * the panel's own header band, whose buttons sit at the far end (right when
+	 * the outline is on the left, left when it is on the right), leaving this
+	 * end of that band empty.
+	 *
+	 * Collapsed it keeps the offset, because there it really is floating over
+	 * the editor pane and the toolbar really is above it.
+	 */
 	.toc-toggle-floating.expanded {
 		left: 24px;
+		top: 48px;
 	}
 
 	.toc-toggle-floating.on-right {

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1173,6 +1173,31 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	}
 
 	/**
+	 * How many documents the preview DOM has been given, as a number anything
+	 * downstream of the render can wait on.
+	 *
+	 * `sanitizedHtml` looks like the same signal and is not. It says a document
+	 * has been *rendered*, and the outline used to take it as saying the article
+	 * now *holds* that document — which is true only if the patch below has
+	 * already run. On a mount it has not: Svelte runs a child component's
+	 * effects before its parent's, so `<Toc>` scanned the article in the same
+	 * flush, one step ahead of the patch that fills it, and found nothing. The
+	 * string does not change again, so nothing asked it to look twice and the
+	 * outline stayed empty until it was unmounted and remounted.
+	 *
+	 * A pinned outline is the one that never gets that remount, which is why it
+	 * was the only place the bug was visible: an overhanging floating outline
+	 * closes itself, and reopening it builds a new component against a DOM that
+	 * is by then complete.
+	 *
+	 * The counter is kept twice on purpose — `previewPatches` is the plain one
+	 * this effect increments, so the `$state` is only ever written here and
+	 * never read, and the effect cannot schedule itself.
+	 */
+	let previewRevision = $state(0);
+	let previewPatches = 0;
+
+	/**
 	 * The one place a rendered document becomes preview DOM.
 	 *
 	 * It used to be three: `{@html sanitizedHtml}` put the markup in, this effect
@@ -1199,6 +1224,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// that keeping the observation alive removed.
 		for (const block of patch.inserted) foldLayout?.observe(block);
 		if (hljs && renderMathInElement && mermaid) renderRichContent(patch.inserted);
+		previewRevision = ++previewPatches;
 	});
 
 	$effect(() => {
@@ -3862,7 +3888,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 								<Toc
 									activeLine={tocActiveLine} 
 										{markdownBody} 
-										htmlContent={sanitizedHtml}
+										{previewRevision}
 										onBeforeJump={pushScrollHistory} 
 										{foldOverrides} 
 										ontoggleFold={(key: string) => toggleFold(foldHost, key)} 

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -8,9 +8,21 @@
 	import { anchorScrollTop } from '../utils/previewAnchor.js';
 	import type { RendererLine } from '../utils/lineCoordinates.js';
 
-	let { markdownBody, htmlContent, activeLine = null, onBeforeJump, foldOverrides, ontoggleFold, oncopyref, oncontext, onjump, onshowTooltip, onhideTooltip } = $props<{
+	let { markdownBody, previewRevision, activeLine = null, onBeforeJump, foldOverrides, ontoggleFold, oncopyref, oncontext, onjump, onshowTooltip, onhideTooltip } = $props<{
 		markdownBody: HTMLElement | null;
-		htmlContent: string;
+		/**
+		 * How many documents the preview DOM has been given. Read as a signal and
+		 * never for its value: it says the article now HOLDS the document, which
+		 * is the thing this component has to wait for before it reads the DOM.
+		 *
+		 * It used to be `htmlContent`, the rendered string itself. That says a
+		 * document was rendered, not that it reached the article, and on a mount
+		 * the two are a step apart — a child's effects run before its parent's,
+		 * so the scan below ran before the patch that fills the article and read
+		 * an empty one. Nothing changed the string afterwards, so nothing asked
+		 * for a second look.
+		 */
+		previewRevision: number;
 		/**
 		 * The source line at the top of the EDITOR's viewport, or `null` when the
 		 * outline should follow the preview alone (the setting is off, or nothing
@@ -86,7 +98,12 @@
 	const CLICK_LOCK_MS = 600;
 
 	$effect(() => {
-		if (htmlContent && markdownBody) {
+		// The dependency, and the whole reason this runs. An empty document is
+		// not a special case: the scan below finds nothing in it and clears the
+		// outline the same way a document with no headings does.
+		void previewRevision;
+
+		if (markdownBody) {
 			const result: TocItem[] = [];
 
 			const entries = markdownBody.querySelectorAll(ENTRY_SELECTOR) as NodeListOf<HTMLElement>;


### PR DESCRIPTION
Two defects in the outline, one commit each. They are independent — different causes, different files, no shared line — and can be split into two PRs if that reads better.

## A pinned outline said it found no headings

Over a document full of them, and stayed that way until it was collapsed and expanded by hand.

`<Toc>` does not parse the HTML it is handed. It uses it as the signal that the preview has been rendered, then reads the live DOM — which `tocDocumentPasses.spec.ts` documents and depends on. But *rendered* is not *in the article*, and on a mount the two are one step apart in the wrong direction: Svelte runs a child component's effects before its parent's, so the scan runs ahead of the parent effect that patches the article and reads an empty one. The string never changes again, so nothing asks for a second look.

```
one mount, one flush
  1. <Toc> effect      → scans <article>   ← still empty, items = []
  2. patch effect      → fills <article>
  3. neither htmlContent nor markdownBody changes → no rescan, ever
```

The signal is now published by the write it is about: the patch effect bumps `previewRevision` after `patchPreviewBlocks` returns, and the outline depends on that. Same one `querySelectorAll` per render — the count `tocDocumentPasses.spec.ts` asserts is unchanged — and `<Toc>` stops being handed a whole document string it never read.

Only a pinned outline could show this, which is why it looks like a pinning bug and is not. A floating outline closes itself whenever it covers the text, so the next open builds a new component against a DOM that is complete by then.

`tocRenderSignal.spec.ts` drives the mount-time order directly: it mounts against an empty article, fills the DOM, bumps the revision, and expects entries. Removing the causal dependency makes it fail.

## The collapse button sat on the outline's first entry

Whenever the editor toolbar was showing.

`top: calc(48px + var(--pane-top-chrome))` is right while the outline is collapsed — the button floats over the editor pane and the offset is what keeps it clear of the toolbar above it. Expanded, it floats over the outline, which has no toolbar, so the offset had nothing to clear and pushed the button out of the panel's header band and onto its first heading.

Expanded, the offset is dropped. 48px is the header band, and the panel's own two buttons sit at the far end of it — right when the outline is on the left, left when it is on the right — so this end is empty either way. Collapsed keeps the offset, and the manual pass checked that case explicitly since it is the one this could break.

## Trade-offs

**A revision number rather than re-reading the string.** Anything derived from `sanitizedHtml` describes the render, not the article, so it can only ever be right by coincidence about when the DOM is ready. A counter written by the patch cannot be wrong about it. It also costs the outline nothing it was not already paying, and removes a document-sized prop from a component that never read it.

**Not a MutationObserver.** It would answer "the DOM changed" without anyone having to publish anything, but the outline would then also wake for every enrichment the render does afterwards — highlighting, KaTeX, Mermaid — none of which can add a heading. The scan is the largest full-document pass left in a render; #632 and the current spec exist to keep it at one per document.

**Two counters.** `previewPatches` is a plain number and `previewRevision` the `$state`, so the effect writes the reactive one and never reads it, and cannot schedule itself.

**A source assertion for the CSS.** The property is an absence — the expanded rule must not carry the offset — and jsdom applies no stylesheet, so there is no runtime state to assert on. It sits with the outline's other placement tests.

## Not changed

- Which side the outline is pinned to, its width, its resize handle, its auto-collapse, and `isTocOverPreview` / `isTocOverhanging`.
- The collapsed toggle's position, deliberately: that is the case the offset was added for.
- The patch itself, the enrichment it triggers, and the fold observation — the revision is published after all of them, so nothing downstream moved.

## Tests

`svelte-check` 0 errors / 0 warnings · `npm test` 952 pass · `npm run test:vitest` 378 pass. New `tocRenderSignal.spec.ts` (2); `tocOverlay.test.ts` gains the toggle-offset assertion; the two specs that mount `<Toc>` follow the prop.

Verified by hand on a debug build: pinned outline populated on launch, on opening another document and on a tab switch; the toggle clear of the first entry with the toolbar showing on both sides, and still clear of the toolbar when collapsed.
