### PR TITLE
fix(status bar): the word count counts CJK and every non-Latin script (#691)

### DIFF
--- a/scripts/imageUndoKeepsFile.spec.ts
+++ b/scripts/imageUndoKeepsFile.spec.ts
@@ -61,6 +61,7 @@ import { callbackBodies, functionSource, readSource } from './sourceTree.js';
 
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { lineEndingLabel } = await import('../src/lib/utils/tabModels.js');
+const { countWords } = await import('../src/lib/utils/wordCount.js');
 // The real module, not a stub: the embed these tests match against is the one
 // it writes, and its escaping is pinned separately in imageEmbed.test.ts.
 const { DEFAULT_IMAGE_DIRECTORY, documentParentDir, imageEmbed } = await import(
@@ -237,7 +238,7 @@ type Component = {
  * the statements that run are the component's own.
  */
 const factorySource = ts.transpileModule(
-	`const __component = (invoke, settings, tabManager, monaco, editor, lineEndingLabel, DEFAULT_IMAGE_DIRECTORY, documentParentDir, imageEmbed) => {
+	`const __component = (invoke, settings, tabManager, monaco, editor, lineEndingLabel, countWords, DEFAULT_IMAGE_DIRECTORY, documentParentDir, imageEmbed) => {
 		let wordCount = 0;
 		let currentLanguage = 'markdown';
 		let lineEnding = 'LF';
@@ -307,6 +308,7 @@ function createComponent(backend: Backend, editor: unknown): Component {
 		monaco: unknown,
 		editor: unknown,
 		lineEndingLabel: unknown,
+		countWords: unknown,
 		defaultImageDirectory: unknown,
 		parentDir: unknown,
 		embed: unknown,
@@ -319,6 +321,7 @@ function createComponent(backend: Backend, editor: unknown): Component {
 		monacoStub,
 		editor,
 		lineEndingLabel,
+		countWords,
 		DEFAULT_IMAGE_DIRECTORY,
 		documentParentDir,
 		imageEmbed,

--- a/scripts/undoHistoryPerTab.spec.ts
+++ b/scripts/undoHistoryPerTab.spec.ts
@@ -57,6 +57,7 @@ const { getTabModel, lineEndingLabel, tabModelUri, trackedTabModelIds } = await 
 	'../src/lib/utils/tabModels.js'
 );
 const { buildTransferredTab } = await import('../src/lib/utils/tabTransfer.js');
+const { countWords } = await import('../src/lib/utils/wordCount.js');
 
 // ------------------------------------------------- the component, as written
 
@@ -316,7 +317,7 @@ type Component = {
  * Types are erased, nothing else: the statements that run are the component's.
  */
 const factorySource = ts.transpileModule(
-	`const __component = (tabManager, monaco, editor, getTabModel, tabModelUri, lineEndingLabel) => {
+	`const __component = (tabManager, monaco, editor, getTabModel, tabModelUri, lineEndingLabel, countWords) => {
 		let currentTabId = null;
 		let language = 'markdown';
 		let currentLanguage = 'markdown';
@@ -370,9 +371,18 @@ function createComponent(editor: Editor): Component {
 		getTabModel: unknown,
 		tabModelUri: unknown,
 		lineEndingLabel: unknown,
+		countWords: unknown,
 	) => Component;
 
-	return factory(tabManager, monacoStub, editor, getTabModel, tabModelUri, lineEndingLabel);
+	return factory(
+		tabManager,
+		monacoStub,
+		editor,
+		getTabModel,
+		tabModelUri,
+		lineEndingLabel,
+		countWords,
+	);
 }
 
 type Harness = {

--- a/scripts/wordCount.spec.ts
+++ b/scripts/wordCount.spec.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+import { countWords } from '../src/lib/utils/wordCount.js';
+
+/*
+ * The status bar counted `text.match(/\S+/g)` and then kept only the tokens
+ * matching `\w` — `[A-Za-z0-9_]`. Both halves are Latin-only assumptions, and
+ * together they made a Chinese or Japanese paragraph worth nothing: one token,
+ * no `\w` in it, dropped. A document with no Latin characters read "0 字".
+ *
+ * The reported case is milder only by accident — the sentence happened to
+ * contain "18", so the whole line survived the filter as a single word.
+ */
+
+test('a CJK paragraph is counted per character, not as one token', () => {
+	// github.com/sftwrdotdev/Markpad/issues/691, verbatim. 18 Han characters
+	// plus 12 space-separated words; the app used to say 12.
+	const document =
+		'尊敬的开发者您好，这里应该有18个中文字符。\n' +
+		'Dear developers, there are 18 Chinese characters in the above text.';
+	assert.equal(countWords(document), 30);
+});
+
+test('a document with no Latin characters is not zero', () => {
+	// The failure the issue did not reach, and the one that matters more.
+	assert.equal(countWords('中文文档没有任何拉丁字母'), 12);
+	assert.equal(countWords('日本語のテキストです'), 10);
+});
+
+test('CJK punctuation is not a word', () => {
+	// `，` and `。` are Script=Common, so they reach the whitespace pass and
+	// have to be filtered there, exactly like `.` and `,`.
+	assert.equal(countWords('你好，世界。'), 4);
+	assert.equal(countWords('Hello, world.'), 2);
+});
+
+test('a number wedged between CJK characters stays its own word', () => {
+	// Removing the CJK run instead of spacing it would glue `18` to `年`'s
+	// neighbours across the gap.
+	assert.equal(countWords('第1章和第2章'), 7);
+});
+
+test('a script with no ASCII in it is not zero either', () => {
+	// The `\w` filter was `[A-Za-z0-9_]`, so it dropped these tokens whole.
+	// Korean is spaced, so the whitespace pass is the right unit for it — three
+	// words, not eight syllables.
+	assert.equal(countWords('안녕하세요 반갑습니다 여러분'), 3);
+	assert.equal(countWords('Привет мир'), 2);
+	assert.equal(countWords('Γειά σου κόσμε'), 3);
+});
+
+test('Latin counting is unchanged', () => {
+	assert.equal(countWords(''), 0);
+	assert.equal(countWords('   \n\t  '), 0);
+	assert.equal(countWords('Hello world'), 2);
+	assert.equal(countWords('one\ntwo\tthree'), 3);
+	// Punctuation-only tokens were already excluded and still are. `___` is a
+	// horizontal rule and now goes with them: it used to count as a word only
+	// because `_` is in `\w`.
+	assert.equal(countWords('--- *** ### ___'), 0);
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -19,6 +19,7 @@
 	import { createMarkdownSemanticTokensProvider } from '../utils/semanticTokens.js';
 	import { getTabModel, lineEndingLabel, tabModelUri } from '../utils/tabModels.js';
 	import { installVimScrollCommands } from '../utils/vimScrollCommands.js';
+	import { countWords } from '../utils/wordCount.js';
 	import {
 		headingLinkContext,
 		headingQueryStart,
@@ -229,7 +230,7 @@
 		currentLanguage = model.getLanguageId();
 		lineEnding = lineEndingLabel(model);
 		const text = model.getValue();
-		wordCount = (text.match(/\S+/g) || []).filter((w) => /\w/.test(w)).length;
+		wordCount = countWords(text);
 	}
 
 	self.MonacoEnvironment = {

--- a/src/lib/utils/wordCount.ts
+++ b/src/lib/utils/wordCount.ts
@@ -1,0 +1,33 @@
+/**
+ * The number the status bar shows.
+ *
+ * The old expression was `\S+` tokens filtered by `/\w/`, and both halves are
+ * Latin-only. `\w` is `[A-Za-z0-9_]`, so it dropped every token written in a
+ * script that has no ASCII in it — Korean, Cyrillic, Greek, Arabic, Thai — and
+ * a document in one of those counted zero. That is what `\p{L}`/`\p{N}` fixes,
+ * and it is the whole fix for every script that puts spaces between words.
+ *
+ * Chinese and Japanese do not, so whitespace tokens are the wrong unit there:
+ * a whole paragraph arrives as one token. Han, Hiragana and Katakana are
+ * counted per character instead, which is what Word, Typora and Obsidian
+ * report and what a Chinese or Japanese reader means by 字数. Hangul is
+ * deliberately not in that set — Korean is spaced, so counting it per syllable
+ * would inflate every Korean document.
+ *
+ * CJK punctuation (`，`, `。`, `、`) is Script=Common, not Script=Han, so it
+ * falls to the whitespace pass and is rejected there like `.` and `,`.
+ */
+const CJK_CHARACTER = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/gu;
+const HAS_LETTER_OR_DIGIT = /[\p{L}\p{N}]/u;
+
+export function countWords(text: string): number {
+	const cjk = text.match(CJK_CHARACTER)?.length ?? 0;
+	// Replaced with a space rather than removed: in `第1章和第2章` the digits
+	// are separate words, and deleting the run around them would glue them
+	// into one.
+	const spaced = text.replace(CJK_CHARACTER, ' ');
+	const words = (spaced.match(/\S+/g) || []).filter((w) =>
+		HAS_LETTER_OR_DIGIT.test(w),
+	).length;
+	return cjk + words;
+}


### PR DESCRIPTION
## What this is

Closes #691, reported by @17Archangel: a document with 18 Chinese characters and 12 English words showed "12 字".

The report understates it. The status bar counted

```js
(text.match(/\S+/g) || []).filter((w) => /\w/.test(w)).length
```

and both halves assume Latin script, so the failure is wider than CJK:

| document | before | after |
|---|---|---|
| the one in #691 | 12 | 30 |
| `中文文档没有任何拉丁字母` | **0** | 12 |
| `日本語のテキストです` | **0** | 10 |
| `안녕하세요 반갑습니다 여러분` | **0** | 3 |
| `Привет мир` | **0** | 2 |
| `Hello world` | 2 | 2 |

**A document written in Korean, Russian, Greek, Arabic or Thai read 0 words.** The reported document read 12 rather than 0 only because the sentence happened to contain "18".

## Mechanism

Two independent Latin assumptions, one per half of the expression.

**`\w` is `[A-Za-z0-9_]`.** The filter exists to keep punctuation-only tokens (`---`, `***`) out of the count, and it does that by asking "is there a word character in here?" — in ASCII. A token spelled `안녕하세요` or `Привет` has no ASCII in it, so the filter threw it away with the punctuation. That is the whole bug for every script that puts spaces between words, and `[\p{L}\p{N}]` is the whole fix: same intent, asked of Unicode instead of ASCII.

**Whitespace is not a word boundary in Chinese or Japanese.** Neither writes spaces between words, so `\S+` yields one token per paragraph and no filter can rescue the count. Han, Hiragana and Katakana are counted per character instead, added to the whitespace pass over what is left. That is what Word, Typora and Obsidian report, and what a reader means by 字数.

Hangul is deliberately **not** in that set. Korean is spaced, so the `\p{L}` fix alone already counts it correctly; adding it to the per-character set would turn every Korean document from too low to too high. Fixing one script by breaking another is not a fix.

CJK punctuation needs no special case: `，` `。` `、` are `Script=Common`, not `Script=Han`, so they fall to the whitespace pass and get rejected there exactly like `.` and `,`.

The CJK run is replaced with a space rather than deleted, so that in `第1章和第2章` the two digits stay two words instead of being glued into `12`.

## Scope

One behaviour change beyond the bug: `___` no longer counts as a word. It counted before only because `_` is in `\w`, which made a horizontal rule a word while `---` and `***` were not. The test pins the new answer.

Not changed: the zh-CN string is still `{{count}} 字`, which is now accurate — it was the counting that was wrong, not the label.

## Tests

`scripts/wordCount.spec.ts`, six cases: the #691 document verbatim, a Latin-free document in Chinese and Japanese, CJK punctuation, a digit between CJK characters, a non-ASCII spaced script (Korean, Cyrillic, Greek), and the Latin behaviour that must not move.

The expression had to leave `Editor.svelte` for any of that to be callable — it was inline in `syncStatusFromModel` with nothing able to reach it, which is why a count that returns 0 for a whole language shipped. `wordCount.ts` is that seam. The two harnesses that lift Editor.svelte's function bodies and evaluate them (`undoHistoryPerTab.spec.ts`, `imageUndoKeepsFile.spec.ts`) inject the new import; that is the entire diff in those two files.

## Verification

```
npm audit             0 vulnerabilities
npm run check         811 files, 0 errors, 0 warnings
npm test              951 pass, 0 fail
npm run test:vitest   43 files, 368 pass
cargo test            161 pass, 0 fail
```

`npm run test:vitest` also reports 14 failures in this environment (session-restore and window-tag snapshots, all `assert.deepEqual` reference-identity complaints from node 26 + jsdom). They are byte-identical on a clean `origin/master` checkout in the same environment — verified by stashing this branch and re-running — so this PR neither causes nor fixes them.

The numbers in the table are `countWords` output, not a screenshot: the status bar renders whatever it returns.
