### PR TITLE
fix(title bar): Auto-Reload and Mod+L agree in every mode (#692)

### DIFF
--- a/scripts/externalChangeReload.spec.ts
+++ b/scripts/externalChangeReload.spec.ts
@@ -218,3 +218,18 @@ test('reloading a clean tab does not throw the user out of the editor', async ()
 	assert.equal(tabManager.activeTab?.isEditing, true, 'the reload left the editor');
 	assert.equal(tabManager.activeTab?.isDirty, false, 'the reloaded buffer is not an edit');
 });
+
+test('entering split view no longer turns Live Mode off behind the user', () => {
+	// #692. Split used to kill live mode on the way in, with no comment and no
+	// way back — the setting was silently dropped and stayed dropped after
+	// leaving. That line arrived with the original split-view commit and reads
+	// as a consequence of the Auto-Reload button being hidden there (nothing
+	// left to turn it off with) rather than a decision that a split pane should
+	// not follow the file. The button and the chord are now offered in all
+	// three modes; a kill here would take the state straight back off.
+	//
+	// An absence claim about a component that cannot be imported, so it is
+	// matched as source text — the same reason as the four assertions above.
+	const body = sliceBetween(viewer, 'async function toggleSplitView', '\n\t}');
+	assert.doesNotMatch(body, /toggleLiveMode|liveMode\s*=/);
+});

--- a/scripts/externalChangeReload.spec.ts
+++ b/scripts/externalChangeReload.spec.ts
@@ -188,3 +188,33 @@ test('turning Live Mode on installs the watcher without reloading', () => {
 	const body = sliceBetween(viewer, 'function toggleLiveMode', '\n\t}');
 	assert.doesNotMatch(body, /loadMarkdown/);
 });
+
+// --- #692: the editor is where the reload has to land ---
+
+test('reloading a clean tab does not throw the user out of the editor', async () => {
+	// The gate on the Auto-Reload button used to hide it in edit mode, so this
+	// path was reachable only by enabling Live Mode in the preview and then
+	// pressing Edit. Now that editing is the case the button is FOR, a reload
+	// that dropped the tab back to preview would be the visible bug.
+	//
+	// `loadMarkdown(path)` with no options is exactly the call the
+	// `file-changed` listener makes for a `reload` outcome.
+	const session = makeSession();
+	const tab = open('/notes/live.md', 'before');
+	tab.isEditing = true;
+
+	handleInvoke = (cmd) => {
+		if (cmd === 'canonicalize_path') return '/notes/live.md';
+		// An editing pane always gets the whole file, never the 5MB preview
+		// slice — an editor bound to a partial buffer auto-saves it back over
+		// the document's tail.
+		if (cmd === 'read_file_content_checked') return ['after', false, 'UTF-8'];
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+
+	await session.loadMarkdown('/notes/live.md');
+
+	assert.equal(tabManager.activeTab?.rawContent, 'after', 'the disk version did not arrive');
+	assert.equal(tabManager.activeTab?.isEditing, true, 'the reload left the editor');
+	assert.equal(tabManager.activeTab?.isDirty, false, 'the reloaded buffer is not an edit');
+});

--- a/scripts/titlebarToolbar.test.ts
+++ b/scripts/titlebarToolbar.test.ts
@@ -9,6 +9,7 @@ import {
 	normalizeTitlebarToolbarHidden,
 	normalizeTitlebarToolbarOrder,
 	normalizeTitlebarToolbarPlacement,
+	visibleTitlebarActionIds,
 } from '../src/lib/utils/titlebarToolbar.js';
 
 test('normalizeTitlebarToolbarOrder drops unknown ids, deduplicates, and appends defaults', () => {
@@ -70,4 +71,87 @@ test('titlebar toolbar reorder helpers resolve drag and keyboard moves', () => {
 	assert.deepEqual(getTitlebarToolbarAdjacentMove(order, 'reload', 'down'), { fromIndex: 1, toIndex: 2 });
 	assert.equal(getTitlebarToolbarReorderMove(order, 'back', 'back'), null);
 	assert.equal(getTitlebarToolbarAdjacentMove(order, 'back', 'up'), null);
+});
+
+/*
+ * #692: editing a file in Markpad while VS Code writes the same file, and
+ * Markpad not noticing until the mode was toggled.
+ *
+ * Auto-Reload is what that user wanted and it already existed, but the button
+ * was gated on `!isEditing` — so in the one mode the feature is for, it was
+ * unreachable. Its chord answered the same question the other way: `Mod+L` is
+ * `editorAction: true` in shortcuts.ts, which registers it on Monaco, so the
+ * chord works in edit mode ONLY. Two answers, exactly complementary, nothing
+ * requiring them to agree. Ctrl+L in the editor flipped the state with no
+ * indicator anywhere on screen.
+ */
+
+const documentContext = {
+	hasActiveTab: true,
+	showHome: false,
+	currentFile: '/notes/a.md',
+	isSplit: false,
+	isEditing: false,
+};
+
+test('Auto-Reload is offered in edit mode, where Mod+L already toggles it', () => {
+	assert.ok(
+		visibleTitlebarActionIds({ ...documentContext, isEditing: true }).includes('live'),
+		'the editor is where a file changing underneath you matters most',
+	);
+	assert.ok(visibleTitlebarActionIds(documentContext).includes('live'));
+});
+
+test('Auto-Reload is not offered in split view, whose preview renders the buffer', () => {
+	assert.ok(
+		!visibleTitlebarActionIds({ ...documentContext, isSplit: true }).includes('live'),
+	);
+});
+
+test('Auto-Reload needs a file on disk to watch', () => {
+	assert.ok(
+		!visibleTitlebarActionIds({ ...documentContext, currentFile: '' }).includes('live'),
+	);
+});
+
+test('the rest of the toolbar still answers to the mode it is in', () => {
+	const view = visibleTitlebarActionIds(documentContext);
+	const edit = visibleTitlebarActionIds({ ...documentContext, isEditing: true });
+	const split = visibleTitlebarActionIds({ ...documentContext, isSplit: true });
+
+	// Find: Monaco owns Ctrl+F in pure edit mode, so the preview's Find hides
+	// there and comes back in split, where a preview is on screen again.
+	assert.deepEqual([view, edit, split].map((ids) => ids.includes('find')), [true, false, true]);
+	// The formatting toolbar is the mirror image: only where a pane can write.
+	assert.deepEqual([view, edit, split].map((ids) => ids.includes('editorToolbar')), [false, true, true]);
+	// Sync Scroll needs two panes; Edit is meaningless once both are showing.
+	assert.deepEqual([view, edit, split].map((ids) => ids.includes('sync')), [false, false, true]);
+	assert.deepEqual([view, edit, split].map((ids) => ids.includes('edit')), [true, true, false]);
+});
+
+test('a non-Markdown file gets none of the Markdown actions', () => {
+	// `.txt` would not do here: it is in MARKDOWN_LINK_EXTENSIONS.
+	const ids = visibleTitlebarActionIds({ ...documentContext, currentFile: '/notes/data.json' });
+	for (const id of ['toc', 'fullWidth', 'live', 'split', 'edit', 'find']) {
+		assert.ok(!ids.includes(id), `${id} was offered for a .json file`);
+	}
+	// An unsaved buffer has no extension to read and is treated as Markdown.
+	assert.ok(visibleTitlebarActionIds({ ...documentContext, currentFile: '' }).includes('split'));
+});
+
+test('the home screen offers only the actions that are not about a document', () => {
+	assert.deepEqual(visibleTitlebarActionIds({ ...documentContext, showHome: true }), [
+		'theme',
+		'settings',
+	]);
+	assert.deepEqual(visibleTitlebarActionIds({ ...documentContext, hasActiveTab: false }), [
+		'theme',
+		'settings',
+	]);
+});
+
+test('Reset Zoom appears only away from 100%', () => {
+	assert.ok(!visibleTitlebarActionIds({ ...documentContext, zoomLevel: 100 }).includes('zoom'));
+	assert.ok(!visibleTitlebarActionIds(documentContext).includes('zoom'));
+	assert.ok(visibleTitlebarActionIds({ ...documentContext, zoomLevel: 125 }).includes('zoom'));
 });

--- a/scripts/titlebarToolbar.test.ts
+++ b/scripts/titlebarToolbar.test.ts
@@ -77,13 +77,18 @@ test('titlebar toolbar reorder helpers resolve drag and keyboard moves', () => {
  * #692: editing a file in Markpad while VS Code writes the same file, and
  * Markpad not noticing until the mode was toggled.
  *
- * Auto-Reload is what that user wanted and it already existed, but the button
- * was gated on `!isEditing` — so in the one mode the feature is for, it was
- * unreachable. Its chord answered the same question the other way: `Mod+L` is
- * `editorAction: true` in shortcuts.ts, which registers it on Monaco, so the
- * chord works in edit mode ONLY. Two answers, exactly complementary, nothing
- * requiring them to agree. Ctrl+L in the editor flipped the state with no
- * indicator anywhere on screen.
+ * Auto-Reload is what that user wanted and it already existed. Its two
+ * surfaces disagreed about where it existed, and their answers were exact
+ * complements: the button was drawn only in the preview (`!isEditing`,
+ * `!isSplit`), while `Mod+L` was only an `editorAction` in shortcuts.ts and
+ * therefore only on Monaco — which exists only in edit and split. Whether a
+ * user got the feature depended on which surface they happened to find, and
+ * pressing the chord in the editor armed the watcher with nothing on screen
+ * to show it had.
+ *
+ * The answer is one condition, in one place, with the chord routed through
+ * the same `toggleLiveMode` (`shortcutRegistry.test.ts` holds the chord end
+ * up, `externalChangeReload.spec.ts` holds the reload end).
  */
 
 const documentContext = {
@@ -94,18 +99,19 @@ const documentContext = {
 	isEditing: false,
 };
 
-test('Auto-Reload is offered in edit mode, where Mod+L already toggles it', () => {
-	assert.ok(
-		visibleTitlebarActionIds({ ...documentContext, isEditing: true }).includes('live'),
-		'the editor is where a file changing underneath you matters most',
-	);
-	assert.ok(visibleTitlebarActionIds(documentContext).includes('live'));
-});
-
-test('Auto-Reload is not offered in split view, whose preview renders the buffer', () => {
-	assert.ok(
-		!visibleTitlebarActionIds({ ...documentContext, isSplit: true }).includes('live'),
-	);
+test('Auto-Reload is offered in every mode that has a file on disk', () => {
+	// An external writer can surprise all three equally: what varies between
+	// them is which pane is on screen, not whether the file can change.
+	for (const mode of [
+		{ label: 'preview' },
+		{ label: 'edit', isEditing: true },
+		{ label: 'split', isSplit: true },
+	]) {
+		assert.ok(
+			visibleTitlebarActionIds({ ...documentContext, ...mode }).includes('live'),
+			`Auto-Reload was missing in ${mode.label} mode`,
+		);
+	}
 });
 
 test('Auto-Reload needs a file on disk to watch', () => {
@@ -124,8 +130,10 @@ test('the rest of the toolbar still answers to the mode it is in', () => {
 	assert.deepEqual([view, edit, split].map((ids) => ids.includes('find')), [true, false, true]);
 	// The formatting toolbar is the mirror image: only where a pane can write.
 	assert.deepEqual([view, edit, split].map((ids) => ids.includes('editorToolbar')), [false, true, true]);
-	// Sync Scroll needs two panes; Edit is meaningless once both are showing.
+	// Sync Scroll and Swap Panes both need two panes; Edit is meaningless once
+	// both are showing.
 	assert.deepEqual([view, edit, split].map((ids) => ids.includes('sync')), [false, false, true]);
+	assert.deepEqual([view, edit, split].map((ids) => ids.includes('swap')), [false, false, true]);
 	assert.deepEqual([view, edit, split].map((ids) => ids.includes('edit')), [true, true, false]);
 });
 

--- a/scripts/viewerKeymap.spec.ts
+++ b/scripts/viewerKeymap.spec.ts
@@ -154,3 +154,23 @@ test('every command the dispatcher can name is one the component can run', () =>
 	assert.ok(reachable.size >= 10, `only ${reachable.size} commands were reached; the sweep is not running`);
 	for (const command of reachable) assert.ok(table[command], `runViewerCommand has no case for ${command}`);
 });
+
+test('Mod+L reaches Auto-Reload from every mode, including the preview', () => {
+	// #692. The chord used to exist only as an `editorAction`, so Monaco owned
+	// it and it did nothing in the preview — the exact inverse of where the
+	// Auto-Reload button was drawn, while the shortcut panel advertised it in
+	// all three modes regardless. The button now appears in all three; this is
+	// the other surface agreeing.
+	const modL = chord('l', 'KeyL', { ctrlKey: true });
+	assert.equal(viewerCommandFor(modL, READING), 'toggle-live-mode');
+	assert.equal(
+		viewerCommandFor(modL, { ...READING, isEditing: true, editorHasFocus: true }),
+		'toggle-live-mode',
+	);
+	assert.equal(viewerCommandFor(modL, { ...READING, isSplit: true }), 'toggle-live-mode');
+
+	// And it is Mod+L, not the cross product Mod+Shift+L / Mod+Alt+L.
+	assert.equal(viewerCommandFor(chord('l', 'KeyL', { ctrlKey: true, shiftKey: true }), READING), null);
+	assert.equal(viewerCommandFor(chord('l', 'KeyL', { ctrlKey: true, altKey: true }), READING), null);
+	assert.equal(viewerCommandFor(chord('l', 'KeyL'), READING), null);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2854,7 +2854,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				return;
 			}
 			tabManager.setSplitEnabled(tab.id, true);
-			if (liveMode) toggleLiveMode();
 		} else {
 			// Closing split view is the same move as leaving edit mode, and it
 			// gets the same treatment: the surviving pane renders the buffer,
@@ -2921,6 +2920,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			case 'toggle-split-view':
 				if (tabManager.activeTabId) toggleSplitView(tabManager.activeTabId);
 				return;
+			case 'toggle-live-mode':
+				return void toggleLiveMode();
 			case 'toggle-edit-view':
 				// The `silentSave` argument this used to pass meant "suppress the
 				// unsaved-changes modal on the hotkey path". There is no modal on a

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -9,10 +9,9 @@
 	import { tabManager } from '../stores/tabs.svelte.js';
 	import { settings } from '../stores/settings.svelte.js';
 	import { t } from '../utils/i18n.js';
-	import { getConfiguredTitlebarToolbarIds } from '../utils/titlebarToolbar.js';
+	import { getConfiguredTitlebarToolbarIds, visibleTitlebarActionIds } from '../utils/titlebarToolbar.js';
 	import { modifierFor, shortcutLabel } from '../utils/shortcuts.js';
 	import { platformOf } from '../utils/platform.js';
-	import { hasMarkdownLinkExtension } from '../utils/markdownLinks.js';
 	import { hasExportableDocument, hasRealFilePath } from '../utils/tabFileActions.js';
 	import { getVersion } from '@tauri-apps/api/app';
 
@@ -327,55 +326,16 @@
 		}
 	});
 
-	let visibleActionIds = $derived.by(() => {
-		const list: string[] = [];
-
-		if (tabManager.activeTab && !showHome) {
-			list.push('back');
-			list.push('forward');
-			if (currentFile) list.push('reload');
-
-			// An unsaved buffer has no name to read an extension off, and is
-			// treated as Markdown — which is what the old inline default of `'md'`
-			// said, spelled as the condition it actually is.
-			const isMarkdown = currentFile ? hasMarkdownLinkExtension(currentFile) : true;
-
-			if (isMarkdown) {
-				list.push('toc');
-				list.push('fullWidth');
-				if (!tabManager.activeTab?.isSplit && !isEditing && currentFile) {
-					list.push('live');
-				}
-				if (tabManager.activeTab?.isSplit) {
-					list.push('sync');
-					// Only a split has two panes to put in an order, so the
-					// control that orders them exists only there.
-					list.push('swap');
-				}
-				list.push('split');
-			}
-			if (isMarkdown && !tabManager.activeTab?.isSplit) {
-				list.push('edit');
-			}
-			// Find in preview: only meaningful when a preview is actually
-			// visible (view mode or split). In pure edit mode Monaco's own
-			// Ctrl+F handles search, so we hide the entry there.
-			if (isMarkdown && (!isEditing || tabManager.activeTab?.isSplit)) {
-				list.push('find');
-			}
-			if (isEditing || tabManager.activeTab?.isSplit) {
-				list.push('editorToolbar');
-			}
-			list.push('zen');
-			list.push('tabs');
-		}
-
-		if (zoomLevel && zoomLevel !== 100) list.push('zoom');
-		list.push('theme');
-		list.push('settings');
-
-		return list;
-	});
+	let visibleActionIds = $derived.by(() =>
+		visibleTitlebarActionIds({
+			hasActiveTab: Boolean(tabManager.activeTab),
+			showHome,
+			currentFile,
+			isSplit: Boolean(tabManager.activeTab?.isSplit),
+			isEditing,
+			zoomLevel,
+		}),
+	);
 
 	let configuredActionIds = $derived.by(() =>
 		getConfiguredTitlebarToolbarIds(

--- a/src/lib/utils/shortcuts.ts
+++ b/src/lib/utils/shortcuts.ts
@@ -348,7 +348,12 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		labelKey: 'menu.toggleLiveMode',
 		chords: ['Mod+L'],
 		group: 'view',
+		// Both halves, like Mod+E: Monaco's own Ctrl+L is `expandLineSelection`,
+		// so the editor action is what stops the chord selecting a line, and the
+		// document command is what makes it work in the preview, where there is
+		// no Monaco to register anything on.
 		editorAction: true,
+		documentCommands: ['toggle-live-mode'],
 	},
 	{
 		id: 'view-toggle-split',

--- a/src/lib/utils/titlebarToolbar.ts
+++ b/src/lib/utils/titlebarToolbar.ts
@@ -1,3 +1,5 @@
+import { hasMarkdownLinkExtension } from './markdownLinks.js';
+
 export type TitlebarToolbarPlacement = 'bar' | 'menu';
 
 type TitlebarToolbarAction = {
@@ -142,6 +144,85 @@ export function applyTitlebarToolbarMove(order: readonly string[], move: Titleba
 	const [moved] = next.splice(move.fromIndex, 1);
 	next.splice(move.toIndex, 0, moved);
 	return next;
+}
+
+export type TitlebarActionContext = {
+	hasActiveTab: boolean;
+	showHome: boolean;
+	currentFile: string;
+	isSplit: boolean;
+	isEditing: boolean;
+	zoomLevel?: number;
+};
+
+/**
+ * Which actions the current document offers, before the user's own order,
+ * hiding and bar/menu placement are applied to them.
+ *
+ * This used to be a `$derived.by` inside TitleBar.svelte, where nothing could
+ * call it — and one of its conditions was wrong for as long as that was true.
+ * The Auto-Reload button was gated on `!isEditing` while its chord, Mod+L, is
+ * an `editorAction` in shortcuts.ts and therefore registered on Monaco: the
+ * chord existed only in edit mode and the button existed everywhere else, so
+ * the two never both applied. Editing a file that another program also writes
+ * — the case auto-reload is for — got the chord with no indicator.
+ *
+ * Its output already fed `getConfiguredTitlebarToolbarIds` below, so this is
+ * the first half of a pipeline moving next to the second, not a new layer.
+ */
+export function visibleTitlebarActionIds(context: TitlebarActionContext): string[] {
+	const list: string[] = [];
+
+	if (context.hasActiveTab && !context.showHome) {
+		list.push('back');
+		list.push('forward');
+		if (context.currentFile) list.push('reload');
+
+		// An unsaved buffer has no name to read an extension off, and is
+		// treated as Markdown — which is what the old inline default of `'md'`
+		// said, spelled as the condition it actually is.
+		const isMarkdown = context.currentFile
+			? hasMarkdownLinkExtension(context.currentFile)
+			: true;
+
+		if (isMarkdown) {
+			list.push('toc');
+			list.push('fullWidth');
+			// Split view stays out on purpose: its preview renders the live
+			// buffer rather than the file, which is why entering it turns live
+			// mode off (`toggleSplitView` in MarkdownViewer.svelte).
+			if (!context.isSplit && context.currentFile) {
+				list.push('live');
+			}
+			if (context.isSplit) {
+				list.push('sync');
+				// Only a split has two panes to put in an order, so the
+				// control that orders them exists only there.
+				list.push('swap');
+			}
+			list.push('split');
+		}
+		if (isMarkdown && !context.isSplit) {
+			list.push('edit');
+		}
+		// Find in preview: only meaningful when a preview is actually
+		// visible (view mode or split). In pure edit mode Monaco's own
+		// Ctrl+F handles search, so we hide the entry there.
+		if (isMarkdown && (!context.isEditing || context.isSplit)) {
+			list.push('find');
+		}
+		if (context.isEditing || context.isSplit) {
+			list.push('editorToolbar');
+		}
+		list.push('zen');
+		list.push('tabs');
+	}
+
+	if (context.zoomLevel && context.zoomLevel !== 100) list.push('zoom');
+	list.push('theme');
+	list.push('settings');
+
+	return list;
 }
 
 export function getConfiguredTitlebarToolbarIds(

--- a/src/lib/utils/titlebarToolbar.ts
+++ b/src/lib/utils/titlebarToolbar.ts
@@ -161,11 +161,13 @@ export type TitlebarActionContext = {
  *
  * This used to be a `$derived.by` inside TitleBar.svelte, where nothing could
  * call it — and one of its conditions was wrong for as long as that was true.
- * The Auto-Reload button was gated on `!isEditing` while its chord, Mod+L, is
- * an `editorAction` in shortcuts.ts and therefore registered on Monaco: the
- * chord existed only in edit mode and the button existed everywhere else, so
- * the two never both applied. Editing a file that another program also writes
- * — the case auto-reload is for — got the chord with no indicator.
+ * The Auto-Reload button was drawn only in the preview (`!isEditing`,
+ * `!isSplit`) while its chord, Mod+L, was only an `editorAction` in
+ * shortcuts.ts and therefore only on Monaco, which exists only in the other
+ * two modes. The two surfaces of one feature never both applied, and the
+ * shortcut panel advertised the chord in all three regardless. Editing a file
+ * that another program also writes — the case auto-reload is for — got the
+ * chord and no indicator.
  *
  * Its output already fed `getConfiguredTitlebarToolbarIds` below, so this is
  * the first half of a pipeline moving next to the second, not a new layer.
@@ -188,10 +190,10 @@ export function visibleTitlebarActionIds(context: TitlebarActionContext): string
 		if (isMarkdown) {
 			list.push('toc');
 			list.push('fullWidth');
-			// Split view stays out on purpose: its preview renders the live
-			// buffer rather than the file, which is why entering it turns live
-			// mode off (`toggleSplitView` in MarkdownViewer.svelte).
-			if (!context.isSplit && context.currentFile) {
+			// Every mode that has a file on disk, which is every mode an
+			// external writer can surprise. The chord answers the same
+			// question the same way — see the note above.
+			if (context.currentFile) {
 				list.push('live');
 			}
 			if (context.isSplit) {

--- a/src/lib/utils/viewerKeymap.ts
+++ b/src/lib/utils/viewerKeymap.ts
@@ -58,6 +58,7 @@ export type ViewerCommand =
 	| 'close-window'
 	| 'toggle-split-view'
 	| 'toggle-edit-view'
+	| 'toggle-live-mode'
 	| 'save-as'
 	| 'save'
 	| 'undo-close-tab'
@@ -244,6 +245,11 @@ export function viewerCommandFor(e: KeyStroke, context: KeyContext): ViewerComma
 	if (mod && key === 'q') return 'close-window';
 	if (mod && (code === 'Backslash' || code === 'IntlBackslash')) return 'toggle-split-view';
 	if (mod && key === 'e') return 'toggle-edit-view';
+	// Mod+L had only the Monaco half (`editorAction` in shortcuts.ts), so it
+	// fired in the editor and in split view and did nothing in the preview —
+	// the exact inverse of where the Auto-Reload button was drawn (#692). The
+	// panel advertised the chord in every mode regardless.
+	if (mod && key === 'l') return 'toggle-live-mode';
 	// Save As. The app menu advertised this chord for as long as the menu has
 	// existed, but nothing ever bound it: the branch below matched on
 	// `cmdOrCtrl && key === 's'` with no Shift guard, so the advertised


### PR DESCRIPTION
## What this is

Closes #692, reported by @17Archangel: editing a `.md` file in Markpad and in VS Code at the same time, saving in VS Code, and Markpad not picking the change up until the mode was toggled.

The feature they wanted already exists — Auto-Reload. It had two surfaces that disagreed about which modes it existed in, and their answers were exact complements:

| | preview | edit | split |
|---|---|---|---|
| title-bar button | yes | **no** | **no** |
| `Mod+L` | **no** | yes | yes |
| shortcut panel | advertises it | advertises it | advertises it |

Whether a user got the feature depended on which surface they happened to find first. The reporter was editing, so they found neither the button (hidden) nor a reason to try the chord.

Two failures fall out of that table beyond the report. Pressing Ctrl+L in the editor **did** work — it armed the watcher and started reloading the document — with nothing on screen to show the state had changed. And the shortcut panel prints `Mod+L` unconditionally (`shortcutSections` filters by group only), so in the preview it advertised a chord that was bound to nothing.

After this PR every cell in that table is yes.

## Mechanism

**The button.** `!isEditing && !isSplit` in `TitleBar.svelte` becomes "there is a file on disk", which is the condition that actually matters: an external writer can surprise all three modes equally, and what varies between them is only which pane is on screen.

**The chord.** `view-toggle-live` carried `editorAction: true` and nothing else, so it existed only as a Monaco action and only where Monaco does. It gets `documentCommands: ['toggle-live-mode']` as well — the same pair `view-toggle-edit` (Mod+E) already carries — plus the branch in `viewerKeymap.ts` and the case in `runViewerCommand`. The Monaco action stays rather than being replaced: Monaco binds Ctrl+L to `expandLineSelection` by default, so dropping the action would make the chord select a line instead of doing nothing.

**Split view stops killing live mode on the way in.** That was one uncommented line in `toggleSplitView`, and `git blame` puts it in the original split-view commit. It reads as a consequence of the button being hidden in split — nothing left to turn the state off with — rather than a decision that a split pane should not follow its file. A split pane is an editor: same exposure to another program writing the file, and `loadMarkdown` already keeps the split through a reload and still routes a dirty buffer to the conflict bar. It also meant enabling Auto-Reload in the preview, entering split and leaving again silently lost the setting.

Nothing downstream of the toggle needed a change. The watcher effect is `if (liveMode && currentFile)`, never gated on the mode; `resolveExternalChange` already sends a dirty tab to the conflict bar instead of overwriting it; and `loadMarkdown` skips the open-mode reset for a tab that already holds the file (`!existing`), so a reload keeps whichever pane you were in and an editable pane takes the `read_file_content_checked` branch rather than the 5MB preview slice.

## Scope

`visibleActionIds` moves out of `TitleBar.svelte` into `titlebarToolbar.ts` as `visibleTitlebarActionIds(context)`. That module already owns which toolbar ids exist and already consumed this function's output through `getConfiguredTitlebarToolbarIds`, so this is the first half of a pipeline moving next to the second, not a new layer. It is also why the bug lasted: the condition sat in a `$derived.by` inside a component where no test could reach it. The moved body is otherwise the same statements in the same order, and the tests below pin every branch of it rather than only the one that changed.

Considered and not done: leaving split unsupported and drawing the button disabled there instead. That keeps a rule to explain, needs a new tooltip string in 26 locales, and the rule itself did not survive being looked at — see the blame above.

Not changed: `liveMode` still defaults to off. Turning it on by default puts Markpad's own auto-save and an external writer on the same file, and whether the self-write grace window absorbs that needs measuring rather than guessing.

## Tests

`scripts/titlebarToolbar.test.ts`, six cases over the extracted function: Auto-Reload offered in all three modes, absent with no file on disk, Find / editor toolbar / Sync Scroll / Edit each still answering to the mode they belong to, a non-Markdown file getting none of the Markdown actions, the home screen, and Reset Zoom.

`scripts/viewerKeymap.spec.ts`, one case: `Mod+L` resolves to `toggle-live-mode` from the preview, from the editor with focus in it, and from split — and `Mod+Shift+L`, `Mod+Alt+L` and a bare `L` resolve to nothing. The file's existing sweep already holds that every command the dispatcher can name has a case in `runViewerCommand`.

`scripts/externalChangeReload.spec.ts`, two cases: `loadMarkdown(path)` — the exact call the `file-changed` listener makes — against a clean tab with `isEditing` true leaves the tab in the editor with the disk content and not dirty; and `toggleSplitView` no longer names `toggleLiveMode`.

Each of the three was checked by breaking what it guards: restoring `!isEditing` on the button, dropping the `!existing` guard in `documentSession`, and putting the split kill back all turn the matching test red.

## Verification

```
npm audit             0 vulnerabilities
npm run check         809 files, 0 errors, 0 warnings
npm test              957 pass, 0 fail
npm run test:vitest   43 files, 365 pass
cargo test            161 pass, 0 fail
```

`npm run test:vitest` also reports 14 failures in this environment (session-restore and window-tag snapshots, all `assert.deepEqual` reference-identity complaints under node 26 + jsdom). Byte-identical on a clean `origin/master` checkout in the same environment, verified by stashing and re-running, so this PR neither causes nor fixes them.

Not verified: the end-to-end gesture on Windows, where the report came from — button pressed in edit mode, file written by another editor, document refreshing in place. The wiring it depends on is platform-independent and the `notify` watcher was already carrying it in preview mode.
