### PR TITLE
fix(watcher): arm Live Mode on the directory, so a save does not kill it

### DIFF
--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -1223,9 +1223,20 @@ mod watch_survives_rename {
                 // The same two decisions `watch_file` makes, so this exercises
                 // the composition rather than notify on its own.
                 let Ok(event) = result else { return };
-                if super::event_concerns(&event, name.as_deref()) {
-                    let _ = tx.send(());
+                if !super::event_concerns(&event, name.as_deref()) {
+                    return;
                 }
+                // The names, not a bare tick. Which file an event was about is
+                // the only timing-independent way to ask whether the filter
+                // held: an event is allowed to arrive late, but it is never
+                // allowed to name somebody else's file.
+                let names: Vec<String> = event
+                    .paths
+                    .iter()
+                    .filter_map(|p| p.file_name())
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .collect();
+                let _ = tx.send(names);
             },
             Config::default(),
         )
@@ -1235,44 +1246,63 @@ mod watch_survives_rename {
             .watch(&super::watch_root(&target), RecursiveMode::NonRecursive)
             .unwrap();
 
+        let mut delivered: Vec<Vec<String>> = Vec::new();
+        let mut collect = |rx: &mpsc::Receiver<Vec<String>>, out: &mut Vec<Vec<String>>| {
+            let first = rx.recv_timeout(Duration::from_secs(5)).ok();
+            let reported = first.is_some();
+            out.extend(first);
+            while let Ok(more) = rx.try_recv() {
+                out.push(more);
+            }
+            reported
+        };
+
         // First write in place, to prove the watch is live at all. Without this
-        // a dead watcher and a broken test harness look identical.
+        // a dead watcher and a broken harness look identical.
         std::fs::write(&target, b"two").unwrap();
-        assert!(
-            rx.recv_timeout(Duration::from_secs(5)).is_ok(),
-            "the watch reported nothing even for an in-place write",
-        );
-        while rx.try_recv().is_ok() {}
+        let alive = collect(&rx, &mut delivered);
 
         // Now the way `atomic_write` — and every editor that saves atomically —
         // actually writes: a new file renamed over the old one.
-        let temp = dir.join("notes.md.tmp");
+        let temp = dir.join("notes.md.tmp1234");
         std::fs::write(&temp, b"three").unwrap();
         std::fs::rename(&temp, &target).unwrap();
-        let replaced = rx.recv_timeout(Duration::from_secs(5)).is_ok();
-        while rx.try_recv().is_ok() {}
+        let replaced = collect(&rx, &mut delivered);
 
-        // And a write to the file that now lives at that path.
+        // The write that used to be invisible: the inode the watch was armed on
+        // is gone, and this one belongs to the file that replaced it.
         std::fs::write(&target, b"four").unwrap();
-        let after = rx.recv_timeout(Duration::from_secs(5)).is_ok();
-        while rx.try_recv().is_ok() {}
+        let after = collect(&rx, &mut delivered);
 
-        // The watch is on the whole directory now, so the filter is the only
-        // thing keeping this from reporting the neighbours — including the
-        // temp file `atomic_write` drops beside every save.
+        // The watch covers the whole directory now, so the filter is the only
+        // thing keeping the neighbours out — including the temp file
+        // `atomic_write` drops beside every save.
         std::fs::write(dir.join("unrelated.md"), b"not ours").unwrap();
-        std::fs::write(dir.join("notes.md.tmp1234"), b"nor this").unwrap();
-        let neighbours = rx.recv_timeout(Duration::from_millis(1500)).is_ok();
+        std::fs::write(dir.join("notes.md.tmp5678"), b"nor this").unwrap();
+        std::thread::sleep(Duration::from_millis(1500));
+        while let Ok(more) = rx.try_recv() {
+            delivered.push(more);
+        }
 
         std::fs::remove_dir_all(&dir).ok();
+        assert!(
+            alive,
+            "the watch reported nothing even for an in-place write"
+        );
         assert!(replaced, "the rename itself was not reported");
         assert!(
             after,
             "the watch died with the replaced inode: every later external change is invisible",
         );
-        assert!(
-            !neighbours,
-            "a sibling file was reported as a change to the watched one",
-        );
+        // Asserted over every event the run produced rather than over a quiet
+        // window, because a late event about the watched file is legitimate and
+        // a slow machine will produce one. What must never appear is a
+        // neighbour's name.
+        for names in &delivered {
+            assert!(
+                names.iter().any(|n| n == "notes.md"),
+                "an event about {names:?} was reported as a change to notes.md",
+            );
+        }
     }
 }

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -1,8 +1,9 @@
 use crate::fs_safety::atomic_write;
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Mutex,
@@ -582,6 +583,55 @@ pub fn create_transfer_window(app: AppHandle, token: String) -> Result<(), Strin
     Ok(())
 }
 
+/// The path a watch for `target` is armed on: its parent directory.
+///
+/// Not `target` itself, which is what this used to be. A Linux `inotify` watch
+/// resolves the path once and then follows the INODE, and `atomic_write` — like
+/// VS Code, Vim, JetBrains and Emacs — saves by writing a temp file alongside
+/// and renaming it over the top. That leaves a new inode at the same path, so
+/// the watch was left holding the unlinked old one: after the first save, its
+/// own or anyone else's, Live Mode on Linux reported nothing for the rest of
+/// the session, and the callback swallowed the error that said so.
+/// `watch_survives_rename` below is that failure, pinned per platform.
+///
+/// A directory watch has no such problem, because the directory is the thing
+/// whose entries changed. The cost is hearing about every sibling file, which
+/// `event_concerns` drops on a name comparison — cheaper than the emit it
+/// replaces, and paid only while Live Mode is on.
+///
+/// Falls back to the target itself when there is no usable parent (a bare
+/// relative filename, or a filesystem root), which keeps the previous
+/// behaviour for the cases a directory watch cannot serve.
+fn watch_root(target: &Path) -> PathBuf {
+    match target.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() && target.file_name().is_some() => {
+            parent.to_path_buf()
+        }
+        _ => target.to_path_buf(),
+    }
+}
+
+/// Whether `event` is about the watched file rather than one of its neighbours.
+///
+/// Compares file names, not whole paths: the watch covers exactly one
+/// directory, so the name is already unambiguous within it, and the platforms
+/// do not agree on how to spell the directory back to us (macOS reports
+/// `/private/var/...` for a path opened as `/var/...`). A rename that brings a
+/// different file to this name is reported too, which is right — the file at
+/// this path changed.
+///
+/// `atomic_write`'s temp file is a sibling with a different name, so a save
+/// emits for the rename and not for the temp write that precedes it.
+///
+/// `None` means the watch is on the file itself (see `watch_root`), where
+/// there is nothing to filter out.
+fn event_concerns(event: &notify::Event, file_name: Option<&OsStr>) -> bool {
+    match file_name {
+        None => true,
+        Some(name) => event.paths.iter().any(|p| p.file_name() == Some(name)),
+    }
+}
+
 pub fn watch_file(
     window: tauri::Window,
     handle: AppHandle,
@@ -592,6 +642,12 @@ pub fn watch_file(
     let event_label = label.clone();
     let watched_path = path.clone();
 
+    // The DIRECTORY, not the file — see `watch_root`. The filename is kept so
+    // the callback can drop everything else that happens in it.
+    let target = Path::new(&path);
+    let file_name = target.file_name().map(OsStr::to_os_string);
+    let root = watch_root(target);
+
     // Build and arm the replacement *before* touching the watcher already
     // registered for this window. Dropping the old one first meant a failure
     // in either step below left the window with no watcher at all: the
@@ -600,15 +656,17 @@ pub fn watch_file(
     // in one step — the map drops the previous watcher, which unregisters it.
     let mut watcher = RecommendedWatcher::new(
         move |result: Result<notify::Event, notify::Error>| {
-            if result.is_ok() {
-                let _ = handle.emit_to(event_label.as_str(), "file-changed", watched_path.clone());
+            let Ok(event) = result else { return };
+            if !event_concerns(&event, file_name.as_deref()) {
+                return;
             }
+            let _ = handle.emit_to(event_label.as_str(), "file-changed", watched_path.clone());
         },
         Config::default(),
     )
     .map_err(|e| e.to_string())?;
     watcher
-        .watch(Path::new(&path), RecursiveMode::NonRecursive)
+        .watch(&root, RecursiveMode::NonRecursive)
         .map_err(|e| e.to_string())?;
 
     lock_recover(&state.watchers).insert(label, watcher);
@@ -1100,6 +1158,48 @@ mod tests {
 /// If this fails on a platform, Live Mode there stops reporting anything after
 /// the first save, silently and for the rest of the session.
 #[cfg(test)]
+mod watch_targeting {
+    use super::{event_concerns, watch_root};
+    use std::ffi::OsStr;
+    use std::path::{Path, PathBuf};
+
+    fn event(paths: &[&str]) -> notify::Event {
+        let mut e = notify::Event::new(notify::EventKind::Any);
+        e.paths = paths.iter().map(PathBuf::from).collect();
+        e
+    }
+
+    #[test]
+    fn a_watch_is_armed_on_the_containing_directory() {
+        assert_eq!(
+            watch_root(Path::new("/notes/a.md")),
+            PathBuf::from("/notes")
+        );
+        // No usable parent: the file itself, which is what it always was.
+        assert_eq!(watch_root(Path::new("a.md")), PathBuf::from("a.md"));
+        assert_eq!(watch_root(Path::new("/")), PathBuf::from("/"));
+    }
+
+    #[test]
+    fn only_events_naming_the_watched_file_get_through() {
+        let name = Some(OsStr::new("a.md"));
+        assert!(event_concerns(&event(&["/notes/a.md"]), name));
+        // A rename reports both sides; ours being either one is our business.
+        assert!(event_concerns(
+            &event(&["/notes/a.md.tmp99", "/notes/a.md"]),
+            name
+        ));
+        // The directory reports its other entries, and the temp file every
+        // `atomic_write` leaves beside the target is one of them.
+        assert!(!event_concerns(&event(&["/notes/b.md"]), name));
+        assert!(!event_concerns(&event(&["/notes/a.md.tmp99"]), name));
+        assert!(!event_concerns(&event(&[]), name));
+        // The fallback watch is on the file, so there is nothing to filter.
+        assert!(event_concerns(&event(&["/notes/b.md"]), None));
+    }
+}
+
+#[cfg(test)]
 mod watch_survives_rename {
     use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
     use std::sync::mpsc;
@@ -1116,10 +1216,14 @@ mod watch_survives_rename {
         let target = dir.join("notes.md");
         std::fs::write(&target, b"one").unwrap();
 
+        let name = target.file_name().map(std::ffi::OsStr::to_os_string);
         let (tx, rx) = mpsc::channel();
         let mut watcher = RecommendedWatcher::new(
             move |result: Result<notify::Event, notify::Error>| {
-                if result.is_ok() {
+                // The same two decisions `watch_file` makes, so this exercises
+                // the composition rather than notify on its own.
+                let Ok(event) = result else { return };
+                if super::event_concerns(&event, name.as_deref()) {
                     let _ = tx.send(());
                 }
             },
@@ -1127,7 +1231,9 @@ mod watch_survives_rename {
         )
         .unwrap();
         // Exactly what `watch_file` arms.
-        watcher.watch(&target, RecursiveMode::NonRecursive).unwrap();
+        watcher
+            .watch(&super::watch_root(&target), RecursiveMode::NonRecursive)
+            .unwrap();
 
         // First write in place, to prove the watch is live at all. Without this
         // a dead watcher and a broken test harness look identical.
@@ -1149,12 +1255,24 @@ mod watch_survives_rename {
         // And a write to the file that now lives at that path.
         std::fs::write(&target, b"four").unwrap();
         let after = rx.recv_timeout(Duration::from_secs(5)).is_ok();
+        while rx.try_recv().is_ok() {}
+
+        // The watch is on the whole directory now, so the filter is the only
+        // thing keeping this from reporting the neighbours — including the
+        // temp file `atomic_write` drops beside every save.
+        std::fs::write(dir.join("unrelated.md"), b"not ours").unwrap();
+        std::fs::write(dir.join("notes.md.tmp1234"), b"nor this").unwrap();
+        let neighbours = rx.recv_timeout(Duration::from_millis(1500)).is_ok();
 
         std::fs::remove_dir_all(&dir).ok();
         assert!(replaced, "the rename itself was not reported");
         assert!(
             after,
             "the watch died with the replaced inode: every later external change is invisible",
+        );
+        assert!(
+            !neighbours,
+            "a sibling file was reported as a change to the watched one",
         );
     }
 }

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -1107,7 +1107,10 @@ mod watch_survives_rename {
 
     #[test]
     fn a_file_watch_still_reports_after_the_file_is_replaced() {
-        let nonce = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
         let dir = std::env::temp_dir().join(format!("markpad-watch-{nonce}"));
         std::fs::create_dir_all(&dir).unwrap();
         let target = dir.join("notes.md");

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -1247,7 +1247,7 @@ mod watch_survives_rename {
             .unwrap();
 
         let mut delivered: Vec<Vec<String>> = Vec::new();
-        let mut collect = |rx: &mpsc::Receiver<Vec<String>>, out: &mut Vec<Vec<String>>| {
+        let collect = |rx: &mpsc::Receiver<Vec<String>>, out: &mut Vec<Vec<String>>| {
             let first = rx.recv_timeout(Duration::from_secs(5)).ok();
             let reported = first.is_some();
             out.extend(first);

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -1087,3 +1087,71 @@ mod tests {
         fs::remove_dir_all(&dir).unwrap();
     }
 }
+
+/// Does a watch armed on a FILE survive that file being replaced by a rename?
+///
+/// Not a test of Markpad's code — a test of the platform behaviour `watch_file`
+/// rests on, which is the only way to know whether the assumption holds on the
+/// three targets. `atomic_write` saves every document by writing a temp file
+/// alongside and renaming it over the target, so this is not an exotic case:
+/// it is what one Markpad save does to its own watch, and what most editors do
+/// to it (VS Code, Vim, JetBrains, Emacs all rename on save).
+///
+/// If this fails on a platform, Live Mode there stops reporting anything after
+/// the first save, silently and for the rest of the session.
+#[cfg(test)]
+mod watch_survives_rename {
+    use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
+    use std::sync::mpsc;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn a_file_watch_still_reports_after_the_file_is_replaced() {
+        let nonce = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let dir = std::env::temp_dir().join(format!("markpad-watch-{nonce}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("notes.md");
+        std::fs::write(&target, b"one").unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        let mut watcher = RecommendedWatcher::new(
+            move |result: Result<notify::Event, notify::Error>| {
+                if result.is_ok() {
+                    let _ = tx.send(());
+                }
+            },
+            Config::default(),
+        )
+        .unwrap();
+        // Exactly what `watch_file` arms.
+        watcher.watch(&target, RecursiveMode::NonRecursive).unwrap();
+
+        // First write in place, to prove the watch is live at all. Without this
+        // a dead watcher and a broken test harness look identical.
+        std::fs::write(&target, b"two").unwrap();
+        assert!(
+            rx.recv_timeout(Duration::from_secs(5)).is_ok(),
+            "the watch reported nothing even for an in-place write",
+        );
+        while rx.try_recv().is_ok() {}
+
+        // Now the way `atomic_write` — and every editor that saves atomically —
+        // actually writes: a new file renamed over the old one.
+        let temp = dir.join("notes.md.tmp");
+        std::fs::write(&temp, b"three").unwrap();
+        std::fs::rename(&temp, &target).unwrap();
+        let replaced = rx.recv_timeout(Duration::from_secs(5)).is_ok();
+        while rx.try_recv().is_ok() {}
+
+        // And a write to the file that now lives at that path.
+        std::fs::write(&target, b"four").unwrap();
+        let after = rx.recv_timeout(Duration::from_secs(5)).is_ok();
+
+        std::fs::remove_dir_all(&dir).ok();
+        assert!(replaced, "the rename itself was not reported");
+        assert!(
+            after,
+            "the watch died with the replaced inode: every later external change is invisible",
+        );
+    }
+}


### PR DESCRIPTION
## What this is

On Linux, Live Mode stopped reporting anything after the first save of the watched file — its own or another program's — silently, for the rest of the session.

Two commits, deliberately kept apart: the first adds the test and **fails CI on Linux**, the second fixes it. The failing run is the evidence, and it is the only way to establish a platform behaviour from a macOS desktop.

```
window_runtime::watch_survives_rename::a_file_watch_still_reports_after_the_file_is_replaced

  before   macOS ✅   Linux ❌ "the watch died with the replaced inode"
  after    macOS ✅   Linux ✅
```

## Mechanism

`watch_file` armed the watch on the file:

```rust
watcher.watch(Path::new(&path), RecursiveMode::NonRecursive)
```

Linux `inotify` resolves that path once and then follows the **inode**. `atomic_write` — Markpad's own save path — writes a temp file alongside the target and renames it over the top, which puts a *new* inode at that path and unlinks the old one. The watch was left holding the unlinked one. VS Code, Vim, JetBrains and Emacs all save the same way, so this is the normal case rather than an exotic one, and the frontend has no way to notice: the callback was `if result.is_ok() { emit }`, so the error saying the watch had died went nowhere.

macOS is unaffected because FSEvents watches the path, which is why this could not be found without CI.

The watch moves to the containing directory. A directory is the thing whose entries a rename changes, so it has no inode problem on any of the three platforms. `event_concerns` then drops the neighbours.

Filtering by file **name**, not by whole path, for two reasons: the watch covers exactly one non-recursive directory, so the name is already unambiguous within it; and the platforms do not agree on how to spell the directory back — macOS reports `/private/var/…` for a path opened as `/var/…`, and a path comparison would drop every event on a temp directory. `atomic_write`'s temp file is a sibling with a different name, so one save emits once, for the rename, rather than twice.

## Scope

This was reachable before — a task checkbox toggled from the preview writes the file, and that is available in the one mode Live Mode used to be — but rare enough that nobody hit it. #692 offers Live Mode in edit mode, which makes it every save.

The cost of a directory watch is hearing about sibling files. That is a `file_name()` comparison per event, cheaper than the emit it replaces, and paid only while Live Mode is on. A vault-sized directory raises the event rate, not the work per event.

Not changed: the callback still drops watcher errors silently (`let Ok(event) = result else { return }`). Surfacing them is a real improvement and a separate one — it needs a user-facing string and a decision about what to say.

Not changed: nothing about *when* Markpad decides an event is external. That is #696's neighbour and is being handled separately.

## Tests

`watch_targeting`, two cases with no filesystem at all: `watch_root` resolves to the parent directory and falls back to the target where there is no usable parent (a bare relative name, a filesystem root); `event_concerns` passes an event naming the file, passes a rename that names it on either side, and rejects a sibling, the `atomic_write` temp file, and an event with no paths.

`watch_survives_rename`, one case against the real filesystem and the real `notify`, running the same two decisions `watch_file` makes. Four steps: an in-place write (so a dead watcher and a broken harness cannot look alike), a rename-over, another in-place write afterwards — the step that used to fail — and finally a sibling plus a temp-file write that must produce nothing, so a watch that simply reports everything cannot pass.

## Verification

```
cargo test            164 pass, 0 fail   (macOS, local)
```

Linux and Windows are what this PR is for; see the checks. The first commit's run is the failing baseline.

Frontend suites are untouched by this change and were not re-run.
