### PR TITLE
fix(save): ask the file who wrote it, and check before overwriting (#692)

### DIFF
--- a/scripts/checkedReadMigration.spec.ts
+++ b/scripts/checkedReadMigration.spec.ts
@@ -66,7 +66,7 @@ function makeSession() {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: (message) => errors.push(message),
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},

--- a/scripts/documentEncodingRoundTrip.spec.ts
+++ b/scripts/documentEncodingRoundTrip.spec.ts
@@ -75,7 +75,7 @@ function makeSession() {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: () => {},
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},

--- a/scripts/documentLoadFailure.spec.ts
+++ b/scripts/documentLoadFailure.spec.ts
@@ -47,7 +47,7 @@ function makeSession(overrides: Record<string, unknown> = {}) {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: (message: string, error: unknown) => void errors.push({ message, error }),
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},

--- a/scripts/explicitSaveCancelsAutoSave.spec.ts
+++ b/scripts/explicitSaveCancelsAutoSave.spec.ts
@@ -78,7 +78,7 @@ function makeSession() {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: () => {},
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: (tabId: string) => void events.push(`cancel:${tabId}`),
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},

--- a/scripts/externalChangeReload.spec.ts
+++ b/scripts/externalChangeReload.spec.ts
@@ -10,11 +10,37 @@ import { readSource, sliceBetween } from './sourceTree.js';
 // not just overwritten, it stops looking dirty afterwards: the user cannot
 // even tell what they lost. Turning Live Mode ON must likewise never pull
 // disk content over the buffer; it only installs the watcher.
+//
+// Whether an event is somebody else's write used to be guessed from the clock:
+// each of our own writes opened a 400ms window in which events for that path
+// were discarded. Both directions of that guess were wrong and both are tested
+// below — a foreign write inside the window was DROPPED and then overwritten by
+// the next auto-save, and a late event about our own write raised a conflict
+// bar about nothing. `originalContent` answers the question exactly, and the
+// same answer now also guards the write itself, which is the half that works
+// when the watcher does not.
 
 // The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
 // Svelte plugin, so the store and the session run under real reactivity, and jsdom
 // supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
-let handleInvoke: (cmd: string, args: any) => unknown = (cmd) => {
+
+/**
+ * The filesystem, as far as these tests are concerned. Real enough for the
+ * question every test here asks — "what does the file say right now?" — and the
+ * reason the suite no longer needs to fake a clock.
+ */
+const disk = new Map<string, string>();
+
+let handleInvoke: (cmd: string, args: any) => unknown = (cmd, args) => {
+	if (cmd === 'canonicalize_path') return args.path;
+	if (cmd === 'read_file_content_checked') {
+		if (!disk.has(args.path)) throw new Error(`no such file: ${args.path}`);
+		return [disk.get(args.path), false, 'UTF-8'];
+	}
+	if (cmd === 'save_file_content') {
+		disk.set(args.path, args.content);
+		return null;
+	}
 	throw new Error(`unexpected invoke: ${cmd}`);
 };
 (window as any).__TAURI_INTERNALS__ = {
@@ -26,6 +52,8 @@ const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
 
 const viewer = readSource('src/lib/MarkdownViewer.svelte');
+
+let refusedSaves: string[] = [];
 
 function makeSession(overrides: Record<string, unknown> = {}) {
 	return createDocumentSession({
@@ -41,7 +69,7 @@ function makeSession(overrides: Record<string, unknown> = {}) {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: () => {},
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: (tabId: string) => refusedSaves.push(tabId),
 		cancelPendingAutoSave: () => {},
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},
@@ -51,30 +79,42 @@ function makeSession(overrides: Record<string, unknown> = {}) {
 	});
 }
 
+/** A file on disk, open in a tab whose buffer matches it. */
 function open(path: string, content: string) {
+	disk.set(path, content);
 	tabManager.addTab(path, content);
-	return tabManager.activeTab!;
+	const tab = tabManager.activeTab!;
+	tab.originalContent = content;
+	return tab;
 }
 
-test('a clean tab that owns the changed file is reloaded', () => {
+function reset() {
 	tabManager.closeAll();
+	disk.clear();
+	refusedSaves = [];
+}
+
+test('a clean tab that owns the changed file is reloaded', async () => {
+	reset();
 	const session = makeSession();
 	const tab = open('/notes/a.md', 'on disk');
+	disk.set('/notes/a.md', 'somebody else wrote this');
 
-	assert.deepEqual(session.resolveExternalChange('/notes/a.md'), {
+	assert.deepEqual(await session.resolveExternalChange('/notes/a.md'), {
 		action: 'reload',
 		tabId: tab.id,
 		path: '/notes/a.md',
 	});
 });
 
-test('a tab with unsaved edits is never reloaded behind the user', () => {
-	tabManager.closeAll();
+test('a tab with unsaved edits is never reloaded behind the user', async () => {
+	reset();
 	const session = makeSession();
 	const tab = open('/notes/a.md', 'on disk');
 	tabManager.updateTabRawContent(tab.id, 'my unsaved paragraph');
+	disk.set('/notes/a.md', 'somebody else wrote this');
 
-	const outcome = session.resolveExternalChange('/notes/a.md');
+	const outcome = await session.resolveExternalChange('/notes/a.md');
 
 	assert.equal(outcome.action, 'conflict');
 	assert.equal((outcome as { tabId: string }).tabId, tab.id);
@@ -85,15 +125,16 @@ test('a tab with unsaved edits is never reloaded behind the user', () => {
 	assert.equal(tab.isDirty, true);
 });
 
-test('the changed path decides which tab is affected, not whichever tab is active', () => {
-	tabManager.closeAll();
+test('the changed path decides which tab is affected, not whichever tab is active', async () => {
+	reset();
 	const session = makeSession();
 	const a = open('/notes/a.md', 'a on disk');
 	const b = open('/notes/b.md', 'b on disk');
 	tabManager.setActive(b.id);
 	tabManager.updateTabRawContent(b.id, 'b unsaved');
+	disk.set('/notes/a.md', 'a changed');
 
-	const outcome = session.resolveExternalChange('/notes/a.md');
+	const outcome = await session.resolveExternalChange('/notes/a.md');
 
 	// Reloading here would pull b.md's disk content over b's unsaved buffer
 	// because a.md changed. Whatever the outcome, it must not name tab b.
@@ -102,53 +143,118 @@ test('the changed path decides which tab is affected, not whichever tab is activ
 	assert.notEqual(a.id, b.id);
 });
 
-test('a change to a file no tab holds is ignored', () => {
-	tabManager.closeAll();
+test('a change to a file no tab holds is ignored', async () => {
+	reset();
 	const session = makeSession();
 	open('/notes/a.md', 'a on disk');
 
-	assert.deepEqual(session.resolveExternalChange('/notes/elsewhere.md'), { action: 'ignore' });
-	assert.deepEqual(session.resolveExternalChange(''), { action: 'ignore' });
+	assert.deepEqual(await session.resolveExternalChange('/notes/elsewhere.md'), { action: 'ignore' });
+	assert.deepEqual(await session.resolveExternalChange(''), { action: 'ignore' });
 });
 
-test('our own writes still suppress the reload', async () => {
-	// Saving fires the watcher too. Reloading on that event would clobber any
-	// keystroke that landed between the write and the notification.
-	tabManager.closeAll();
+test('our own write is not an external change, however late the event arrives', async () => {
+	reset();
 	const session = makeSession();
 	const tab = open('/notes/a.md', 'on disk');
 	tabManager.updateTabRawContent(tab.id, 'my edit');
-	handleInvoke = (cmd) => {
-		if (cmd === 'save_file_content') return null;
-		throw new Error(`unexpected invoke: ${cmd}`);
-	};
-
 	assert.equal(await session.saveContent(tab.id), true);
 
-	assert.deepEqual(session.resolveExternalChange('/notes/a.md'), { action: 'ignore' });
+	// No clock is consulted, so there is no window to be outside of. The old
+	// guard answered this correctly for 400ms and then started answering it
+	// wrong; a slow watcher, a network share or a synced folder is all it took.
+	assert.deepEqual(await session.resolveExternalChange('/notes/a.md'), { action: 'ignore' });
+	assert.deepEqual(await session.resolveExternalChange('/notes/a.md'), { action: 'ignore' });
 });
 
-test('the suppression expires, and does not outlive its own grace period', async () => {
-	// The other half of the same guard, and the one with teeth: a suppression
-	// that never lifts turns Live Mode off for that file for the rest of the
-	// session, silently. Grace 0 makes the window already over by the time the
-	// event arrives, which is what a real event a second later looks like.
-	tabManager.closeAll();
-	const session = makeSession({ selfWriteGraceMs: 0 });
+test('a late event about our own save is not raised as a conflict', async () => {
+	// The second failure of the clock, and the one that costs trust rather than
+	// data: with the user typing again after a save, an event that arrived after
+	// the window found a dirty tab and asked "this file changed on disk" about
+	// their own keystrokes. Zed is disliked for exactly this
+	// (zed-industries/zed#42108) — a question that is sometimes false gets
+	// dismissed the times it is true.
+	reset();
+	const session = makeSession();
 	const tab = open('/notes/a.md', 'on disk');
 	tabManager.updateTabRawContent(tab.id, 'my edit');
-	handleInvoke = (cmd) => {
-		if (cmd === 'save_file_content') return null;
-		throw new Error(`unexpected invoke: ${cmd}`);
-	};
+	assert.equal(await session.saveContent(tab.id), true);
+	tabManager.updateTabRawContent(tab.id, 'my edit, and more');
+
+	assert.deepEqual(await session.resolveExternalChange('/notes/a.md'), { action: 'ignore' });
+	assert.equal(tab.isDirty, true, 'and the later typing is still unsaved');
+});
+
+test('a foreign write moments after our own is still reported', async () => {
+	// The direction that lost data. Inside the old 400ms window this event was
+	// DISCARDED with nothing re-queued: the buffer held our text, the disk held
+	// theirs, the tab looked clean, and the next keystroke's auto-save put ours
+	// back over theirs. Nothing anywhere said so.
+	reset();
+	const session = makeSession();
+	const tab = open('/notes/a.md', 'on disk');
+	tabManager.updateTabRawContent(tab.id, 'my edit');
 	assert.equal(await session.saveContent(tab.id), true);
 
-	assert.equal(session.shouldReloadExternalChange('/notes/a.md'), true, 'a later change is not suppressed');
-	assert.equal(
-		session.shouldReloadExternalChange('/notes/a.md'),
-		true,
-		'and the expired entry is dropped rather than re-consulted',
-	);
+	disk.set('/notes/a.md', 'their edit, one moment later');
+
+	assert.deepEqual(await session.resolveExternalChange('/notes/a.md'), {
+		action: 'reload',
+		tabId: tab.id,
+		path: '/notes/a.md',
+	});
+});
+
+// --- the guard that does not depend on the watcher ---
+
+test('a save is refused when the disk moved under it', async () => {
+	// Live Mode is off by default and its events can be missed, so this is the
+	// check every editor that does not lose work has: VS Code refuses the save
+	// ("The content of the file is newer"), Vim re-stats before each write, and
+	// Vim has no watcher at all.
+	reset();
+	const session = makeSession();
+	const tab = open('/notes/a.md', 'on disk');
+	tabManager.updateTabRawContent(tab.id, 'my edit');
+	disk.set('/notes/a.md', 'their edit');
+
+	assert.equal(await session.saveContent(tab.id), false);
+	assert.equal(disk.get('/notes/a.md'), 'their edit', 'their work was overwritten anyway');
+	assert.deepEqual(refusedSaves, [tab.id], 'the refusal was not reported, so nothing asked the user');
+	assert.equal(tab.rawContent, 'my edit', 'and the refusal must not cost the user their buffer');
+	assert.equal(tab.isDirty, true);
+});
+
+test('answering "keep mine" authorises the next save, and only the next one', async () => {
+	reset();
+	const session = makeSession();
+	const tab = open('/notes/a.md', 'on disk');
+	tabManager.updateTabRawContent(tab.id, 'my edit');
+	disk.set('/notes/a.md', 'their edit');
+	assert.equal(await session.saveContent(tab.id), false);
+
+	session.allowOverwriteOnce(tab.id);
+	assert.equal(await session.saveContent(tab.id), true);
+	assert.equal(disk.get('/notes/a.md'), 'my edit');
+
+	// A third program writing a minute later is a new question the user has not
+	// answered, so the authorisation must not still be lying around.
+	tabManager.updateTabRawContent(tab.id, 'my later edit');
+	disk.set('/notes/a.md', 'somebody else again');
+	assert.equal(await session.saveContent(tab.id), false);
+	assert.equal(disk.get('/notes/a.md'), 'somebody else again');
+});
+
+test('an ordinary save of an untouched file still just saves', async () => {
+	// The guard has to be invisible in the common case, which is every save.
+	reset();
+	const session = makeSession();
+	const tab = open('/notes/a.md', 'on disk');
+	tabManager.updateTabRawContent(tab.id, 'my edit');
+
+	assert.equal(await session.saveContent(tab.id), true);
+	assert.equal(disk.get('/notes/a.md'), 'my edit');
+	assert.deepEqual(refusedSaves, []);
+	assert.equal(tab.isDirty, false);
 });
 
 // --- wiring that cannot be executed outside a Svelte runtime ---

--- a/scripts/largeFileLoadRevision.spec.ts
+++ b/scripts/largeFileLoadRevision.spec.ts
@@ -77,7 +77,7 @@ function makeSession() {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: (message) => errors.push(message),
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},

--- a/scripts/liveModeWatchedPath.test.ts
+++ b/scripts/liveModeWatchedPath.test.ts
@@ -8,14 +8,16 @@ const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 test('Live Mode routes a watcher notification to its watched path', () => {
 	assert.match(runtime, /emit_to\(event_label\.as_str\(\), "file-changed", watched_path\.clone\(\)\)/);
-	assert.match(viewer, /await appWindow\.listen\('file-changed', \(event\) => \{/);
+	// `async` because deciding what an event means now reads the file: the
+	// answer to "did somebody else write this" is the file itself, not a clock.
+	assert.match(viewer, /await appWindow\.listen\('file-changed', async \(event\) => \{/);
 	assert.match(viewer, /const changedPath = event\.payload as string;/);
 	// The listener no longer compares the payload with the active file itself:
 	// resolveExternalChange looks up the tab that OWNS the changed path (and
 	// refuses to reload it when it has unsaved edits). See
 	// externalChangeReload.test.ts for the routing behaviour.
 	assert.match(viewer, /if \(!liveMode\) return;/);
-	assert.match(viewer, /documentSession\.resolveExternalChange\(changedPath\)/);
+	assert.match(viewer, /await documentSession\.resolveExternalChange\(changedPath\)/);
 	const session = readSource('src/lib/sessions/documentSession.svelte.ts');
 	assert.match(session, /tabManager\.tabs\.find\(\(tab\) => tab\.path === changedPath\)/);
 });

--- a/scripts/lossySaveRefusalScope.spec.ts
+++ b/scripts/lossySaveRefusalScope.spec.ts
@@ -71,7 +71,7 @@ function makeSession() {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: (message) => void toasts.push(message),
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},

--- a/scripts/oneWritePerTabInFlight.spec.ts
+++ b/scripts/oneWritePerTabInFlight.spec.ts
@@ -95,7 +95,7 @@ function makeSession() {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: () => {},
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},

--- a/scripts/pathIdentityCaseFolding.spec.ts
+++ b/scripts/pathIdentityCaseFolding.spec.ts
@@ -100,7 +100,7 @@ function makeSession() {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: (message: string) => void errors.push(message),
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},

--- a/scripts/reopenDirtyDocument.spec.ts
+++ b/scripts/reopenDirtyDocument.spec.ts
@@ -59,7 +59,7 @@ function makeSession() {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: () => {},
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},
@@ -227,8 +227,12 @@ test('a Reload of a file changed under unsaved edits replaces the buffer', async
 	const edited = openEdited('/notes/a.md', 'on disk', 'my unsaved paragraph');
 
 	disk.set('/notes/a.md', 'someone else wrote this');
-	const outcome = session.resolveExternalChange('/notes/a.md');
+	const outcome = await session.resolveExternalChange('/notes/a.md');
 	assert.equal(outcome.action, 'conflict', 'the watcher never reloads it on its own');
+	// Deciding that took a read of its own — comparing the file against the
+	// tab's baseline is how "who wrote this" is answered now. `reads` is here
+	// to measure what the OPEN does, so the resolution's read is cleared first.
+	reads.length = 0;
 
 	// The options resolveExternalChangeByReloading passes, verbatim.
 	await session.loadMarkdown('/notes/a.md', {
@@ -249,7 +253,8 @@ test('a conflict alone does not authorize the next open to discard the buffer', 
 	const edited = openEdited('/notes/a.md', 'on disk', 'my unsaved paragraph');
 
 	disk.set('/notes/a.md', 'someone else wrote this');
-	session.resolveExternalChange('/notes/a.md');
+	await session.resolveExternalChange('/notes/a.md');
+	reads.length = 0;
 
 	// Same tab, same path, conflict outstanding — but this is an open, and it
 	// did not ask to discard anything.

--- a/scripts/taskToggleLineEndings.spec.ts
+++ b/scripts/taskToggleLineEndings.spec.ts
@@ -60,7 +60,7 @@ function makeSession() {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: () => {},
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose: async () => 'discard' as const,
 		onCloseSaveNewerEdits: () => {},

--- a/scripts/truncatedBufferGuard.spec.ts
+++ b/scripts/truncatedBufferGuard.spec.ts
@@ -61,7 +61,7 @@ function makeSession() {
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: (message) => errors.push(message),
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose: async () => closeAnswer,
 		onCloseSaveNewerEdits: () => {},
@@ -287,10 +287,24 @@ async function openPartialTasks() {
  * through so that a guard which stops refusing is caught by the write it lets
  * happen, not by an "unexpected invoke" from the stub.
  */
+/**
+ * The original file's tail cannot be read any more — the case Save As exists to
+ * rescue. `/docs/copy.md`, the file the rescue writes, is readable: it is a new
+ * file the process just created, and every save checks the disk against its own
+ * baseline before overwriting.
+ */
 function makeTailUnreadable() {
-	handleInvoke = (cmd) => {
-		if (cmd === 'read_file_content_checked') return Promise.reject(new Error('Os { code: 5, kind: Uncategorized }'));
-		if (cmd === 'save_file_content') return null;
+	const written = new Map<string, string>();
+	handleInvoke = (cmd, args) => {
+		if (cmd === 'read_file_content_checked') {
+			const saved = written.get(args.path);
+			if (saved !== undefined) return [saved, false, 'UTF-8'];
+			return Promise.reject(new Error('Os { code: 5, kind: Uncategorized }'));
+		}
+		if (cmd === 'save_file_content') {
+			written.set(args.path, args.content);
+			return null;
+		}
 		if (cmd === 'canonicalize_path') return '/docs/copy.md';
 		if (cmd === 'plugin:dialog|save') return '/docs/copy.md';
 		throw new Error(`unexpected invoke: ${cmd}`);

--- a/scripts/viewModeWithoutSaving.spec.ts
+++ b/scripts/viewModeWithoutSaving.spec.ts
@@ -377,7 +377,7 @@ function makeSession(askClose: (title: string) => Promise<'save' | 'discard' | '
 		isScrolling: () => false,
 		renderRichContent: () => {},
 		onError: () => {},
-		selfWriteGraceMs: 400,
+		onDiskChangedUnderSave: () => {},
 		cancelPendingAutoSave: () => {},
 		askClose,
 		onCloseSaveNewerEdits: () => {},

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -266,9 +266,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	// same-length ones (overwriting characters, formatting toggles) that
 	// a length-based tick would miss.
 	const lastContentRefByTab = new Map<string, string>();
-	// Suppress the file-watcher reload that fires when we ourselves write the file.
-	// Maps absolute path -> wall-clock ms after which an event for that path is real again.
-	const SELF_WRITE_GRACE_MS = 400;
 	const AUTO_SAVE_DEBOUNCE_MS = 1500;
 
 	// Cancel a pending auto-save for a tab. Call this only on paths that
@@ -784,7 +781,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			console.error(message, error);
 			addToast(`${message}: ${String(error)}`, 'error');
 		},
-		selfWriteGraceMs: SELF_WRITE_GRACE_MS,
+		onDiskChangedUnderSave: noteExternalChangeConflict,
 		cancelPendingAutoSave,
 		askClose: (title) =>
 			askCustom(t('modal.youHaveUnsavedChanges', settings.language).replace('{title}', title), {
@@ -1976,13 +1973,20 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let lineCoords = $derived(lineCoordinates(rawContent));
 
 	async function saveContent(tabId?: string): Promise<boolean> {
-		const saved = await documentSession.saveContent(tabId);
+		const id = tabId ?? tabManager.activeTabId ?? '';
 		// Every route into here is an explicit decision — Cmd+S, the close
 		// dialog, a mode-toggle dialog — and the background debounce is held
 		// back entirely while a conflict is open (see the auto-save effect).
-		// So a save that lands here IS the answer "keep my version": our text
-		// is now the newest on disk and the bar has nothing left to ask.
-		if (saved) clearExternalChangeConflict(tabId ?? tabManager.activeTabId ?? '');
+		// So a save that lands here IS the answer "keep my version": it both
+		// authorises the write the session would otherwise refuse, and leaves
+		// the bar with nothing to ask.
+		//
+		// Without the first half the bar became a trap: the disk really has
+		// changed, so the guard in `saveContent` refuses, so the bar goes back
+		// up, and Cmd+S can never get the user out of it.
+		if (externalChangeConflicts[id]) documentSession.allowOverwriteOnce(id);
+		const saved = await documentSession.saveContent(tabId);
+		if (saved) clearExternalChangeConflict(id);
 		return saved;
 	}
 
@@ -2031,7 +2035,14 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	/** "Keep my version": dismiss. The buffer stays dirty and saveable. */
 	function resolveExternalChangeByKeepingBuffer() {
-		if (tabManager.activeTabId) clearExternalChangeConflict(tabManager.activeTabId);
+		const id = tabManager.activeTabId;
+		if (!id) return;
+		// The answer is about a write, not about a bar: the next save has to be
+		// allowed past the guard that would otherwise refuse to overwrite the
+		// changed file. One save only — a third program writing a minute later
+		// is a new question, and the user has not answered that one.
+		documentSession.allowOverwriteOnce(id);
+		clearExternalChangeConflict(id);
 	}
 
 	/**
@@ -2142,6 +2153,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 								// file and the way out. "Auto-save failed" on top
 								// of that says nothing new.
 								if (documentSession.isLossySaveRefused(s.id)) return;
+								// Same reasoning for the other refusal: the disk
+								// moved under the write, and the conflict bar is
+								// already on screen saying so and offering both
+								// ways out.
+								if (externalChangeConflicts[s.id]) return;
 								addToast(
 									t('toast.autoSaveFailed', settings.language),
 									'error',
@@ -3203,7 +3219,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				}),
 			);
 			unlisteners.push(
-				await appWindow.listen('file-changed', (event) => {
+				await appWindow.listen('file-changed', async (event) => {
 					const changedPath = event.payload as string;
 					if (!liveMode) return;
 					// The event names the changed file. Which tab that touches —
@@ -3211,7 +3227,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 					// session: it owns the self-write grace window (so our own
 					// auto-save does not bounce back) and it refuses to reload a
 					// tab with unsaved edits.
-					const outcome = documentSession.resolveExternalChange(changedPath);
+					const outcome = await documentSession.resolveExternalChange(changedPath);
 					if (outcome.action === 'ignore') return;
 					if (outcome.action === 'conflict') {
 						noteExternalChangeConflict(outcome.tabId);

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -51,7 +51,8 @@ type DocumentSessionOptions = {
 	isScrolling: () => boolean;
 	renderRichContent: () => void;
 	onError: (message: string, error: unknown) => void;
-	selfWriteGraceMs: number;
+	/** The disk moved under a save, which was refused. Raise the conflict bar. */
+	onDiskChangedUnderSave: (tabId: string) => void;
 	cancelPendingAutoSave: (tabId: string) => void;
 	askClose: (title: string) => Promise<'save' | 'discard' | 'cancel'>;
 	onCloseSaveNewerEdits: () => void;
@@ -79,15 +80,9 @@ function foldsForTab(tabId: string): Set<string> {
 export function createDocumentSession(options: DocumentSessionOptions) {
 	const loadRevisionByTab = new Map<string, number>();
 	const loadingTabs = new Set<string>();
-	const selfWriteUntilByPath = new Map<string, number>();
-
-	function markSelfWrite(path: string) {
-		selfWriteUntilByPath.set(path, Date.now() + options.selfWriteGraceMs);
-	}
-
-	function clearSelfWrite(path: string) {
-		selfWriteUntilByPath.delete(path);
-	}
+	// Tabs whose next save is authorised to overwrite a changed file, set by
+	// answering the conflict bar with "keep mine". One save each.
+	const overwriteAllowed = new Set<string>();
 
 	/**
 	 * Per tab: a promise that settles once every save queued for it so far has
@@ -141,12 +136,59 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		return result;
 	}
 
-	function shouldReloadExternalChange(path: string) {
-		const until = selfWriteUntilByPath.get(path);
-		if (until === undefined) return true;
-		if (Date.now() < until) return false;
-		selfWriteUntilByPath.delete(path);
-		return true;
+	/**
+	 * Has this file changed from the version the tab believes is on disk?
+	 *
+	 * The one question both halves of the external-change guard are asking,
+	 * which is why they are one function. `originalContent` IS the text last
+	 * known to be in the file — every load sets it, every successful save sets
+	 * it — so "different" means somebody has written since, and "equal" means
+	 * nobody has, whoever ran the write.
+	 *
+	 * It replaces a 400ms window opened at each of our own writes, inside which
+	 * every event for that path was discarded as ours. A clock cannot answer a
+	 * question about identity, and it was wrong in both directions:
+	 *
+	 * - too early — another program writing inside the window had its event
+	 *   DROPPED, with nothing re-queued. The buffer then held our text and the
+	 *   disk held theirs, with the tab looking clean, so the next keystroke's
+	 *   auto-save put ours back over theirs. Silent loss of someone else's
+	 *   edit, which is the exact thing this guard exists to prevent.
+	 * - too late — an event arriving after the window (a network share, a
+	 *   synced folder, any watcher latency over 400ms) read as external, and if
+	 *   the user had typed since, the conflict bar asked about their own save.
+	 *   Zed is disliked for precisely this (zed-industries/zed#42108): a
+	 *   question that is sometimes false teaches people to dismiss it,
+	 *   including the times it is true.
+	 *
+	 * A truncated tab (the >5MB preview slice) always answers "changed" and
+	 * needs no better answer: `ensureFullContent` gates every path that can
+	 * write, so a tab we have never written has no write of ours to recognise.
+	 */
+	async function fileDiffersFromBaseline(tab: Tab, path: string): Promise<boolean> {
+		if (!path || tab.isTruncated) return true;
+		try {
+			// The same read the reload does, so the two strings are comparable:
+			// decoded with the file's own encoding rather than assumed UTF-8.
+			const [content] = (await invoke('read_file_content_checked', { path })) as [string, boolean, string];
+			return content !== tab.originalContent;
+		} catch {
+			// Unreadable right now — mid-write, or gone. "Changed" is the safe
+			// answer: it stops a save and asks, instead of quietly deciding that
+			// nothing happened.
+			return true;
+		}
+	}
+
+	/**
+	 * "Keep my version" — the next save of this tab may overwrite a file that
+	 * has changed underneath it.
+	 *
+	 * One save, not a mode: the answer was given about the change the user was
+	 * shown, and a third program writing a minute later is a new question.
+	 */
+	function allowOverwriteOnce(tabId: string) {
+		overwriteAllowed.add(tabId);
 	}
 
 	/**
@@ -159,16 +201,18 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 	 * `originalContent` too, so the overwrite would also erase the evidence
 	 * that anything was lost. The caller offers the user the choice instead.
 	 */
-	function resolveExternalChange(changedPath: string): ExternalChangeOutcome {
+	async function resolveExternalChange(changedPath: string): Promise<ExternalChangeOutcome> {
 		if (!changedPath) return { action: 'ignore' };
-		if (!shouldReloadExternalChange(changedPath)) return { action: 'ignore' };
 
 		const active = tabManager.activeTab;
 		const owner =
 			active && active.path === changedPath
 				? active
 				: tabManager.tabs.find((tab) => tab.path === changedPath);
+		// Ahead of the read, so an event for a file no tab holds costs no I/O.
 		if (!owner) return { action: 'ignore' };
+
+		if (!(await fileDiffersFromBaseline(owner, changedPath))) return { action: 'ignore' };
 
 		if (owner.isDirty) return { action: 'conflict', tabId: owner.id, path: changedPath };
 
@@ -608,7 +652,32 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			// Snapshot taken on the far side of the wait. Anything typed while
 			// the previous write drained is part of what this save is for.
 			const snapshot = tab.rawContent;
-			markSelfWrite(targetPath);
+			// The second line of defence, and the only one that does not rest on
+			// the watcher. Live Mode is off by default, its events can be
+			// dropped, and until recently a watch armed on a file did not
+			// survive that file being renamed over — which is how `atomic_write`
+			// and most other editors save. None of that reaches this check,
+			// because it asks the file itself at the moment of writing.
+			//
+			// Every editor with a claim to not losing work has one. VS Code
+			// refuses the save ("The content of the file is newer"), Vim
+			// re-stats before each write ("WARNING: The file has been changed
+			// since reading it!!!"), Emacs raises `file-supersession` as soon as
+			// you type into a superseded buffer. Vim has no watcher at all and
+			// is still safe, which is the argument for the check living here and
+			// not only on the event.
+			//
+			// A refusal, not a merge and not a retry: the user is shown the bar
+			// and answers it. "Keep mine" authorises exactly the next save,
+			// which is what `overwriteAllowed` carries.
+			//
+			// The gap between this read and the rename is real, and is the same
+			// gap Vim and VS Code have. It narrows the exposure from "the whole
+			// time the document is open" to "the length of one write".
+			if (!overwriteAllowed.delete(tab.id) && (await fileDiffersFromBaseline(tab, targetPath))) {
+				options.onDiskChangedUnderSave(tab.id);
+				return false;
+			}
 			try {
 				// The tab's own encoding, so a GBK or Shift-JIS document is
 				// written back as the file it was opened from rather than
@@ -616,7 +685,6 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				// buffer saved through the dialog above still carries the
 				// `UTF-8` it was created with, which is what it should be.
 				await invoke('save_file_content', { path: targetPath, content: snapshot, encoding: tab.encoding });
-				markSelfWrite(targetPath);
 				if (tab.path === '') {
 					tabManager.updateTabPath(tab.id, targetPath, targetKey);
 					options.saveRecentFile(targetPath);
@@ -627,7 +695,6 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				tab.originalContent = snapshot;
 				return true;
 			} catch (error) {
-				clearSelfWrite(targetPath);
 				const { message, detail } = describeSaveFailure(error, tab);
 				options.onError(message, detail);
 				return false;
@@ -674,7 +741,6 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		// overwrite that collides outright.
 		return writeExclusively(tab.id, async () => {
 			const snapshot = tab.rawContent;
-			markSelfWrite(selected);
 			try {
 				// Deliberately UTF-8, not `tab.encoding`. Save As is the way out
 				// of both failure modes this file guards: a buffer nothing could
@@ -682,7 +748,6 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				// represent. Writing the copy in the encoding that caused the
 				// problem would take the exit away.
 				await invoke('save_file_content', { path: selected, content: snapshot, encoding: 'UTF-8' });
-				markSelfWrite(selected);
 				tabManager.updateTabPath(tab.id, selected, selectedKey);
 				// The buffer now has a UTF-8 file of its own that it matches
 				// exactly, so it is safe to save from here on — and every save
@@ -709,7 +774,6 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				if (copyIsPartial) options.onPartialCopySaved();
 				return true;
 			} catch (error) {
-				clearSelfWrite(selected);
 				const { message, detail } = describeSaveFailure(error, tab);
 				options.onError(message === 'Failed to save file' ? 'Failed to save file as' : message, detail);
 				return false;
@@ -797,5 +861,5 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		return true;
 	}
 
-	return { loadMarkdown, saveContent, saveContentAs, toggleTaskCheckbox, shouldReloadExternalChange, resolveExternalChange, ensureFullContent, canCloseTab, isLossySaveRefused };
+	return { loadMarkdown, saveContent, saveContentAs, toggleTaskCheckbox, allowOverwriteOnce, resolveExternalChange, ensureFullContent, canCloseTab, isLossySaveRefused };
 }


### PR DESCRIPTION
> Depends on nothing — #696 is merged. Reads best after #697. Merge order: #697, then this, then #699.

## What this is

Two failures of one mechanism, and one replacement for both.

Whether a `file-changed` event was somebody else's write was guessed from the clock: each of our own writes opened a 400ms window in which every event for that path was discarded as ours.

**Too early.** A program writing inside that window had its event dropped, with nothing re-queued:

```
T+0     our auto-save writes          window open until T+400
T+150   VS Code writes
T+160   event arrives, inside window  → DISCARDED
                                      → buffer holds ours, disk holds theirs,
                                        tab reads clean, nothing is pending
T+1500  one more keystroke, auto-save → their edit is gone, silently
```

That is loss of somebody else's work, produced by the guard that exists to prevent it.

**Too late.** An event arriving after the window — a network share, a synced folder, any watcher latency over 400ms — read as external:

```
T+0     our auto-save writes          window open until T+400
T+200   the user types again          tab is dirty
T+600   the event finally arrives     → "This file changed on disk while you
                                         had unsaved changes."  (it did not)
```

Nothing is lost, but the bar is now sometimes lying, and [Zed is disliked for exactly this](https://github.com/zed-industries/zed/issues/42108). What people learn from a question that is sometimes false is to dismiss it, including the times it is true.

## Mechanism

`originalContent` is already the text last known to be in the file — every load sets it, every successful save sets it. So "the file differs from `originalContent`" *is* the question, exactly, with no window and no clock:

```ts
async function fileDiffersFromBaseline(tab, path) {
	if (!path || tab.isTruncated) return true;
	const [content] = await invoke('read_file_content_checked', { path });
	return content !== tab.originalContent;
}
```

Equal means nobody has written since, whoever ran the last write. Different means somebody has, however long ago. Both directions above collapse. `selfWriteUntilByPath`, `markSelfWrite`, `clearSelfWrite`, `shouldReloadExternalChange` and `SELF_WRITE_GRACE_MS` are all deleted; nothing replaces them but the function above.

An external write of *identical bytes* now resolves to `ignore`, which is right — nothing changed.

A truncated tab (the >5MB preview slice) always answers "changed" and needs no better answer: `ensureFullContent` gates every path that can write, so a tab we have never written has no write of ours to recognise.

## The same question, asked before the write

The second half, and the reason this is one PR. That check now also runs immediately before `save_file_content`, and refuses the save if the disk has moved.

This is the guard that does not depend on the watcher, which matters because the watcher is not dependable: Live Mode is off by default, its events can be dropped, and a watch armed on a file does not always survive that file being renamed over (#697). None of that reaches a check made at the moment of writing.

Every editor with a claim to not losing work has one, and this is the shape they agree on:

| | on the event | before the write |
|---|---|---|
| VS Code | reload / ignore / compare | **refuses**: "The content of the file is newer" → Compare / Overwrite |
| Vim | `autoread`, opt-in | **re-stats**: "WARNING: The file has been changed since reading it!!!" |
| Emacs | — | `file-supersession`, raised as soon as you type |
| Sublime | reload / ignore all / cancel | — |
| Markpad, before | reload / keep mine | **nothing** |
| Markpad, after | reload / keep mine | refuses, and raises the same bar |

Vim has no file watcher at all and is still safe, which is the argument for this check existing independently of the event path rather than instead of it.

A refusal, not a merge and not a retry. "Keep my version" authorises exactly the next save — one save, because a third program writing a minute later is a question the user has not answered. Cmd+S while the bar is up carries the same authorisation: without that the bar was a trap, since the disk really has changed, so the guard refuses, so the bar goes back up, and nothing the user presses gets them out.

The gap between the read and the rename is real and is the same gap Vim and VS Code have. It narrows exposure from "the whole time the document is open" to "the length of one write".

## Scope

One read per watcher event and one per save. Every event that is not ignored already led to a read, so the new cost is a read per *own* save — while typing with auto-save on, one per 1.5s, of a file being written at the same rate. Files over 5MB take the `isTruncated` branch and skip it.

Not changed: the auto-save toast. A refused save returns `false` like a failed one, and the generic "auto-save failed" is suppressed exactly as it already is for the lossy-decode refusal — the conflict bar is on screen saying what happened and offering both ways out.

Not changed, and next: `canCloseTab` saves a dirty tab without consulting the bar, so closing a tab with an unanswered conflict still silently answers "keep mine". And the bar still offers an irreversible Reload with no way to see what would be lost.

## Tests

`scripts/externalChangeReload.spec.ts` is rebuilt on a fake disk — a `Map` the stubbed `read_file_content_checked` and `save_file_content` share — because every question in it is now "what does the file say?". That is also what let the fake clock go: no test here manipulates time any more.

Seventeen cases. The four that name this change:

- our own write is not an external change, **however late** the event arrives (asked twice, to show there is no window to fall out of)
- a late event about our own save is not raised as a conflict, with the user's later typing still unsaved
- a foreign write moments after our own is still reported — the case that used to lose data
- a save is refused when the disk moved under it: returns false, their bytes still on disk, the refusal reported, and the user's buffer intact
- answering "keep mine" authorises the next save **and only** the next one
- an ordinary save of an untouched file still just saves

Checked by breaking what they guard: stubbing `fileDiffersFromBaseline` to always answer "changed" turns four red; removing the guard from the write path turns two red.

`scripts/reopenDirtyDocument.spec.ts` and `scripts/truncatedBufferGuard.spec.ts` are updated for the new call shape — the resolution is `async` now, and it does a read of its own, which the read counters had to stop attributing to the open.

## Verification

```
npm audit             0 vulnerabilities
npm run check         814 files, 0 errors, 0 warnings
npm test              963 pass, 0 fail
npm run test:vitest   44 files, 377 pass
```

`npm run test:vitest` also reports 14 failures in this environment (session-restore and window-tag snapshots, `assert.deepEqual` reference-identity under node 26 + jsdom). Byte-identical on a clean checkout of the base branch in the same environment, verified by stashing and re-running.

`cargo test` not re-run: no Rust changed here. #697 covers that side.

Not verified by hand: the end-to-end gesture with a real second editor. The behaviours above are pinned against a fake disk, which is where the decisions are made; what is not pinned is watcher latency in the wild, and the point of this change is that no decision depends on it any more.