### PR TITLE
fix(conflict): closing cannot answer the question, and Compare shows the answer (#692)

### DIFF
--- a/scripts/externalChangeReload.spec.ts
+++ b/scripts/externalChangeReload.spec.ts
@@ -54,6 +54,8 @@ const { createDocumentSession } = await import('../src/lib/sessions/documentSess
 const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 let refusedSaves: string[] = [];
+let closeQuestions: boolean[] = [];
+let closeAnswer: 'save' | 'discard' | 'cancel' = 'discard';
 
 function makeSession(overrides: Record<string, unknown> = {}) {
 	return createDocumentSession({
@@ -71,7 +73,10 @@ function makeSession(overrides: Record<string, unknown> = {}) {
 		onError: () => {},
 		onDiskChangedUnderSave: (tabId: string) => refusedSaves.push(tabId),
 		cancelPendingAutoSave: () => {},
-		askClose: async () => 'discard' as const,
+		askClose: async (_title: string, diskMoved: boolean) => {
+			closeQuestions.push(diskMoved);
+			return closeAnswer;
+		},
 		onCloseSaveNewerEdits: () => {},
 		onCloseAutoSaveFailed: () => {},
 		onPartialCopySaved: () => {},
@@ -92,6 +97,8 @@ function reset() {
 	tabManager.closeAll();
 	disk.clear();
 	refusedSaves = [];
+	closeQuestions = [];
+	closeAnswer = 'discard';
 }
 
 test('a clean tab that owns the changed file is reloaded', async () => {
@@ -257,6 +264,53 @@ test('an ordinary save of an untouched file still just saves', async () => {
 	assert.equal(tab.isDirty, false);
 });
 
+// --- closing must not answer the question for the user ---
+
+test('closing a tab whose file changed asks, instead of auto-saving over it', async () => {
+	// Auto-save is on by default, and `canCloseTab` used to hand a dirty tab
+	// straight to it — which is the same answer as "keep mine", to a question
+	// the user was shown and did not answer, in the direction that destroys the
+	// other program's work. VS Code prompts here.
+	reset();
+	const session = makeSession();
+	const tab = open('/notes/a.md', 'on disk');
+	tabManager.updateTabRawContent(tab.id, 'my edit');
+	disk.set('/notes/a.md', 'their edit');
+
+	closeAnswer = 'cancel';
+	assert.equal(await session.canCloseTab(tab.id), false);
+	assert.deepEqual(closeQuestions, [true], 'the dialog was not told the disk had moved');
+	assert.equal(disk.get('/notes/a.md'), 'their edit', 'and nothing was written behind the question');
+});
+
+test('answering Save to that dialog does overwrite, rather than failing silently', async () => {
+	// The write guard refuses a changed file, so without the authorisation this
+	// answer carries, Save would return false and the tab would refuse to close
+	// — a dialog whose Save button does nothing.
+	reset();
+	const session = makeSession();
+	const tab = open('/notes/a.md', 'on disk');
+	tabManager.updateTabRawContent(tab.id, 'my edit');
+	disk.set('/notes/a.md', 'their edit');
+
+	closeAnswer = 'save';
+	assert.equal(await session.canCloseTab(tab.id), true);
+	assert.equal(disk.get('/notes/a.md'), 'my edit');
+});
+
+test('closing an untouched file still just saves and closes', async () => {
+	// The question is for the case that earned it. Every other close keeps the
+	// behaviour it had.
+	reset();
+	const session = makeSession();
+	const tab = open('/notes/a.md', 'on disk');
+	tabManager.updateTabRawContent(tab.id, 'my edit');
+
+	assert.equal(await session.canCloseTab(tab.id), true);
+	assert.equal(disk.get('/notes/a.md'), 'my edit');
+	assert.deepEqual(closeQuestions, [], 'nothing was asked');
+});
+
 // --- wiring that cannot be executed outside a Svelte runtime ---
 
 test('the watcher listener routes every event through the guarded resolution', () => {
@@ -338,4 +392,46 @@ test('entering split view no longer turns Live Mode off behind the user', () => 
 	// matched as source text — the same reason as the four assertions above.
 	const body = sliceBetween(viewer, 'async function toggleSplitView', '\n\t}');
 	assert.doesNotMatch(body, /toggleLiveMode|liveMode\s*=/);
+});
+
+// --- #4: the irreversible answer is now visible before it is given ---
+
+test('the conflict bar offers Compare beside the two answers', () => {
+	// Reload replaces the buffer and `setValue` clears the undo stack with it,
+	// so the bar asks for an irreversible decision. VS Code and Sublime both
+	// put a Compare next to the same two choices.
+	const bar = sliceBetween(viewer, 'external-change-bar', '{/if}');
+	assert.match(bar, /t\('externalChange\.compare'/);
+	assert.match(bar, /t\('externalChange\.reload'/);
+	assert.match(bar, /t\('externalChange\.keepMine'/);
+});
+
+test('Compare reads the file at the moment it is asked, not when the bar went up', () => {
+	// The bar can stand for a while. What the user needs to see is the file as
+	// it is when they are actually answering.
+	const fn = sliceBetween(viewer, 'async function compareExternalChange', '\n\t}');
+	assert.match(fn, /read_file_content_checked/);
+	assert.match(fn, /tab\.rawContent/);
+});
+
+test('answering the bar closes the comparison with it', () => {
+	// Otherwise the overlay outlives the question and shows a diff against a
+	// version that is no longer either side of anything.
+	for (const name of ['resolveExternalChangeByReloading', 'resolveExternalChangeByKeepingBuffer']) {
+		const fn = sliceBetween(viewer, `function ${name}`, '\n\t}');
+		assert.match(fn, /comparison = null/, `${name} left the comparison open`);
+	}
+});
+
+test('the diff view owns its models and never edits the document', () => {
+	// Handing it the tab's live model would put a second editor on a buffer
+	// Editor.svelte owns, and a read-only view of a document is not a place to
+	// change it from.
+	const overlay = readSource('src/lib/components/DiffOverlay.svelte');
+	assert.match(overlay, /createModel\(/);
+	assert.match(overlay, /readOnly: true/);
+	assert.match(overlay, /originalEditable: false/);
+	// Every model it creates is disposed, or opening the view repeatedly leaks
+	// one document's worth of text each time.
+	assert.match(overlay, /for \(const model of models\) model\.dispose\(\)/);
 });

--- a/scripts/settingsSemantics.test.ts
+++ b/scripts/settingsSemantics.test.ts
@@ -85,7 +85,11 @@ test('nothing evaluates the pair any more', () => {
 	assert.match(viewerSource, /if \(!settings\.autoSave\) return;/); // leaving an editable pane
 	assert.match(viewerSource, /if \(!settings\.autoSave\) \{/); // the debounce
 	assert.match(viewerSource, /if \(settings\.autoSave\) \{/); // the close-window walk
-	assert.match(sessionSource, /if \(settings\.autoSave && tab\.path !== ''\)/); // closing a tab
+	// Closing a tab. The condition grew a third term — a file that changed
+	// under the buffer is a question for the user, not something auto-save may
+	// answer by writing — but it is still this one switch that decides whether
+	// the silent save happens at all.
+	assert.match(sessionSource, /if \(settings\.autoSave && tab\.path !== '' && !diskMoved\)/);
 });
 
 /* ---------------------------------------------- B & C: visible dependency */

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -9,6 +9,7 @@
 	import { open, save, ask } from '@tauri-apps/plugin-dialog';
 	import Settings from './components/Settings.svelte';
 	import TitleBar from './components/TitleBar.svelte';
+	import DiffOverlay from './components/DiffOverlay.svelte';
 	import Editor from './components/Editor.svelte';
 	import EditorToolbar from './components/EditorToolbar.svelte';
 	import Modal from './components/Modal.svelte';
@@ -783,12 +784,23 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		},
 		onDiskChangedUnderSave: noteExternalChangeConflict,
 		cancelPendingAutoSave,
-		askClose: (title) =>
-			askCustom(t('modal.youHaveUnsavedChanges', settings.language).replace('{title}', title), {
-				title: t('modal.unsavedChanges', settings.language),
-				kind: 'warning',
-				showSave: true,
-			}),
+		// Two questions, one dialog. With the file untouched, Save means "write
+		// what I typed" and the ordinary wording is right. With the disk moved
+		// under the buffer, Save means "overwrite what somebody else wrote", and
+		// saying "you have unsaved changes" would hide the half that matters.
+		// The changed-on-disk sentence is the same one the conflict bar uses,
+		// because it is the same news.
+		askClose: (title, diskMoved) =>
+			askCustom(
+				diskMoved
+					? t('externalChange.message', settings.language)
+					: t('modal.youHaveUnsavedChanges', settings.language).replace('{title}', title),
+				{
+					title: t('modal.unsavedChanges', settings.language),
+					kind: 'warning',
+					showSave: true,
+				},
+			),
 		onCloseSaveNewerEdits: () => addToast(t('toast.savedNewerEdits', settings.language), 'info'),
 		onCloseAutoSaveFailed: () => addToast(t('toast.autoSaveFailed', settings.language), 'error'),
 		// Not an error: the copy is the way out of a partial buffer, and it was
@@ -2020,6 +2032,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	async function resolveExternalChangeByReloading() {
 		const tab = tabManager.activeTab;
 		if (!tab?.path) return;
+		comparison = null;
 		clearExternalChangeConflict(tab.id);
 		await loadMarkdown(tab.path, {
 			preserveEditState: true,
@@ -2033,6 +2046,33 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		});
 	}
 
+	/**
+	 * The two versions the conflict bar is asking about, once the user has
+	 * asked to see them.
+	 *
+	 * Read on demand rather than kept alongside the flag: the bar can stand for
+	 * a while, and what matters is what the file says when the question is
+	 * actually being answered, not what it said when it was raised.
+	 */
+	let comparison = $state<{ onDisk: string; mine: string; language: string } | null>(null);
+
+	/** "Compare": show what Reload would replace, before it is irreversible. */
+	async function compareExternalChange() {
+		const tab = tabManager.activeTab;
+		if (!tab?.path) return;
+		try {
+			const [onDisk] = (await invoke('read_file_content_checked', { path: tab.path })) as [string, boolean, string];
+			comparison = {
+				onDisk,
+				mine: tab.rawContent,
+				language: getLanguage(tab.path),
+			};
+		} catch (error) {
+			console.error('Failed to read the file for comparison', error);
+			addToast(`${t('externalChange.compare', settings.language)}: ${String(error)}`, 'error');
+		}
+	}
+
 	/** "Keep my version": dismiss. The buffer stays dirty and saveable. */
 	function resolveExternalChangeByKeepingBuffer() {
 		const id = tabManager.activeTabId;
@@ -2042,6 +2082,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// changed file. One save only — a third program writing a minute later
 		// is a new question, and the user has not answered that one.
 		documentSession.allowOverwriteOnce(id);
+		comparison = null;
 		clearExternalChangeConflict(id);
 	}
 
@@ -3638,6 +3679,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	{#if activeExternalChangeConflict && !showHome}
 		<div class="external-change-bar" role="status">
 			<span class="external-change-text">{t('externalChange.message', settings.language)}</span>
+			<button class="external-change-action" onclick={compareExternalChange}>
+				{t('externalChange.compare', settings.language)}
+			</button>
 			<button class="external-change-action" onclick={resolveExternalChangeByReloading}>
 				{t('externalChange.reload', settings.language)}
 			</button>
@@ -3646,6 +3690,22 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			</button>
 		</div>
 	{/if}
+
+	<DiffOverlay
+		show={comparison !== null}
+		onDisk={comparison?.onDisk ?? ''}
+		mine={comparison?.mine ?? ''}
+		language={comparison?.language ?? 'markdown'}
+		labels={{
+			onDisk: t('externalChange.onDisk', settings.language),
+			mine: t('externalChange.mine', settings.language),
+			reload: t('externalChange.reload', settings.language),
+			keepMine: t('externalChange.keepMine', settings.language),
+			close: t('externalChange.close', settings.language),
+		}}
+		onclose={() => (comparison = null)}
+		onreload={resolveExternalChangeByReloading}
+		onkeep={resolveExternalChangeByKeepingBuffer} />
 
 	{#if tabManager.activeTab && !isHomePath(tabManager.activeTab.path) && !showHome}
 			<div

--- a/src/lib/components/DiffOverlay.svelte
+++ b/src/lib/components/DiffOverlay.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+	import type * as Monaco from 'monaco-editor';
+
+	/**
+	 * Side-by-side view of what is on disk against what the buffer holds.
+	 *
+	 * The conflict bar asks a question with an irreversible answer — Reload
+	 * replaces the buffer and `setValue` clears the undo stack with it — and
+	 * used to ask it without showing what would be lost. VS Code and Sublime
+	 * both put a Compare beside the same two choices; this is that third
+	 * option, offering them again once the user has seen the difference.
+	 *
+	 * Monaco is dynamically imported, exactly as `Editor.svelte` does it, so
+	 * this costs nothing until the overlay is opened. The chunk is already in
+	 * the bundle by then.
+	 */
+	let {
+		show = false,
+		onDisk = '',
+		mine = '',
+		language = 'markdown',
+		labels,
+		onclose,
+		onreload,
+		onkeep,
+	}: {
+		show?: boolean;
+		onDisk?: string;
+		mine?: string;
+		language?: string;
+		labels: { onDisk: string; mine: string; reload: string; keepMine: string; close: string };
+		onclose: () => void;
+		onreload: () => void;
+		onkeep: () => void;
+	} = $props();
+
+	let host = $state<HTMLDivElement | null>(null);
+	let editor: Monaco.editor.IStandaloneDiffEditor | null = null;
+	let models: Monaco.editor.ITextModel[] = [];
+
+	function dispose() {
+		editor?.dispose();
+		editor = null;
+		for (const model of models) model.dispose();
+		models = [];
+	}
+
+	$effect(() => {
+		const element = host;
+		const original = onDisk;
+		const modified = mine;
+		const languageId = language;
+		if (!show || !element) {
+			dispose();
+			return;
+		}
+
+		let cancelled = false;
+		(async () => {
+			const monaco = await import('monaco-editor');
+			if (cancelled) return;
+			dispose();
+			// Models of its own rather than the tab's: this view must not be
+			// able to touch the document, and handing it the live model would
+			// put a second editor on a buffer that `Editor.svelte` owns.
+			const left = monaco.editor.createModel(original, languageId);
+			const right = monaco.editor.createModel(modified, languageId);
+			models = [left, right];
+			editor = monaco.editor.createDiffEditor(element, {
+				readOnly: true,
+				originalEditable: false,
+				automaticLayout: true,
+				renderSideBySide: true,
+				scrollBeyondLastLine: false,
+				minimap: { enabled: false },
+			});
+			editor.setModel({ original: left, modified: right });
+		})();
+
+		return () => {
+			cancelled = true;
+			dispose();
+		};
+	});
+
+	function onKeyDown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			event.stopPropagation();
+			onclose();
+		}
+	}
+</script>
+
+<svelte:window on:keydown={show ? onKeyDown : undefined} />
+
+{#if show}
+	<div class="diff-overlay" role="dialog" aria-modal="true">
+		<div class="diff-head">
+			<span class="diff-label">{labels.onDisk}</span>
+			<span class="diff-label">{labels.mine}</span>
+			<div class="diff-actions">
+				<button class="diff-action" onclick={onreload}>{labels.reload}</button>
+				<button class="diff-action primary" onclick={onkeep}>{labels.keepMine}</button>
+				<button class="diff-action" onclick={onclose}>{labels.close}</button>
+			</div>
+		</div>
+		<div class="diff-body" bind:this={host}></div>
+	</div>
+{/if}
+
+<style>
+	.diff-overlay {
+		position: fixed;
+		inset: 36px 0 0 0;
+		z-index: 40001;
+		display: flex;
+		flex-direction: column;
+		background: var(--color-canvas-default);
+	}
+
+	.diff-head {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 14px;
+		border-bottom: 1px solid var(--color-border-default);
+		font-size: 12px;
+		color: var(--color-fg-muted);
+	}
+
+	.diff-label {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.diff-actions {
+		display: flex;
+		gap: 8px;
+		flex: none;
+	}
+
+	.diff-action {
+		padding: 4px 10px;
+		border: 1px solid var(--color-border-default);
+		border-radius: 6px;
+		background: var(--color-canvas-subtle);
+		color: var(--color-fg-default);
+		font-size: 12px;
+		cursor: pointer;
+	}
+
+	.diff-action.primary {
+		background: var(--color-accent-fg, #0969da);
+		border-color: var(--color-accent-fg, #0969da);
+		color: #fff;
+	}
+
+	.diff-body {
+		flex: 1;
+		min-height: 0;
+	}
+</style>

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -54,7 +54,12 @@ type DocumentSessionOptions = {
 	/** The disk moved under a save, which was refused. Raise the conflict bar. */
 	onDiskChangedUnderSave: (tabId: string) => void;
 	cancelPendingAutoSave: (tabId: string) => void;
-	askClose: (title: string) => Promise<'save' | 'discard' | 'cancel'>;
+	/**
+	 * `diskMoved` picks the question. "You have unsaved changes" is the wrong
+	 * one when the file also changed underneath them: Save there means
+	 * overwriting somebody else's work, and the dialog has to say so.
+	 */
+	askClose: (title: string, diskMoved: boolean) => Promise<'save' | 'discard' | 'cancel'>;
 	onCloseSaveNewerEdits: () => void;
 	onCloseAutoSaveFailed: () => void;
 	/**
@@ -837,15 +842,29 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		const tab = tabManager.tabs.find((item) => item.id === tabId);
 		if (!tab || (!tab.isDirty && tab.path !== '')) return true;
 		if (!tab.isDirty) return true;
-		if (settings.autoSave && tab.path !== '') {
+		// Asked before auto-save gets its turn, because auto-save's answer to a
+		// dirty tab — write it and close — is the same answer as "keep mine",
+		// and the user has not given it. The conflict bar may well be on screen
+		// asking that exact question; closing the tab used to answer it for
+		// them, in the direction that destroys the other program's work, with
+		// nothing said. VS Code prompts here, and so does this.
+		//
+		// Only ever reached with a dirty tab, so an untouched document still
+		// closes with no I/O and no question.
+		const diskMoved = tab.path !== '' && (await fileDiffersFromBaseline(tab, tab.path));
+		if (settings.autoSave && tab.path !== '' && !diskMoved) {
 			const success = await saveContent(tabId);
 			if (success && !tab.isDirty) return true;
 			if (success) options.onCloseSaveNewerEdits();
 			else options.onCloseAutoSaveFailed();
 		}
-		const response = await options.askClose(tab.title);
+		const response = await options.askClose(tab.title, diskMoved);
 		if (response === 'cancel') return false;
 		if (response === 'save') {
+			// Answering Save to the changed-on-disk question IS "keep mine", so
+			// it has to carry the authorisation the write guard is waiting for —
+			// otherwise Save silently fails and the tab refuses to close.
+			if (diskMoved) allowOverwriteOnce(tab.id);
 			return saveContent(tabId);
 		}
 		// Kept, but not because the timer would otherwise fire: the two lines

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -306,7 +306,11 @@ export const translations: Record<LanguageCode, Translation> = {
         externalChange: {
             message: 'This file changed on disk while you had unsaved changes.',
             reload: 'Reload from disk',
-            keepMine: 'Keep my version'
+            keepMine: 'Keep my version',
+            compare: 'Compare',
+            onDisk: 'On disk',
+            mine: 'Your version',
+            close: 'Close'
         },
         modal: {
             confirmExit: 'Confirm Exit',
@@ -673,7 +677,11 @@ export const translations: Record<LanguageCode, Translation> = {
         externalChange: {
             message: '此文件在你有未保存修改时被外部程序改动。',
             reload: '从磁盘重新加载',
-            keepMine: '保留我的版本'
+            keepMine: '保留我的版本',
+            compare: '对比',
+            onDisk: '磁盘上的版本',
+            mine: '我的版本',
+            close: '关闭'
         },
         modal: {
             confirmExit: '确认退出',
@@ -1320,7 +1328,11 @@ export const translations: Record<LanguageCode, Translation> = {
         externalChange: {
             message: '當您有未儲存的變更時，此檔案在磁碟上已被修改。',
             reload: '從磁碟重新讀取',
-            keepMine: '保留我的版本'
+            keepMine: '保留我的版本',
+            compare: '比對',
+            onDisk: '磁碟上的版本',
+            mine: '我的版本',
+            close: '關閉'
         },
         modal: {
             confirmExit: '確認結束',


### PR DESCRIPTION
> #697 and #698 are merged; this now sits directly on master.

## What this is

The external-change bar asks a question. Two things stopped it from being answerable.

**Closing the tab answered it, silently, in the destructive direction.** `canCloseTab` handed a dirty tab straight to auto-save, which is on by default:

```
VS Code writes  →  the bar goes up: "Reload from disk" / "Keep my version"
                          │
      the user presses Ctrl+W without answering
                          │
                          ▼
        canCloseTab: dirty + autoSave  →  saveContent
                          │
                          ▼
        their version is overwritten, nothing said
```

A save *is* the answer "keep mine". Giving it on the user's behalf, to a question they were shown and did not answer, is the one direction that destroys somebody else's work. VS Code prompts here.

**And the answer itself was invisible.** "Reload from disk" replaces the buffer, and `setValue` clears the undo stack with it, so the bar asked for an irreversible decision with no way to see what would be lost. Two buttons, no diff. VS Code and Sublime both put a **Compare** beside the same two choices.

## Mechanism

**Closing.** The disk is checked before the auto-save branch, and a file that moved gets the question instead:

```ts
const diskMoved = tab.path !== '' && (await fileDiffersFromBaseline(tab, tab.path));
if (settings.autoSave && tab.path !== '' && !diskMoved) { …unchanged… }
const response = await options.askClose(tab.title, diskMoved);
```

`askClose` takes the flag rather than a second dialog, because it is the same three answers — Save / Discard / Cancel — with a different meaning for Save. The wording swaps to the sentence the bar already uses ("This file changed on disk while you had unsaved changes"), so no string is minted for it and "you have unsaved changes" stops being said where it would hide the half that matters.

Answering Save calls `allowOverwriteOnce` first. Without that the write guard from #698 refuses, `saveContent` returns false, `canCloseTab` returns false, and the dialog has a Save button that does nothing and a tab that will not close.

Only reached with a dirty tab, so an untouched document still closes with no I/O and no question.

**Compare.** A read-only Monaco diff of the file against the buffer, opened from a third button on the bar, with both answers repeated once the difference is on screen. Monaco is dynamically imported exactly as `Editor.svelte` does it, so it costs nothing until the overlay opens and the chunk is already in the bundle by then.

The file is read when Compare is pressed, not when the bar went up: the bar can stand for a while, and what matters is the file as it is when the question is actually being answered.

The view creates its own models and disposes them. Handing it the tab's live model would put a second editor on a buffer `Editor.svelte` owns, and a read-only view of a document is not a place to change it from.

## Scope

One read per close of a dirty tab, and one per Compare. Neither is on a hot path.

Three of the 26 locales carry the `externalChange` section at all; the rest already fall back to English for it, so `compare`, `onDisk`, `mine` and `close` are nine strings, not a hundred.

Not done: making Reload undoable. `pushEditOperation` instead of `setValue` would let Ctrl+Z resurrect the replaced buffer, and the existing comment in `Editor.svelte` explains why that is a separate change — it would also let undo resurrect a buffer the truncation and lossy-decode guards exist to keep away from the file. Compare addresses the same complaint from the other side: the decision is visible before it is irreversible rather than reversible after.

Not done: a three-way merge. Obsidian does one (diff-match-patch) and it is the better answer where it applies; it is also a different feature, and this bar is about a choice between two versions.

Not done: `liveMode` still defaults to off.

## Tests

`scripts/externalChangeReload.spec.ts`, seven added.

Behavioural, against the fake disk #698 introduced:

- closing a tab whose file changed asks, and is told the disk moved, and writes nothing behind the question
- answering Save to that dialog does overwrite, rather than failing silently — the case the authorisation exists for
- closing an untouched file still just saves and closes, with nothing asked

Source-shape, for the parts that need a Svelte runtime:

- the bar offers Compare beside the two answers
- Compare reads the file when it is pressed, and diffs it against the buffer
- both answers close the comparison with them, so the overlay cannot outlive its question
- the diff view creates its own models, is read-only on both sides, and disposes what it created

Checked by breaking what they guard: pinning `diskMoved` to false turns two red; dropping the two `comparison = null` lines turns one red.

## Verification

```
npm audit             0 vulnerabilities
npm run check         815 files, 0 errors, 0 warnings
npm test              963 pass, 0 fail
npm run test:vitest   44 files, 384 pass
npm run build         clean
```

`npm run test:vitest` also reports 14 failures in this environment (session-restore and window-tag snapshots, `assert.deepEqual` reference-identity under node 26 + jsdom), byte-identical on a clean checkout of the base branch.

`cargo test` not re-run: no Rust changed here.

Not verified by hand: how the diff overlay looks. It is a `createDiffEditor` with the app's own Monaco theme in a fixed-position panel, and the build is clean, but nobody has opened it. That is the one part of this PR a test cannot speak for.