### PR TITLE
Cut the dead issue-form fields, and ask for the three things triage keeps reconstructing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,11 +9,20 @@ body:
 
         **One problem per issue, please.** If you have hit several, open one issue for each: problems added to the end of an existing report tend to get lost in the thread while the first one is being discussed.
 
+  - type: input
+    id: app-version
+    attributes:
+      label: Markpad version
+      description: Shown in Settings, or in the About / Markpad menu.
+      placeholder: "2.7.4"
+    validations:
+      required: true
+
   - type: dropdown
     id: install-method
     attributes:
-      label: How did you install Markpad?
-      description: This is often the single most useful line in the report — the installer and the portable build, or a snap and an AppImage, fail in different ways.
+      label: How did you install it?
+      description: The installer and the portable build, or a snap and an AppImage, fail in different ways.
       options:
         - "Windows — installer (Markpad_…_setup.exe)"
         - "Windows — portable (Markpad_….exe)"
@@ -25,37 +34,25 @@ body:
         - "Linux — snap"
         - "Built from source"
         - "Not sure"
-
-  - type: input
-    id: app-version
-    attributes:
-      label: App version
-      description: Shown in Settings, or in the About / Markpad menu.
-      placeholder: "2.7.0"
+    validations:
+      required: true
 
   - type: input
     id: os-version
     attributes:
       label: OS and version
-      placeholder: "Windows 11 24H2 · macOS 26.1 · Ubuntu 24.04"
-
-  - type: input
-    id: linux-details
-    attributes:
-      label: "Linux only: distribution, session and GPU/driver"
-      description: Skip this on Windows and macOS. On Linux it is usually what localises the bug.
-      placeholder: "CachyOS · GNOME on Wayland (also tried X11) · Intel Arc, Mesa"
+      description: On Linux, add the desktop session and GPU driver — that is usually what localises the bug.
+      placeholder: "Windows 11 24H2 · macOS 26.1 · CachyOS, GNOME on Wayland, Intel Arc/Mesa"
+    validations:
+      required: true
 
   - type: textarea
     id: what-happens
     attributes:
-      label: What happens
+      label: What happens, and what you expected instead
       placeholder: Paste any error text from the terminal or a dialog here too — it is often the fastest route to the cause.
-
-  - type: textarea
-    id: what-expected
-    attributes:
-      label: What you expected
+    validations:
+      required: true
 
   - type: textarea
     id: steps
@@ -67,18 +64,7 @@ body:
         3. See …
 
   - type: textarea
-    id: source-document
+    id: extras
     attributes:
-      label: The document, if one triggers it
-      description: If the bug only shows up with a particular file, attach the `.md` or paste the smallest part that still reproduces it. Reports that depend on a document and do not include one often cannot be reproduced at all.
-
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots
-      description: Drag images straight into this box.
-
-  - type: textarea
-    id: anything-else
-    attributes:
-      label: Anything else
+      label: Screenshots, sample file, anything else
+      description: Drag images straight into this box. If the bug only shows up with a particular document, attach the `.md` or paste the smallest part that still reproduces it — reports that depend on a document and do not include one often cannot be reproduced at all.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,7 +64,14 @@ body:
         3. See …
 
   - type: textarea
+    id: source-markdown
+    attributes:
+      label: The Markdown that triggers it
+      description: Paste it as text, not as a screenshot of text — a screenshot has to be retyped before it can be tested, and the retyping is where the actual trigger gets lost. Paste the smallest part that still reproduces it, or attach the `.md`.
+      render: markdown
+
+  - type: textarea
     id: extras
     attributes:
-      label: Screenshots, sample file, anything else
-      description: Drag images straight into this box. If the bug only shows up with a particular document, attach the `.md` or paste the smallest part that still reproduces it — reports that depend on a document and do not include one often cannot be reproduced at all.
+      label: Screenshots, and anything else
+      description: Drag images straight into this box.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,6 +15,13 @@ body:
     attributes:
       label: What would you like?
 
+  - type: textarea
+    id: reference
+    attributes:
+      label: Has another app got this right?
+      description: A screenshot of it, or just a name, is the single most useful thing you can add. Requests that point at something concrete get answered against that thing; requests that describe it in prose get answered against a guess at what you meant.
+      placeholder: Drag screenshots straight into this box.
+
   - type: dropdown
     id: platform
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,15 +6,32 @@ body:
     id: problem
     attributes:
       label: What problem would this solve?
-      placeholder: What you were trying to do when you wanted it.
+      placeholder: What you were trying to do when you wanted it, and any workaround you settled for.
+    validations:
+      required: true
 
   - type: textarea
     id: proposal
     attributes:
       label: What would you like?
 
-  - type: textarea
-    id: alternatives
+  - type: dropdown
+    id: platform
     attributes:
-      label: What have you tried instead?
-      description: Workarounds, other editors, or nothing — all three are useful to know.
+      label: Which platform is this for?
+      description: Some requests only make sense on one OS — tray icons, package managers, file associations.
+      options:
+        - "All platforms"
+        - "Windows"
+        - "macOS"
+        - "Linux"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: input
+    id: setup
+    attributes:
+      label: Your Markpad version and how you installed it
+      description: Skip only if the request has nothing to do with your setup.
+      placeholder: "2.7.4 · Windows installer"

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -9,15 +9,14 @@ body:
   - type: textarea
     id: goal
     attributes:
-      label: What are you trying to do?
-
-  - type: textarea
-    id: tried
-    attributes:
-      label: What have you tried?
+      label: What are you trying to do, and what have you tried?
+    validations:
+      required: true
 
   - type: input
     id: platform-version
     attributes:
-      label: Platform and app version
-      placeholder: "Windows 11 · Markpad 2.7.0"
+      label: Platform and Markpad version
+      placeholder: "Windows 11 · Markpad 2.7.4"
+    validations:
+      required: true


### PR DESCRIPTION
The three issue forms were last rewritten in #469, which deliberately made every field optional. Twenty-seven external issues have come in since, and they show two different problems — the bug form asks for things nobody answers, and the feature form does not ask for the one thing triage needs.

## What the filled-in issues show

Bug report, 9 issues, 10 fields:

| answered | field |
| --- | --- |
| 9/9 | Markpad version, install method, OS and version |
| 9/9 | What happens |
| 7/9 | What you expected |
| 4/8 | Steps to reproduce |
| 3/9 | Screenshots |
| 1/9 | The document, if one triggers it |
| 0/9 | Anything else |
| 0/9 | Linux only: distribution, session and GPU/driver |

The environment block is not the expensive part — it is answered every time. The tail is: four fields at or under a third, one of them structurally impossible to answer because it is skipped on Windows and macOS, and Windows and macOS are where the reports come from.

Feature request, 17 issues, 3 fields: no environment field exists, so all 17 arrived without one. Several of them are Windows-only asks — #702 (tray icon), #672 (Scoop), #671 (a CLI flag) — and the form gives no way to tell that apart from a cross-platform request without reading the prose and guessing.

Question, 1 issue in sixteen days, and it was relabelled `enhancement` (#676, a duplicate of #682).

## What changed

**Bug report, 10 fields to 7.** `Linux only: distribution, session and GPU/driver` becomes a clause in the OS placeholder, so Linux reporters still get asked and everyone else stops seeing an empty box. `Screenshots` and `Anything else` collapse into one box. `The document, if one triggers it` stays a separate field and becomes `The Markdown that triggers it`, with `render: markdown` so the paste arrives as text: #690 and #691 each attached a *screenshot* of the Markdown, and both replies had to read the trigger back out of the image before it could be tested. At 1/9 the field looked dead, but the cost of it being empty was the highest of any field on the form. `What you expected` folds into `What happens`, since at 7/9 it is nearly always answered in the same breath. Version, install method and OS become required: they were already 9/9, so this costs reporters nothing and stops the occasional blank one.

**Feature request, 3 fields to 5.** Adds a required platform dropdown (All / Windows / macOS / Linux / Not sure) and an optional one-line version-and-install field. It also adds `Has another app got this right?`, which takes screenshots: #701 and #681 each attached one of another editor unprompted and are the two requests that were answered against something concrete, while #683, #604, #669 and #690 had to have Typora, Obsidian, Notion or GitHub named in the reply before there was a reference at all. `What have you tried instead?` (8/17) folds into the first placeholder.

**Question, 3 fields to 2.** Goal and what-you-tried merge; the platform line is now required.

## Trade-offs

A dropdown rather than the bug form's three-field environment block on the feature request. Triaging an enhancement needs one bit — is this Windows-only — not a reproducible environment; asking for three lines to get one bit is what makes a form feel heavy. The version input stays optional and free-text for the cases where it matters ("the 2.7.4 export dialog should…").

Required fields on identity but not on content. GitHub's `required: true` blocks submission, so it is only safe on fields with a 100% answer rate already. Everything describing the problem stays optional, which is what #469 established and the fill rates support.

`question.yml` kept rather than deleted. One use in sixteen days is a case for deleting it, but discussions are off on this repository and blank issues are enabled, so removing it just moves those reports to a form with no platform field at all.

## Not changed

`blank_issues_enabled: true` stays. Three of the recent issues used the wrong form for their content (#702 and #559 filed as feature requests are bugs; #676 filed as a question is a request) — that is a routing problem, and narrowing the entry points is a separate change from simplifying the forms.

YAML parses for all four files; GitHub validates the schema on push to the default branch.

