### PR TITLE
fix(window): a cold start no longer takes focus from the app you switched to (#702)

### DIFF
--- a/scripts/coldStartDoesNotStealFocus.test.ts
+++ b/scripts/coldStartDoesNotStealFocus.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readRustBackend, readSource } from './sourceTree.js';
+
+const backend = readRustBackend();
+
+function showWindowSource(): string {
+	const match = /pub async fn show_window\([\s\S]*?\n\}/.exec(backend);
+	assert.ok(match, 'show_window is gone: this file no longer states anything');
+	return match[0];
+}
+
+test('the main window is shown without being activated on a cold start', () => {
+	const showWindow = showWindowSource();
+
+	// The defect (#702): the window is built hidden and revealed once the
+	// frontend mounts, seconds after launch, and the reveal called `set_focus`
+	// unconditionally — pulling the user out of whatever they had switched to.
+	// The label and the one-shot flag together are what make it the FIRST show
+	// of the MAIN window that stays quiet.
+	assert.match(showWindow, /window\.label\(\)\s*==\s*"main"/);
+	assert.match(showWindow, /MAIN_WINDOW_SHOWN\.swap\(true,/);
+
+	// Not vacuous: the other callers — a detached tab window, the close walk
+	// needing its dialog visible — still activate, so this cannot pass by
+	// `set_focus` having been deleted outright.
+	assert.match(showWindow, /set_focus\(\)/);
+
+	// And the quiet path returns before reaching it.
+	const guard = showWindow.indexOf('return;');
+	const focus = showWindow.indexOf('set_focus()');
+	assert.ok(guard > 0 && guard < focus, 'the cold-start path falls through to set_focus');
+});
+
+test('the main window builder carries the Windows half of the fix', () => {
+	const app = readSource('src-tauri/src/app.rs');
+
+	// `show()` maps to `SW_SHOW` on Windows, which activates: skipping
+	// `set_focus` does not by itself keep the first show quiet there.
+	// `.focused(false)` sets tao's one-shot `MARKER_DONT_FOCUS` so that show
+	// uses `SW_SHOWNOACTIVATE` instead.
+	assert.match(app, /\.focused\(false\)/);
+
+	// The comment on that line, and its no-op status on macOS and Linux, both
+	// depend on the window still being built hidden.
+	assert.match(app, /\.visible\(false\)/);
+
+	// Detached tab windows are built hidden too, and they SHOULD activate when
+	// revealed — the user just asked for them. Exactly one builder opts out.
+	assert.equal(backend.match(/\.focused\(false\)/g)?.length, 1);
+});

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -82,6 +82,15 @@ pub fn run() {
             .inner_size(900.0, 650.0)
             .min_inner_size(400.0, 300.0)
             .visible(false)
+            // Half of "a cold start does not steal focus"; the other half is
+            // `show_window`. Windows maps `show()` to `SW_SHOW`, which
+            // activates, so dropping the `set_focus` call there is not enough
+            // on its own. This sets tao's one-shot `MARKER_DONT_FOCUS`, which
+            // makes the FIRST show use `SW_SHOWNOACTIVATE` and is then cleared,
+            // so every later show still comes to the front. On macOS and Linux
+            // it is a no-op: tao only reads `focused` for a window that is
+            // built visible, and this one is not.
+            .focused(false)
             .resizable(true)
             .shadow(false)
             .center();

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -5,7 +5,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     Mutex,
 };
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -350,9 +350,37 @@ pub fn focus_window(app: AppHandle, label: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Consumed by the main window's first show. See `show_window`.
+static MAIN_WINDOW_SHOWN: AtomicBool = AtomicBool::new(false);
+
+/// Reveals a window that was built hidden.
+///
+/// The main window is built hidden so no empty frame is on screen while the
+/// webview boots, and the frontend calls this once it has mounted — seconds
+/// after launch, by which time the user has usually gone back to whatever they
+/// were doing. Activating then is wrong, and `set_focus` is not a polite
+/// request to activate: it is each platform's override for the focus-stealing
+/// prevention the OS applies on the user's behalf — `SetForegroundWindow` on
+/// Windows, with a *synthesized Alt keypress* as the fallback when the OS
+/// refuses, `activateIgnoringOtherApps:` on macOS, `present_with_time` passed
+/// `GDK_CURRENT_TIME` on Linux. Shown without it, the window appears behind
+/// whatever the user moved on to and waits there (#702).
+///
+/// Only that first show is quiet. Every other caller is answering something the
+/// user just did — a detached tab window revealing itself, or the close walk
+/// bringing its window up so the dialog is not hidden behind another — and each
+/// of those must still come to the front.
 #[tauri::command]
 pub async fn show_window(window: tauri::Window) {
+    let is_cold_start =
+        window.label() == "main" && !MAIN_WINDOW_SHOWN.swap(true, Ordering::Relaxed);
+
     let _ = window.show();
+
+    if is_cold_start {
+        return;
+    }
+
     let _ = window.unminimize();
     let _ = window.set_focus();
 }


### PR DESCRIPTION
## What this is

Closes #702, reported by @Fallgrim. Launching Markpad and switching away while it starts meant the app activated itself a few seconds later and took focus out of whatever you had moved on to — mid-sentence, in his case.

The main window's first show no longer activates. It appears behind whatever is in front and waits there. Nothing else changes: the startup delay is unchanged, and there is nothing to configure.

## Mechanism

The window is built hidden (`app.rs`) so no empty frame is on screen while the webview boots, and the frontend reveals it from `onMount` — seconds later, once the JS bundle has loaded. The reveal command ended with `set_focus()`, unconditionally, with nothing asking whether the user was still there.

`set_focus` is not a request to activate. It is each platform's override for the focus-stealing prevention the OS applies on the user's behalf:

| platform | what `set_focus` reaches |
|---|---|
| Windows | `SetForegroundWindow`; when the OS refuses — the protection working correctly — tao's fallback **synthesizes an Alt keypress** via `SendInput` to fake recent user input, then retries |
| macOS | `activateIgnoringOtherApps:` |
| Linux | `present_with_time(GDK_CURRENT_TIME)` — passing 0 rather than a real user-event timestamp is what defeats the WM's check |

The reporter is on Windows 10, so the Alt keypress applies to him: it is delivered to whatever window is foreground, and a lone Alt press activates the menu bar in most Windows apps. That may be a second, separate interruption on top of the window appearing.

Dropping `set_focus` is not sufficient on Windows, because `show()` maps to `SW_SHOW`, which activates on its own. `.focused(false)` on the builder sets tao's one-shot `MARKER_DONT_FOCUS`, which makes the first show use `SW_SHOWNOACTIVATE` and is then cleared, so later shows are unaffected. tao only reads `focused` for a window built visible, so it is a no-op on macOS and Linux.

The one-shot lives in Rust rather than being passed in by the caller because the frontend cannot tell a cold start from a reload, and the same command serves three callers with different needs: the cold start (quiet), a detached tab window revealing itself (must activate — the user just asked for it), and the close walk bringing its window up so the dirty-tab dialog is not hidden behind another window (must activate).

## Scope

**No tray icon**, which is what the issue asked for. It would work around the forced activation by ensuring the window never appears on its own, leaving the bug in place for everyone who does not use it — and it is a much larger change: a tray means closing the last window no longer quits, and the close path runs the dirty-tab walk and writes the session snapshot on exactly that assumption. Splitting that into "hide" and "really quit" with different save semantics is where data loss gets introduced. On top of that, Windows 10/11 collapse new notification-area icons into the overflow chevron by default, and GNOME needs an extension to show a tray at all — so on both, "minimize to tray" can mean the app simply disappears.

**The startup delay is untouched.** Showing the window at ~100ms with a background colour instead of at `onMount` would remove both the wait and the problem, since the OS grants activation to a just-launched app and nothing would need to override anything. It also needs the window-state plugin's geometry restore to happen before the show, or the window appears at 900×650 centred and then jumps. That is a bigger change than this issue needs.

**The other activation call sites are untouched, and one of them still reaches the same override.** `handle_single_instance` brings the existing window up when Markpad is launched again — double-clicking a second `.md` file, say. The activation is performed by the *first* process, which has no foreground rights; the second process, which does, exits without handing them over, and `tauri-plugin-single-instance` calls `AllowSetForegroundWindow` nowhere. So on Windows that path is still refused and still falls back to the synthesized Alt keypress. Coming to the front there is what the user asked for by double-clicking, so the behaviour is right and only the mechanism is wrong — and fixing it means the second instance granting the first its rights before exiting, which is a change on the plugin's path, not this one.

Also worth recording: launching *with* a file already shows the window from `setup`, immediately after `set_background_color`, instead of waiting for `onMount`. The "show early against a themed background" shape that removing the delay would need is therefore already in the tree, on that one path.

**`unminimize()` is skipped on the quiet path too.** The window-state plugin does not restore a minimised state, so there is nothing to undo there.

## Tests

`scripts/coldStartDoesNotStealFocus.test.ts`, source-shape assertions against the Rust backend. Reverted both halves of the fix with the test kept: **both tests go red.**

The anchors are the label comparison and the one-shot swap inside `show_window`, `.focused(false)` in `app.rs`, and a count assertion that exactly one builder in the backend opts out of focus — the last one is the interesting one, since it is a claim about the *absence* of a second opt-out, which is what would silently make detached tab windows stop coming to the front. A `set_focus()` match keeps the check from passing by the call having been deleted outright, and an index comparison confirms the quiet path returns before reaching it.

No behavior test: the subject is a platform activation call, and running it under a test runner would assert nothing about what the window manager does with it.

## Verification

```
npm audit             0 vulnerabilities
npm run check         816 files, 0 errors, 0 warnings
npm test              965 pass, 0 fail
npm run test:vitest   398 pass (44 files)
cargo test            164 pass
```

**Not verified:** the behaviour itself, on any platform. The window is shown by the OS compositor and whether it takes focus is the OS's answer, not something the process can assert about itself. What is above is read from tao 0.35.3's `platform_impl` — `SW_SHOW` vs `SW_SHOWNOACTIVATE` behind `MARKER_DONT_FOCUS` (`windows/window_state.rs`), `makeKeyAndOrderFront` vs `activateIgnoringOtherApps:` (`macos/`), `present_with_time` (`linux/event_loop.rs`) — and from the fact that `focused` is only read for a window built visible. Windows is where the reporter is and where the `SW_SHOW` half matters, and it is the one I could not run.
