### PR TITLE
Enter continues a block quote, as it already continues a list (#700)

### DIFF
--- a/scripts/keymapHarness.ts
+++ b/scripts/keymapHarness.ts
@@ -6,7 +6,7 @@ import { KeyCode } from 'monaco-editor/esm/vs/editor/common/standalone/standalon
 import { KeyMod } from 'monaco-editor/esm/vs/editor/common/services/editorBaseApi.js';
 import ts from 'typescript';
 
-import { listEnter, parseListItem } from '../src/lib/utils/listEditing.js';
+import { blockEnter, parseListItem } from '../src/lib/utils/listEditing.js';
 import { tableOperation, tableStep } from '../src/lib/utils/tableEditing.js';
 import { viewerCommandFor, type KeyContext, type ViewerCommand } from '../src/lib/utils/viewerKeymap.js';
 import { readSource, functionSource } from './sourceTree.js';
@@ -471,7 +471,7 @@ export function runEditorHandler(
 	};
 
 	const scope: Record<string, unknown> = {
-		listEnter,
+		blockEnter,
 		parseListItem,
 		tableStep,
 		tableOperation,

--- a/scripts/listContinuation.test.ts
+++ b/scripts/listContinuation.test.ts
@@ -4,7 +4,7 @@ import test from 'node:test';
 import { KeyCode } from 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js';
 import { KeyMod } from 'monaco-editor/esm/vs/editor/common/services/editorBaseApi.js';
 
-import { listEnter, parseListItem } from '../src/lib/utils/listEditing.js';
+import { blockEnter, parseListItem } from '../src/lib/utils/listEditing.js';
 import { bareCommands, runEditorHandler } from './keymapHarness.js';
 import { functionSource, readSource } from './sourceTree.js';
 
@@ -16,7 +16,8 @@ import { functionSource, readSource } from './sourceTree.js';
  *
  * The decision — "given this line and this caret, what should the next line
  * say" — is a pure function in `src/lib/utils/listEditing.ts` and is CALLED
- * here, once per shape of list item the app claims to understand.
+ * here, once per shape of list item and block quote the app claims to
+ * understand.
  *
  * The two handlers in `Editor.svelte` are lifted out of the component and run
  * against a stub editor, the same trick `keymapHarness.ts` uses, so what is
@@ -33,9 +34,9 @@ import { functionSource, readSource } from './sourceTree.js';
 
 // ------------------------------------------------------------- the pure part
 
-/** `listEnter` at the end of `line`, which is where Enter is normally pressed. */
+/** `blockEnter` at the end of `line`, which is where Enter is normally pressed. */
 function enterAtEnd(line: string) {
-	return listEnter(line, line.length + 1);
+	return blockEnter(line, line.length + 1);
 }
 
 test('a bullet item continues with the same bullet character', () => {
@@ -105,8 +106,10 @@ test('lines that are not list items are left to the ordinary Enter', () => {
 		'',
 		'plain text',
 		'# heading',
-		'> quoted prose',
 		'    indented code',
+		// A `>` inside a sentence is prose: the quote has to start the line.
+		'a > b',
+		'-> arrow',
 		// A thematic break is a bullet character followed by more of them, never
 		// by a space — which is what keeps `---` out.
 		'---',
@@ -120,20 +123,102 @@ test('lines that are not list items are left to the ordinary Enter', () => {
 	}
 });
 
-test('a caret still inside the marker gets the ordinary Enter', () => {
-	// Enter at the very start of `- item` means "make room above me". A
-	// continuation there would write a second marker in front of the first.
-	assert.equal(listEnter('- item', 1), null);
-	assert.equal(listEnter('- item', 2), null);
-	assert.deepEqual(listEnter('- item', 3), { kind: 'continue', text: '- ' });
-	assert.equal(listEnter('  - [ ] item', 8), null);
-	assert.deepEqual(listEnter('  - [ ] item', 9), { kind: 'continue', text: '  - [ ] ' });
+// -------------------------------------------------------- block quotes (#700)
+
+test('a quoted line continues the quote', () => {
+	assert.deepEqual(enterAtEnd('> quoted'), { kind: 'continue', text: '> ' });
+	assert.deepEqual(enterAtEnd('> > deeper'), { kind: 'continue', text: '> > ' });
+	assert.deepEqual(enterAtEnd('  > indented'), { kind: 'continue', text: '  > ' });
+	// The spacing is copied, not normalised — the rule the hand-aligned list
+	// above lives by, applied to the quote.
+	assert.deepEqual(enterAtEnd('>   wide'), { kind: 'continue', text: '>   ' });
+});
+
+test('a quote written without its space is a quote too', () => {
+	// `>text` IS a block quote — CommonMark says so, comrak says so, and the
+	// preview beside the editor draws one. VS Code's Markdown All in One
+	// declines it (`/^> /.test(textBeforeCursor)`); this key does not, because
+	// declining would make Enter disagree with the app's own renderer.
+	assert.deepEqual(enterAtEnd('>tight'), { kind: 'continue', text: '>' });
+	assert.deepEqual(enterAtEnd('>> deep'), { kind: 'continue', text: '>> ' });
+	// A bare `>` is an empty quote, so Enter leaves the quote as it does on `> `.
+	assert.deepEqual(enterAtEnd('>'), { kind: 'clear', line: '' });
+});
+
+test('Enter on an empty quote leaves the quote, whatever its depth', () => {
+	assert.deepEqual(enterAtEnd('> '), { kind: 'clear', line: '' });
+	assert.deepEqual(enterAtEnd('> > '), { kind: 'clear', line: '' });
+	assert.deepEqual(enterAtEnd('  > '), { kind: 'clear', line: '' });
+});
+
+test('leaving a quoted list takes one Enter per block, not one per level', () => {
+	// The ladder the two branches make together, and the reason `clear` on a
+	// quote goes to nothing rather than one level shallower: the list ends, then
+	// the quote ends. Three Enters from a nested item to prose.
+	assert.deepEqual(enterAtEnd('> > - item'), { kind: 'continue', text: '> > - ' });
+	assert.deepEqual(enterAtEnd('> > - '), { kind: 'clear', line: '> > ' });
+	assert.deepEqual(enterAtEnd('> > '), { kind: 'clear', line: '' });
+});
+
+test('the caret joins the block after the marker\'s CHARACTERS, not after its space', () => {
+	// THE RULE, and the reason it is not "after the marker's text starts".
+	//
+	// A caret just after the `>` of `> quoted` and one just after the `>` of
+	// `>quoted` are the same pixel and the same gesture; the first sits inside a
+	// two-character marker, the second at the head of the content. Measuring to
+	// where the TEXT starts answers those two opposite things — one Enter ending
+	// the quote, the other continuing it — from a position nobody can tell
+	// apart. Measuring to where the marker's characters stop answers both the
+	// same. It is CodeMirror's rule for the same reason: @codemirror/lang-markdown
+	// declines only when `inner.to - inner.spaceAfter.length > pos`.
+	//
+	// Column 1 is still the ordinary Enter everywhere: in front of the marker,
+	// Enter means "make room above me".
+	assert.equal(blockEnter('> quoted', 1), null);
+	assert.deepEqual(blockEnter('> quoted', 2), { kind: 'continue', text: '>' });
+	assert.equal(blockEnter('>quoted', 1), null);
+	assert.deepEqual(blockEnter('>quoted', 2), { kind: 'continue', text: '>' });
+
+	// Lists answer to the same measurement, which is where `-` stops.
+	assert.equal(blockEnter('- item', 1), null);
+	assert.deepEqual(blockEnter('- item', 2), { kind: 'continue', text: '-' });
+	assert.deepEqual(blockEnter('1. item', 3), { kind: 'continue', text: '2.' });
+	// A task item's marker runs through the box, so the space that does not
+	// count is the one after `]`, not the one before `[`.
+	assert.equal(blockEnter('  - [ ] item', 7), null);
+	assert.deepEqual(blockEnter('  - [ ] item', 8), { kind: 'continue', text: '  - [ ]' });
+
+	// Between the quote and a list marker the LIST has not started but the quote
+	// has, so the tail moving down keeps its `> `.
+	assert.deepEqual(blockEnter('> - item', 2), { kind: 'continue', text: '>' });
+	assert.deepEqual(blockEnter('> - item', 4), { kind: 'continue', text: '> -' });
+});
+
+test('a caret inside the marker\'s space does not double that space', () => {
+	// The separator is split by the caret: its second half rides down with the
+	// text, so writing a whole one at the head of the new line lands an extra
+	// space — and another on every Enter after that. What each pair below has to
+	// add up to is the separator that was already there, not two of them.
+	const split = (line: string, column: number) => {
+		const next = blockEnter(line, column);
+		assert.equal(next?.kind, 'continue', line);
+		return [line.slice(0, column - 1), (next as { text: string }).text + line.slice(column - 1)];
+	};
+
+	assert.deepEqual(split('> quoted', 2), ['>', '> quoted']);
+	assert.deepEqual(split('- item', 2), ['-', '- item']);
+	// A hand-aligned list keeps every one of its spaces, and no more.
+	assert.deepEqual(split('-   aligned', 2), ['-', '-   aligned']);
+	// The marker's CHARACTERS are never rationed, only its whitespace: the
+	// number still counts up and the box still comes back unchecked.
+	assert.deepEqual(split('9. item', 3), ['9.', '10. item']);
+	assert.deepEqual(split('- [x] task', 6), ['- [x]', '- [ ] task']);
 });
 
 test('a caret in the middle of an item still continues the list', () => {
 	// Splitting an item is continuing it: the tail moves down behind the new
 	// marker, which is what every editor does and what the caller relies on.
-	assert.deepEqual(listEnter('- hello world', 9), { kind: 'continue', text: '- ' });
+	assert.deepEqual(blockEnter('- hello world', 9), { kind: 'continue', text: '- ' });
 });
 
 test('parseListItem reports where the marker ends', () => {
@@ -168,8 +253,10 @@ const EDITOR = 'src/lib/components/Editor.svelte';
 
 const TAB_HANDLER = ['soleCaret', 'applyTableEdit', 'stepTableCell', 'handleTabKey'];
 
+const ENTER_HANDLER = ['continueListOnEnter'];
+
 test('Enter on a list item inserts the line break and the next marker in one edit', () => {
-	const run = runEditorHandler(['continueListOnEnter'], { lines: ['- item'], selections: [[1, 7, 1, 7]] });
+	const run = runEditorHandler(ENTER_HANDLER, { lines: ['- item'], selections: [[1, 7, 1, 7]] });
 
 	assert.deepEqual(run.triggers, [], 'the plain Enter must not fire as well');
 	assert.deepEqual(run.edits, [
@@ -182,7 +269,7 @@ test('the line break is the document\'s, not a hard-coded \\n', () => {
 	// The CRLF class of defect this repo has been bitten by before (#148): a
 	// handler that writes '\n' into a CRLF document leaves one mixed line
 	// behind, and nothing downstream reports it.
-	const run = runEditorHandler(['continueListOnEnter'], {
+	const run = runEditorHandler(ENTER_HANDLER, {
 		lines: ['1. item'],
 		selections: [[1, 8, 1, 8]],
 		eol: '\r\n',
@@ -191,7 +278,7 @@ test('the line break is the document\'s, not a hard-coded \\n', () => {
 });
 
 test('Enter on an empty item replaces the line instead of breaking it', () => {
-	const run = runEditorHandler(['continueListOnEnter'], { lines: ['- ', 'x'], selections: [[1, 3, 1, 3]] });
+	const run = runEditorHandler(ENTER_HANDLER, { lines: ['- ', 'x'], selections: [[1, 3, 1, 3]] });
 
 	assert.deepEqual(run.triggers, []);
 	assert.deepEqual(run.edits, [
@@ -204,7 +291,7 @@ test('Enter on an empty item replaces the line instead of breaking it', () => {
 
 test('Enter anywhere else is a plain Enter', () => {
 	for (const lines of [['plain text'], ['---'], ['']]) {
-		const run = runEditorHandler(['continueListOnEnter'], {
+		const run = runEditorHandler(ENTER_HANDLER, {
 			lines,
 			selections: [[1, lines[0].length + 1, 1, lines[0].length + 1]],
 		});
@@ -213,17 +300,27 @@ test('Enter anywhere else is a plain Enter', () => {
 	}
 });
 
+test('a quoted line continues in the editor too', () => {
+	const run = runEditorHandler(ENTER_HANDLER, { lines: ['> quoted'], selections: [[1, 9, 1, 9]] });
+	assert.deepEqual(run.triggers, []);
+	assert.deepEqual(run.edits, [{ range: [1, 9, 1, 9], text: '\n> ', cursor: [2, 3, 2, 3] }]);
+	assert.equal(run.undoStops, 1);
+
+	const leaving = runEditorHandler(ENTER_HANDLER, { lines: ['> ', 'x'], selections: [[1, 3, 1, 3]] });
+	assert.deepEqual(leaving.edits, [{ range: [1, 1, 1, 3], text: '', cursor: [1, 1, 1, 1] }]);
+});
+
 test('a selection, or a second caret, gets the plain Enter', () => {
 	// One edit at the primary selection would silently discard what the other
 	// carets were about to do.
-	const spanning = runEditorHandler(['continueListOnEnter'], {
+	const spanning = runEditorHandler(ENTER_HANDLER, {
 		lines: ['- item'],
 		selections: [[1, 3, 1, 7]],
 	});
 	assert.deepEqual(spanning.edits, []);
 	assert.deepEqual(spanning.triggers, ['type:"\\n"']);
 
-	const multi = runEditorHandler(['continueListOnEnter'], {
+	const multi = runEditorHandler(ENTER_HANDLER, {
 		lines: ['- one', '- two'],
 		selections: [
 			[1, 6, 1, 6],

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -12,7 +12,7 @@
 		type InlineWrapToolId,
 		type LineMarkerToolId,
 	} from '../utils/editorToolbar.js';
-	import { listEnter, parseListItem } from '../utils/listEditing.js';
+	import { blockEnter, parseListItem } from '../utils/listEditing.js';
 	import { tableOperation, tableStep, type TableEdit, type TableOperation } from '../utils/tableEditing.js';
 	import { editorOptionsFromSettings } from '../utils/editorOptions.js';
 	import { markdownTokenRules, semanticTokenRules } from '../utils/editorTheme.js';
@@ -1021,10 +1021,11 @@
 	};
 
 	/**
-	 * Enter on a list item writes the next item's marker; Enter on an item that
-	 * has a marker and no text takes the marker away instead, which is how a
-	 * list ends. What the next line should say is decided by `listEnter` in
-	 * utils/listEditing.ts, where it can be tested without a browser.
+	 * Enter on a list item writes the next item's marker; Enter on a block quote
+	 * writes the quote (#700); Enter on either with a marker and no text takes
+	 * the marker away instead, which is how the block ends. What the next line
+	 * should say is decided by `blockEnter` in utils/listEditing.ts, where it can
+	 * be tested without a browser.
 	 *
 	 * Only a single collapsed caret is claimed. A selection, or several carets,
 	 * gets the ordinary Enter: replacing a multi-cursor edit with one edit at
@@ -1041,7 +1042,7 @@
 
 		const selection = selections[0];
 		const line = selection.startLineNumber;
-		const next = listEnter(model.getLineContent(line), selection.startColumn);
+		const next = blockEnter(model.getLineContent(line), selection.startColumn);
 		if (!next) return plainEnter();
 
 		// Its own undo step, so one Ctrl+Z gives back the marker this took away

--- a/src/lib/utils/listEditing.ts
+++ b/src/lib/utils/listEditing.ts
@@ -1,8 +1,15 @@
-import { LIST_MARKER, LIST_MARKER_PREFIX, ORDERED_MARKER, TASK_BOX } from './listSyntax.js';
+import {
+	LIST_MARKER,
+	LIST_MARKER_PREFIX,
+	ORDERED_MARKER,
+	QUOTE_MARKER,
+	TASK_BOX,
+} from './listSyntax.js';
 
 /**
- * "Given a list line and where the caret is, what should the next line be" —
- * the whole of issue #604's second item, with no editor in it.
+ * "Given a block line and where the caret is, what should the next line be" —
+ * the whole of issue #604's second item, plus #700's block quotes, with no
+ * editor in it.
  *
  * WHY THIS IS A SEPARATE MODULE
  *
@@ -11,9 +18,9 @@ import { LIST_MARKER, LIST_MARKER_PREFIX, ORDERED_MARKER, TASK_BOX } from './lis
  * was empty and the marker should therefore go away. The uninteresting part is
  * asking Monaco for the line and handing it back an edit. Keeping the first
  * part here means it can be RUN by `node --test` — every case in
- * `scripts/listEditing.test.ts` is the real function, not a description of it —
- * and leaves `Editor.svelte` with a keybinding, a `when` clause and four lines
- * of plumbing, which is all that genuinely needs a browser.
+ * `scripts/listContinuation.test.ts` is the real function, not a description of
+ * it — and leaves `Editor.svelte` with a keybinding, a `when` clause and four
+ * lines of plumbing, which is all that genuinely needs a browser.
  *
  * The marker vocabulary comes from ./listSyntax.ts, which is the same grammar
  * the toolbar's toggles and the preview's checkbox rewrite read. A fourth
@@ -60,6 +67,62 @@ const LIST_ITEM = new RegExp(
 	String.raw`^(${LIST_MARKER_PREFIX})(${LIST_MARKER})([ \t]+)(?:(${TASK_BOX})([ \t]*))?(.*)$`,
 );
 
+/**
+ * The whitespace a marker ends with, which the caret test below does NOT count
+ * as part of it.
+ */
+const TRAILING_SEPARATOR = /[ \t]+$/;
+
+/**
+ * Where a marker's characters stop — the column Enter starts belonging to the
+ * block at, one short of where its text starts.
+ *
+ * WHY NOT SIMPLY "WHERE THE TEXT STARTS". A caret drawn just after the `>` of
+ * `> text` and one drawn just after the `>` of `>text` are the same pixel and
+ * the same gesture, but the first is inside a two-character marker and the
+ * second is at the head of the content. Testing against the text would answer
+ * those two opposite things — one Enter ending the quote, the other continuing
+ * it — from a position the user has no way to tell apart. Testing against the
+ * marker's characters answers both the same.
+ *
+ * This is CodeMirror's rule, arrived at for the same reason: `commands.ts` in
+ * @codemirror/lang-markdown declines only when
+ * `inner.to - inner.spaceAfter.length > pos`, subtracting exactly this
+ * whitespace. VS Code's Markdown All in One instead requires `> ` before the
+ * caret and never continues `>text` at all, which sidesteps the question rather
+ * than answering it — and cannot be copied here, because comrak draws `>text`
+ * as a quote in the preview beside the editor.
+ */
+function markerColumn(prefix: string, markerAndSeparator: string): number {
+	return prefix.length + markerAndSeparator.replace(TRAILING_SEPARATOR, '').length + 1;
+}
+
+/**
+ * The marker to write, with its separator cut back to the part the caret has
+ * already passed.
+ *
+ * WHY IT IS CUT. A caret parked inside the marker's own separator — `>| text`,
+ * `-|  item` — splits that separator in two. The half after the caret travels
+ * down with the text, because that is what a line break does; writing a whole
+ * separator at the head of the new line therefore lands one space more than the
+ * user typed, every time, and it accumulates on every Enter. Copying only the
+ * half already behind the caret makes the two halves add back up to exactly the
+ * separator that was there.
+ *
+ * The marker's CHARACTERS are never cut: the caret is past them or `blockEnter`
+ * would not have got here. So an ordered marker still counts up and a task box
+ * still resets, and only their trailing whitespace is rationed.
+ *
+ * CodeMirror writes the whole separator here and does land the extra space
+ * (`commands.ts` walks `from` back over whitespace BEFORE the caret, which is a
+ * different case). It is a small thing to see and an easy one to fix, so this
+ * is one of the few places worth diverging.
+ */
+function markerUpTo(marker: string, markerColumn: number, column: number): string {
+	const separator = TRAILING_SEPARATOR.exec(marker)?.[0].length ?? 0;
+	return marker.slice(0, marker.length - separator + (column - markerColumn));
+}
+
 /** Is this whole marker an ordered one? The one question `nextMarker` asks. */
 const ORDERED_ONLY = new RegExp(String.raw`^${ORDERED_MARKER}$`);
 
@@ -103,38 +166,93 @@ function nextMarker(marker: string): string {
  *
  * `continue` is the ordinary case: the text to put at the head of the new line,
  * after the line break. `clear` is the escape hatch every Markdown editor has
- * and this one needs most — an item with a marker and no text is how a list
+ * and this one needs most — a block with a marker and no text is how that block
  * ENDS, so Enter there takes the marker away instead of writing another one,
  * and the caller replaces the whole line with `line` rather than breaking it.
- * Without that there is no keystroke that gets a user out of a list.
+ * Without that there is no keystroke that gets a user out of a list or a quote.
  */
-export type ListEnter =
+export type BlockEnter =
 	| { readonly kind: 'continue'; readonly text: string }
 	| { readonly kind: 'clear'; readonly line: string };
 
 /**
- * Enter at `column` (1-based, as Monaco counts) of `line`, or null for "this is
- * not a list item; do whatever Enter normally does".
- *
- * A caret still inside the marker answers null too. Enter with the caret at the
- * very start of `- item` means "make room above me", and a continuation there
- * would write its marker in front of the one already on the line.
+ * A line that is a block quote and nothing else: `> text`, at any depth and
+ * under any indentation. Anchored at the start, so a `>` in the middle of a
+ * sentence is prose.
  */
-export function listEnter(line: string, column: number): ListEnter | null {
-	const item = parseListItem(line);
-	if (!item || column < item.contentColumn) return null;
+const QUOTE_LINE = new RegExp(String.raw`^([ \t]*)((?:${QUOTE_MARKER})+)(.*)$`);
 
-	if (item.content.trim() === '') {
-		// The prefix is kept when it carries a block quote (`> - ` empties to
-		// `> `, staying in the quote the user is writing) and dropped when it is
-		// only indentation, which would otherwise leave a line of trailing
-		// spaces behind on every list a user finishes.
-		return { kind: 'clear', line: item.prefix.trim() === '' ? '' : item.prefix };
+
+/**
+ * Enter on a line whose whole marker is the quote — #700.
+ *
+ * The quote is copied rather than normalised, for the reason the list's spacing
+ * is: `>  text` is a document someone typed that way, and answering it with
+ * `> ` rewrites their file on a keystroke that was supposed to add a line. Both
+ * implementations read for #700 normalise instead — CodeMirror to one space,
+ * Markdown All in One to a hard-coded `> ` — but neither preserves a
+ * hand-aligned LIST either, and agreeing with this app's own lists is worth
+ * more here than agreeing with them.
+ *
+ * An empty quote clears to nothing rather than one level shallower. That is the
+ * list rule, not a new one — `- [ ] ` clears the box AND the bullet in one
+ * keystroke, never the box alone — and it is what makes the way out of `> > `
+ * one Enter instead of one per level.
+ */
+function quoteEnter(line: string, column: number): BlockEnter | null {
+	const match = QUOTE_LINE.exec(line);
+	if (!match) return null;
+
+	const [, indent, marker, content] = match;
+	const from = markerColumn(indent, marker);
+	if (column < from) return null;
+	if (content.trim() === '') return { kind: 'clear', line: '' };
+	return { kind: 'continue', text: markerUpTo(`${indent}${marker}`, from, column) };
+}
+
+/**
+ * Enter at `column` (1-based, as Monaco counts) of `line`, or null for "this is
+ * not a list item or a quote; do whatever Enter normally does".
+ *
+ * A caret still inside a marker does NOT answer null on its own — it answers
+ * whatever the enclosing block says. Enter with the caret at the very start of
+ * `- item` means "make room above me", so the list branch declines and nothing
+ * else claims the line; Enter at `> |- item` also declines the list, but the
+ * quote still owns that caret, and the tail moving down keeps its `> `.
+ *
+ * WHAT THIS FUNCTION CANNOT SEE: a fence. `- item` inside a ``` block is the
+ * same six characters as `- item` outside one, and the difference lives in the
+ * lines above, which never reach here — nor does the caller check, so a list or
+ * a quote inside a code block is continued as if it were prose. That is not new
+ * with the quote branch; it is where lists have always stood. Nothing public in
+ * Monaco answers "is this line code" without re-tokenizing every line above the
+ * caret, which is 27 ms at 2 000 lines and 275 ms at 20 000 — a price Enter, of
+ * all keys, cannot pay. Whoever fixes it has to reach Monaco's own incremental
+ * tokens or this app's semantic layer first.
+ */
+export function blockEnter(line: string, column: number): BlockEnter | null {
+	const item = parseListItem(line);
+	// The separator between the marker and the text belongs to neither: see
+	// `markerColumn`. For a task item the marker runs through the box, so what
+	// is subtracted is the space after the BOX, not the one before it.
+	const listMarker = `${item?.marker}${item?.spacing}${item?.box ?? ''}${item?.boxSpacing ?? ''}`;
+	const from = item ? markerColumn(item.prefix, listMarker) : 0;
+	if (item && column >= from) {
+		if (item.content.trim() === '') {
+			// The prefix is kept when it carries a block quote (`> - ` empties to
+			// `> `, staying in the quote the user is writing) and dropped when it
+			// is only indentation, which would otherwise leave a line of trailing
+			// spaces behind on every list a user finishes.
+			return { kind: 'clear', line: item.prefix.trim() === '' ? '' : item.prefix };
+		}
+
+		// A checked box never propagates: the new item is something still to do.
+		// `boxSpacing` can be empty when the box ended the line, and a `- [ ]`
+		// with no space after it is not a task item to any renderer.
+		const box = item.box ? `[ ]${item.boxSpacing || ' '}` : '';
+		const marker = `${item.prefix}${nextMarker(item.marker)}${item.spacing}${box}`;
+		return { kind: 'continue', text: markerUpTo(marker, from, column) };
 	}
 
-	// A checked box never propagates: the new item is something still to do.
-	// `boxSpacing` can be empty when the box ended the line, and a `- [ ]` with
-	// no space after it is not a task item to any renderer.
-	const box = item.box ? `[ ]${item.boxSpacing || ' '}` : '';
-	return { kind: 'continue', text: `${item.prefix}${nextMarker(item.marker)}${item.spacing}${box}` };
+	return quoteEnter(line, column);
 }

--- a/src/lib/utils/listSyntax.ts
+++ b/src/lib/utils/listSyntax.ts
@@ -52,6 +52,15 @@ export const LIST_MARKER = String.raw`(?:${BULLET_MARKER}|${ORDERED_MARKER})`;
 export const TASK_BOX = String.raw`\[[ xX]\]`;
 
 /**
+ * One level of block quote: the `>` and whatever separates it from what follows.
+ *
+ * A fragment of its own because a quote is TWO things to this app — the prefix a
+ * list item may be nested inside, and, since #700, a block Enter continues on
+ * its own. Both spellings were `>[ \t]*` and a second copy is how they drift.
+ */
+export const QUOTE_MARKER = String.raw`>[ \t]*`;
+
+/**
  * What may stand between the start of a line and the marker: indentation, then
  * any depth of block-quote nesting.
  *
@@ -60,4 +69,4 @@ export const TASK_BOX = String.raw`\[[ xX]\]`;
  * every task in a CRLF document to the previous line (#148). See the call site
  * in documentSession.svelte.ts for the full account.
  */
-export const LIST_MARKER_PREFIX = String.raw`[ \t]*(?:>[ \t]*)*`;
+export const LIST_MARKER_PREFIX = String.raw`[ \t]*(?:${QUOTE_MARKER})*`;


### PR DESCRIPTION
## What this is

Enter on a block quote writes the next line's `>`, and Enter on a quote with
nothing after the marker takes it away. Closes #700, reported by @17Archangel,
who asked for the behaviour lists already have — "回车两次再取消掉".

It also changes one thing about lists, deliberately: see *Scope*.

## Mechanism

`utils/listSyntax.ts` has always spelled the list-marker prefix
`[ \t]*(?:>[ \t]*)*`, so `>` was understood — as the thing a list item can be
nested *inside*. `listEnter` asked `parseListItem` and nothing else, and that
pattern needs a `-`, `*` or `1.` to match at all. `> quoted` is a line with a
prefix and no marker, so it parsed as no block, and Enter fell through to
Monaco's own.

The module answers for both blocks now and is named for it (`blockEnter`), with
`QUOTE_MARKER` factored out beside the fragments the prefix already used.

### Where the caret joins the block

The interesting decision is not "does a quote continue" but "from which
column". Measuring to where the marker's TEXT starts — the obvious rule, and
the one the list branch used — answers two opposite things for one gesture:

```
"> text"    caret just after the `>`   ->  inside a two-character marker
">text"     caret just after the `>`   ->  head of the content
```

Same pixel, same keystroke, and the user cannot see which spelling they are in
without counting spaces. So the boundary is the end of the marker's
*characters* instead, and both answer "continue". That is CodeMirror's rule,
reached for the same reason — `@codemirror/lang-markdown`'s `commands.ts`
declines only when `inner.to - inner.spaceAfter.length > pos`, subtracting
exactly that whitespace.

### The separator, once instead of twice

A caret parked inside the separator splits it. The half after the caret rides
down with the text, because that is what a line break does, so a new marker
carrying a whole separator lands one space more than was typed — and another on
every Enter after that, which is what the reporter would have hit first:

```
"- item", caret between `-` and its space, Enter five times
  before   "-  item" -> "-   item" -> "-    item" -> ...
  after    "- item"  -> "- item"   -> "- item"
```

`markerUpTo` rations the separator to the half already behind the caret, so the
two halves add back up to what was there. The marker's characters are never
rationed: an ordered marker still counts up (`9.` -> `10.`) and a task box still
comes back unchecked.

## Alternatives considered

**Suppressing continuation inside fenced code.** Built and then removed. `- item`
inside a ```` ```diff ```` block is prose-shaped text in somebody's code and
continuing it is wrong, and `utils/pasteContext.ts` already answers "is the
caret in code" for Ctrl+V, so the guard was four lines. It costs
`monaco.editor.tokenize()` over every line above the caret: **5.5 ms at 500
lines, 27 ms at 2 000, 275 ms at 20 000** (Monarch's own markdown grammar,
realistic prose). Ctrl+V has paid that since it shipped because a paste is one
keystroke in a while; Enter is every second keystroke of a paragraph. Nothing
public in Monaco is cheaper — `ITextModel.getLineTokens` is internal, and the
encoded tokens it holds have lost the type strings this needs (a bare fence's
body encodes as `Other`, indistinguishable from prose), while this app's own
semantic layer arrives a tick late inside Monaco's sparse store. CodeMirror
*does* bail on `FencedCode`, cheaply, because it has a Lezer tree to resolve
against; we do not. So lists and quotes are both still continued inside a fence,
as lists always have been, and `listEditing.ts` says so with the numbers.

**Declining `>text`, as VS Code's Markdown All in One does**
(`/^> /.test(textBeforeCursor)`). It sidesteps the caret problem above rather
than answering it, and it cannot be copied here: comrak renders `>text` as a
quote — `semantic_spans` returns `quote.marker` for it, exactly as for
`> text` — so Enter would be disagreeing with the preview drawn beside it.

**Normalising the separator.** CodeMirror collapses it to one space, Markdown
All in One writes a hard-coded `> `. Neither preserves a hand-aligned list
either, and this app does (`-   item` continues as `-   `), so `>   quoted`
keeps its spacing for the same reason.

**Trimming the whitespace behind the caret**, which CodeMirror does before
breaking (`while (from > line.from && /\s/...) from--`). It would make the
abandoned line byte-identical whichever side of the separator Enter is pressed,
and `render.hardbreaks` means trailing spaces carry no meaning here, so nothing
would break. Left out anyway: the line it cleans is one nobody can see the
difference in, and Enter quietly deleting characters to the left of the caret is
more than this key was asked to do.

## Scope

**Lists change too.** The boundary and the separator rule are one implementation
for both blocks, so `-|  item` now continues instead of dropping out of the
list, and `- [x]|  task` continues from after the box. That is the same defect
one marker over; fixing it only for quotes would leave quotes one column more
forgiving than lists with nothing to point at for why.

Not touched: Tab and Shift+Tab, which read the same lines through
`parseListItem` and have their own reasons to; the fence blind spot above; and
the empty-quote ladder, which stays at one Enter per block rather than
CodeMirror's and Markdown All in One's two empty `>` lines — the reporter asked
for the list's two-Enter exit and this app's lists give it.

## Tests

`scripts/listContinuation.test.ts`: 968 -> 969 node tests, all green, plus
`npm run check` (815 files, 0 errors), `npm run test:vitest` (398), `npm audit`
(0), `cargo test`.

The pure function is CALLED, once per shape: every quote depth and spelling,
the caret at each column across the marker of a quote, a bullet, an ordered
item and a task item, and the split-doubling case as a before/after pair. The
two `Editor.svelte` handlers are lifted out and run against the stub editor as
before, so the edits asserted are the real ones.

Reverting each half with the tests left in place: the quote branch -> 5 red;
the boundary -> the caret and doubling tests red; both restored -> green.

## Verification

`npm audit`, `npm run check`, `npm test`, `npm run test:vitest`,
`cd src-tauri && cargo test` — all pass locally.

Driven by hand in a release build on macOS 15 (Apple silicon): every case above,
plus Enter held down on a quote and on a list to watch the separator stay one
space wide.

Not verified: Windows and Linux — the reporter is on Windows 10 — and that
Monaco delivers Enter to this handler at runtime, which no test here can
establish. What is pinned instead is the `when` clause the app declares.
