### PR TITLE
Tab on a list item is a level, not a tabSize

### DIFF
--- a/scripts/keymapHarness.ts
+++ b/scripts/keymapHarness.ts
@@ -6,7 +6,7 @@ import { KeyCode } from 'monaco-editor/esm/vs/editor/common/standalone/standalon
 import { KeyMod } from 'monaco-editor/esm/vs/editor/common/services/editorBaseApi.js';
 import ts from 'typescript';
 
-import { blockEnter, parseListItem } from '../src/lib/utils/listEditing.js';
+import { blockEnter, parseListItem, shiftListItem } from '../src/lib/utils/listEditing.js';
 import { tableOperation, tableStep } from '../src/lib/utils/tableEditing.js';
 import { viewerCommandFor, type KeyContext, type ViewerCommand } from '../src/lib/utils/viewerKeymap.js';
 import { readSource, functionSource } from './sourceTree.js';
@@ -473,6 +473,7 @@ export function runEditorHandler(
 	const scope: Record<string, unknown> = {
 		blockEnter,
 		parseListItem,
+		shiftListItem,
 		tableStep,
 		tableOperation,
 		monaco: { Range: FakeRange, Selection: FakeRange },

--- a/scripts/listContinuation.test.ts
+++ b/scripts/listContinuation.test.ts
@@ -4,7 +4,7 @@ import test from 'node:test';
 import { KeyCode } from 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js';
 import { KeyMod } from 'monaco-editor/esm/vs/editor/common/services/editorBaseApi.js';
 
-import { blockEnter, parseListItem } from '../src/lib/utils/listEditing.js';
+import { blockEnter, parseListItem, shiftListItem } from '../src/lib/utils/listEditing.js';
 import { bareCommands, runEditorHandler } from './keymapHarness.js';
 import { functionSource, readSource } from './sourceTree.js';
 
@@ -237,6 +237,95 @@ test('parseListItem reports where the marker ends', () => {
 	assert.equal('  > - [x]  do it'.slice(item.contentColumn - 1), 'do it');
 });
 
+// ----------------------------------------------------- #711: the level, run
+
+/** A document of literal lines — the two methods `shiftListItem` asks for. */
+const docOf = (lines: string[]) => ({
+	getLineCount: () => lines.length,
+	getLineContent: (line: number) => lines[line - 1],
+});
+
+/** Tab (or Shift+Tab) on `line`, as the lines it writes back. Null is "no level to move to". */
+function shift(lines: string[], line: number, back = false): string[] | null {
+	const edit = shiftListItem(docOf(lines), line, 1, back);
+	return edit ? [...edit.lines] : null;
+}
+
+test('Tab nests to the parent’s content column, which is not tabSize', () => {
+	// #711 verbatim: Enter continued `1. something` as `2. `, and Tab has to put
+	// that line INSIDE the item above it. Under `1. ` that column is 3 — with
+	// tabSize at 2 the old Tab wrote two spaces, which CommonMark reads as the
+	// next sibling, so the user got neither the nesting nor the number.
+	assert.deepEqual(shift(['1. something', '2. '], 2), ['   1. ']);
+	// Four under `10. `, and two under a bullet: the column is the marker’s width,
+	// so it is a different number for every list.
+	assert.deepEqual(shift(['10. a', '11. b'], 2), ['    1. b']);
+	assert.deepEqual(shift(['- a', '- b'], 2), ['  - b']);
+	// The box travels with the item and stays checked: this key moves an item, it
+	// does not re-open a task the way Enter opens a new one.
+	assert.deepEqual(shift(['- [ ] a', '- [x] b'], 2), ['  - [x] b']);
+});
+
+test('the item that moves starts its sub-list at 1, and the list it left closes up', () => {
+	// Both halves of the renumbering, in one edit: `3. c` becomes the first item
+	// of a nested list, and `4. d` — which is now the parent list’s third item —
+	// stops claiming to be its fourth.
+	assert.deepEqual(shift(['1. a', '2. b', '3. c', '4. d'], 3), ['   1. c', '3. d']);
+	// The same in reverse: an item that leaves a sub-list takes the number of the
+	// list it rejoins.
+	assert.deepEqual(shift(['1. a', '   1. b', '   2. c'], 3, true), ['2. c']);
+});
+
+test('a list that starts at five keeps starting at five', () => {
+	// The divergence from Markdown All in One, which renumbers a list’s first
+	// item too and would rewrite this list to 1, 2, 3 on a Tab three lines away.
+	// A first item is the one item whose number the renderer reads, so it is the
+	// one item nobody may quietly overwrite.
+	assert.deepEqual(shift(['5. a', '6. b', '7. c'], 2), ['   1. b', '6. c']);
+	// Including when it is the line that moved: this one was a list’s start
+	// before the key and is a list’s start after it.
+	assert.deepEqual(shift(['   3. orphan'], 1, true), ['3. orphan']);
+});
+
+test('a level that does not exist is not invented', () => {
+	// The first item of a list has nothing to nest under, and an item at the
+	// margin has nothing to fall back to. Both answer null, and the handler turns
+	// that into a key that does nothing rather than one that inserts whitespace.
+	assert.equal(shift(['1. a', '2. b'], 1), null);
+	assert.equal(shift(['1. a', '   - x'], 2), null, 'already the first item of its sub-list');
+	assert.equal(shift(['1. a', '2. b'], 2, true), null);
+});
+
+test('a quoted list is indented inside the quote, not in front of it', () => {
+	// What Markdown All in One cannot do and Obsidian still gets wrong in
+	// callouts: the `>` stays where it is and the indentation goes after it.
+	assert.deepEqual(shift(['> 1. a', '> 2. b'], 2), ['>    1. b']);
+	assert.deepEqual(shift(['> 1. a', '>    1. b', '>    2. c'], 3, true), ['> 2. c']);
+});
+
+test('the renumbering stops where the list does', () => {
+	// A blank line and a paragraph at the margin end a list, and the list AFTER
+	// them is a different list — its `1.` must not be counted as this one’s third
+	// item. `endLine` is the last line that actually changed, so the undo step and
+	// the dirty-diff cover the move and nothing else.
+	const edit = shiftListItem(docOf(['1. a', '2. b', '', 'text', '', '1. new']), 2, 1, false);
+	assert.deepEqual(edit, {
+		startLine: 2,
+		endLine: 2,
+		lines: ['   1. b'],
+		caretLine: 2,
+		caretColumn: 4,
+	});
+});
+
+test('the caret keeps its place in the text it was in', () => {
+	// Column 7 is in front of `bcd`; after a three-column indent it is column 10,
+	// still in front of `bcd`. Losing that is how a level change stops being a
+	// level change and starts being a jump.
+	const edit = shiftListItem(docOf(['1. a', '2. bcd']), 2, 7, false);
+	assert.deepEqual(edit?.caretColumn, 10);
+});
+
 // ------------------------------------------------- the handlers, actually run
 //
 // The two handlers are lifted out of the component and run against a stub
@@ -251,7 +340,15 @@ test('parseListItem reports where the marker ends', () => {
 
 const EDITOR = 'src/lib/components/Editor.svelte';
 
-const TAB_HANDLER = ['soleCaret', 'applyTableEdit', 'stepTableCell', 'handleTabKey'];
+const TAB_HANDLER = ['soleCaret', 'applyLineEdit', 'stepTableCell', 'shiftListLevel', 'handleTabKey'];
+
+const SHIFT_TAB_HANDLER = [
+	'soleCaret',
+	'applyLineEdit',
+	'stepTableCell',
+	'shiftListLevel',
+	'handleShiftTabKey',
+];
 
 const ENTER_HANDLER = ['continueListOnEnter'];
 
@@ -331,19 +428,33 @@ test('a selection, or a second caret, gets the plain Enter', () => {
 	assert.deepEqual(multi.triggers, ['type:"\\n"']);
 });
 
-test('Tab on a list item indents the line; Tab anywhere else is a Tab', () => {
-	// `editor.action.indentLines` moves the whole line by one level wherever the
-	// caret is on it; the core `tab` command inserts indentation AT the caret,
-	// which inside an item's text would be a tab character in the sentence.
+test('Tab on a list item is the list module’s edit, and Tab anywhere else is a Tab', () => {
+	// The handler no longer sends `editor.action.indentLines`: that command moves
+	// the line by `tabSize`, which is not a nesting level, and leaves the number
+	// alone — both halves of #711. What it sends now is one `executeEdits` built
+	// from `shiftListItem`, and nothing else, because a trigger AND an edit would
+	// indent the line twice.
+	const run = runEditorHandler(TAB_HANDLER, {
+		lines: ['1. something', '2. ', '3. c'],
+		selections: [[2, 4, 2, 4]],
+	});
+	assert.deepEqual(run.triggers, [], 'a core command fired as well as the edit');
+	assert.deepEqual(run.edits, [{ range: [2, 1, 3, 5], text: '   1. \n2. c', cursor: [2, 7, 2, 7] }]);
+	assert.equal(run.undoStops, 1, 'one Ctrl+Z must give the level back');
+
+	// A LIST ITEM’S TAB NEVER FALLS THROUGH. The first item of a list has nothing
+	// to nest under, so the key does nothing — handing it to `indentLines` would
+	// indent a line that no longer nests anywhere, which is the state #711’s
+	// reporter was left in.
 	for (const line of ['- item', '  1. item', '> - [x] item', '- ']) {
-		const run = runEditorHandler(TAB_HANDLER, { lines: [line], selections: [[1, 3, 1, 3]] });
-		assert.deepEqual(run.triggers, ['editor.action.indentLines'], line);
-		assert.deepEqual(run.edits, [], line);
+		const alone = runEditorHandler(TAB_HANDLER, { lines: [line], selections: [[1, 3, 1, 3]] });
+		assert.deepEqual(alone.triggers, [], line);
+		assert.deepEqual(alone.edits, [], line);
 	}
 
 	for (const line of ['plain text', '# heading', '']) {
-		const run = runEditorHandler(TAB_HANDLER, { lines: [line], selections: [[1, 1, 1, 1]] });
-		assert.deepEqual(run.triggers, ['tab'], JSON.stringify(line));
+		const prose = runEditorHandler(TAB_HANDLER, { lines: [line], selections: [[1, 1, 1, 1]] });
+		assert.deepEqual(prose.triggers, ['tab'], JSON.stringify(line));
 	}
 
 	// A selection spans lines on purpose or by accident; Monaco's own Tab
@@ -353,6 +464,32 @@ test('Tab on a list item indents the line; Tab anywhere else is a Tab', () => {
 		selections: [[1, 1, 2, 6]],
 	});
 	assert.deepEqual(selected.triggers, ['tab']);
+});
+
+test('Shift+Tab on a list item is the list’s level, not Monaco’s outdent', () => {
+	const run = runEditorHandler(SHIFT_TAB_HANDLER, {
+		lines: ['1. a', '   1. b', '   2. c'],
+		selections: [[3, 10, 3, 10]],
+	});
+	assert.deepEqual(run.triggers, [], 'outdent fired as well as the edit');
+	// It rejoins the list it left, so it is that list’s second item and not `1.`.
+	assert.deepEqual(run.edits, [{ range: [3, 1, 3, 8], text: '2. c', cursor: [3, 7, 3, 7] }]);
+
+	// Prose still gets Monaco’s own outdent.
+	for (const line of ['plain text', '']) {
+		const fallback = runEditorHandler(SHIFT_TAB_HANDLER, { lines: [line], selections: [[1, 1, 1, 1]] });
+		assert.deepEqual(fallback.triggers, ['outdent'], JSON.stringify(line));
+		assert.deepEqual(fallback.edits, [], JSON.stringify(line));
+	}
+
+	// A list item at the margin has no level to give up, and — like Tab’s first
+	// item — does not fall through either. `outdent` on a line with no
+	// indentation does nothing anyway; what the swallow rules out is the day a
+	// list item carries indentation Monaco would happily eat a `tabSize` of,
+	// leaving the item nested under nothing.
+	const margin = runEditorHandler(SHIFT_TAB_HANDLER, { lines: ['1. a'], selections: [[1, 1, 1, 1]] });
+	assert.deepEqual(margin.triggers, []);
+	assert.deepEqual(margin.edits, []);
 });
 
 // ------------------------------------------------------------- the when clauses
@@ -413,11 +550,13 @@ test('Shift+Tab still means outdent everywhere except inside a table', () => {
 	// and said in its own failure message that one may only appear if it does more
 	// than outdent.
 	//
-	// Tables are that "more": there is no core command for "previous cell". So the
-	// binding exists now, and what is pinned instead is the SAME decision one
-	// level in — the handler's non-table path re-sends `outdent` rather than
-	// reimplementing it, so a list item, a code block and a paragraph all still
-	// get exactly Monaco's own behaviour.
+	// Tables were the first "more": there is no core command for "previous cell".
+	// #711 is the second — a level is not a `tabSize`, and an item that leaves a
+	// sub-list has to take the number of the list it rejoins. So the binding
+	// exists now, and what is pinned instead is the SAME decision two branches in:
+	// the handler's LAST path re-sends `outdent` rather than reimplementing it, so
+	// a code block, a paragraph and an item already at the margin all still get
+	// exactly Monaco's own behaviour.
 	const handler = functionSource(readSource(EDITOR), 'handleShiftTabKey');
 	assert.match(
 		handler,

--- a/scripts/tableEditing.test.ts
+++ b/scripts/tableEditing.test.ts
@@ -569,10 +569,10 @@ test('a table operation outside a table does nothing', () => {
  * Naming the collaborators is what keeps this honest: a stub `stepTableCell`
  * would let a Tab handler that had stopped looking at tables pass.
  */
-const TAB = ['soleCaret', 'applyTableEdit', 'stepTableCell', 'handleTabKey'];
-const SHIFT_TAB = ['soleCaret', 'applyTableEdit', 'stepTableCell', 'handleShiftTabKey'];
-const MOD_ENTER = ['soleCaret', 'applyTableEdit', 'editTable', 'handleModEnterKey'];
-const MOD_SHIFT_ENTER = ['soleCaret', 'applyTableEdit', 'editTable', 'handleModShiftEnterKey'];
+const TAB = ['soleCaret', 'applyLineEdit', 'stepTableCell', 'shiftListLevel', 'handleTabKey'];
+const SHIFT_TAB = ['soleCaret', 'applyLineEdit', 'stepTableCell', 'shiftListLevel', 'handleShiftTabKey'];
+const MOD_ENTER = ['soleCaret', 'applyLineEdit', 'editTable', 'handleModEnterKey'];
+const MOD_SHIFT_ENTER = ['soleCaret', 'applyLineEdit', 'editTable', 'handleModShiftEnterKey'];
 
 test('Tab in a table writes the re-aligned table in one edit, and no plain Tab', () => {
 	const run = runEditorHandler(TAB, { lines: [...INSERTED], selections: [[4, 26, 4, 26]] });
@@ -624,20 +624,33 @@ test('Shift+Tab in the first cell moves the caret and writes nothing', () => {
 	assert.deepEqual(run.selections, [[1, 4, 1, 4]]);
 });
 
-test('Shift+Tab outside a table is Monaco’s own outdent', () => {
-	for (const line of ['plain text', '  - a nested list item', '']) {
+test('Shift+Tab outside a table and outside a list is Monaco’s own outdent', () => {
+	for (const line of ['plain text', '']) {
 		const run = runEditorHandler(SHIFT_TAB, { lines: [line], selections: [[1, 1, 1, 1]] });
 		assert.deepEqual(run.triggers, ['outdent'], JSON.stringify(line));
 		assert.deepEqual(run.edits, [], JSON.stringify(line));
 	}
+
+	// A list item stopped falling through with #711: `outdent` moves the line by
+	// `tabSize`, which lands on a level only by coincidence, and it renumbers
+	// nothing. The middle branch owns it now — table, then list, then the key.
+	const item = runEditorHandler(SHIFT_TAB, {
+		lines: ['  - a nested list item'],
+		selections: [[1, 1, 1, 1]],
+	});
+	assert.deepEqual(item.triggers, []);
+	assert.deepEqual(item.edits, [{ range: [1, 1, 1, 23], text: '- a nested list item', cursor: [1, 1, 1, 1] }]);
 });
 
 test('Tab on a list item is still the list’s Tab, and Tab in prose is still a Tab', () => {
 	// The dispatch order this feature had to fit into: table, then list, then the
 	// key's own meaning. #636 owns the middle branch and must not have moved.
-	const list = runEditorHandler(TAB, { lines: ['- item'], selections: [[1, 3, 1, 3]] });
-	assert.deepEqual(list.triggers, ['editor.action.indentLines']);
-	assert.deepEqual(list.edits, []);
+	// #711 changed what the middle branch DOES — one `executeEdits` from
+	// `shiftListItem` instead of `editor.action.indentLines` — but not where it
+	// sits, which is what this file is about.
+	const list = runEditorHandler(TAB, { lines: ['- a', '- item'], selections: [[2, 3, 2, 3]] });
+	assert.deepEqual(list.triggers, []);
+	assert.deepEqual(list.edits, [{ range: [2, 1, 2, 7], text: '  - item', cursor: [2, 5, 2, 5] }]);
 
 	const prose = runEditorHandler(TAB, { lines: ['plain text'], selections: [[1, 1, 1, 1]] });
 	assert.deepEqual(prose.triggers, ['tab']);

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -12,7 +12,7 @@
 		type InlineWrapToolId,
 		type LineMarkerToolId,
 	} from '../utils/editorToolbar.js';
-	import { blockEnter, parseListItem } from '../utils/listEditing.js';
+	import { blockEnter, parseListItem, shiftListItem, type ListEdit } from '../utils/listEditing.js';
 	import { tableOperation, tableStep, type TableEdit, type TableOperation } from '../utils/tableEditing.js';
 	import { editorOptionsFromSettings } from '../utils/editorOptions.js';
 	import { markdownTokenRules, semanticTokenRules } from '../utils/editorTheme.js';
@@ -1082,15 +1082,17 @@
 	};
 
 	/**
-	 * Replace a table with its re-aligned self and put the caret in the cell the
-	 * edit names. Every table operation ends here, because every one of them
-	 * changes a column's width and therefore has to redraw the pipes.
+	 * Replace a run of lines with what a Markdown edit says they should be, and
+	 * put the caret where it says. Every table operation ends here, because every
+	 * one of them changes a column's width and therefore has to redraw the pipes;
+	 * so does every list level change (#711), which renumbers the items the moved
+	 * one left behind and is therefore a run of lines rather than one line.
 	 *
 	 * An edit that changes nothing but the caret — Shift+Tab in the first cell of
 	 * an already-aligned table — moves the caret WITHOUT an edit, so it does not
 	 * push an undo step that undoes nothing.
 	 */
-	const applyTableEdit = (edit: TableEdit, source: string) => {
+	const applyLineEdit = (edit: TableEdit | ListEdit, source: string) => {
 		const model = editor.getModel();
 		if (!model) return;
 
@@ -1122,7 +1124,7 @@
 		if (!caret) return false;
 		const step = tableStep(caret.model, caret.line, caret.column, back);
 		if (!step) return false;
-		applyTableEdit(step, "table-step");
+		applyLineEdit(step, "table-step");
 		return true;
 	};
 
@@ -1136,40 +1138,54 @@
 		if (!caret) return false;
 		const edit = tableOperation(caret.model, caret.line, caret.column, operation);
 		if (!edit) return false;
-		applyTableEdit(edit, `table-${operation}`);
+		applyLineEdit(edit, `table-${operation}`);
 		return true;
 	};
 
 	/**
-	 * Tab: the next cell of a table, else a list item's nesting level, else a Tab.
+	 * Tab / Shift+Tab on a list item: the level, decided by `shiftListItem` in
+	 * utils/listEditing.ts, where it can be tested without a browser.
 	 *
-	 * `editor.action.indentLines` rather than a hand-written edit, and that is
-	 * also what makes Tab mean the level and not the caret: the core `tab` command
-	 * inserts indentation AT the caret, so a Tab in the middle of an item's text
-	 * would drop a tab character into the sentence.
+	 * A LIST ITEM'S TAB NEVER FALLS THROUGH, not even when the edit is refused.
+	 * On a list item this key means the level and only the level, and the two
+	 * refusals are both "there is no other level": Tab on the first item of a
+	 * list, which has nothing to nest under, and Shift+Tab on an item already at
+	 * the margin. Handing those to `indentLines` or `outdent` would move the line
+	 * by `tabSize` into a column that nests under nothing — which is half of
+	 * #711 — so the key does nothing instead, as it does in every outliner.
 	 */
+	const shiftListLevel = (back: boolean) => {
+		const caret = soleCaret();
+		if (!caret || !parseListItem(caret.model.getLineContent(caret.line))) return false;
+		const edit = shiftListItem(caret.model, caret.line, caret.column, back);
+		if (edit) applyLineEdit(edit, back ? "list-outdent" : "list-indent");
+		return true;
+	};
+
+	/** Tab: the next cell of a table, else a list item's nesting level, else a Tab. */
 	const handleTabKey = () => {
 		if (stepTableCell(false)) return;
-		const caret = soleCaret();
-		const onListItem = !!caret && parseListItem(caret.model.getLineContent(caret.line)) !== null;
-		editor.trigger("keyboard", onListItem ? "editor.action.indentLines" : "tab", null);
+		if (shiftListLevel(false)) return;
+		editor.trigger("keyboard", "tab", null);
 	};
 
 	/**
-	 * Shift+Tab: the previous cell of a table, else Monaco's own `outdent`.
+	 * Shift+Tab: the previous cell of a table, else a list item's level, else
+	 * Monaco's own `outdent`.
 	 *
-	 * THE FALL-THROUGH IS THE POINT. Shift+Tab was left unbound on purpose when
-	 * the list keys landed, because `outdent` already had the chord and already
-	 * took one indent level off the current line wherever the caret sat on it —
-	 * a command of ours in front of it would have been a second name for a key
-	 * that was already right. Tables need the chord for something `outdent` does
-	 * not do, so this handler takes it and hands it straight back everywhere
-	 * except inside a table: `outdent` remains what Shift+Tab means, including on
-	 * a list item, and `scripts/listContinuation.test.ts` still pins that against
-	 * the installed Monaco rather than against this comment.
+	 * IT USED TO BE A PURE FALL-THROUGH, and the reason it no longer is, is #711.
+	 * `outdent` takes `tabSize` columns off the line wherever the caret sits on
+	 * it, which was close enough to right while nothing renumbered — but a level
+	 * is not a `tabSize`, and an item that leaves a sub-list has to take the
+	 * number of the list it rejoins. Both are `shiftListItem`'s, in the same
+	 * function as Tab's, because they are the same edit with the sign flipped.
+	 *
+	 * `outdent` remains what the chord means on every line that is not a list
+	 * item, which is what the third line preserves.
 	 */
 	const handleShiftTabKey = () => {
 		if (stepTableCell(true)) return;
+		if (shiftListLevel(true)) return;
 		editor.trigger("keyboard", "outdent", null);
 	};
 

--- a/src/lib/utils/listEditing.ts
+++ b/src/lib/utils/listEditing.ts
@@ -256,3 +256,352 @@ export function blockEnter(line: string, column: number): BlockEnter | null {
 
 	return quoteEnter(line, column);
 }
+
+/* ---------------------------------------------------------------- #711: Tab
+
+ * Changing an item's LEVEL, which is two edits and not one.
+ *
+ * `editor.action.indentLines` — what Tab did until #711 — moves the line by the
+ * editor's `tabSize` and leaves the number alone. Both halves of that are wrong
+ * in Markdown, and each is wrong on its own:
+ *
+ *   1. NESTING IS A COLUMN, NOT A TAB. An item nests inside the one above it
+ *      only when its indentation reaches that item's CONTENT column: 2 for
+ *      `- `, 3 for `1. `, 4 for `10. `. With `tabSize` at 2 under a `1. ` parent
+ *      the line moves and nothing nests — CommonMark reads it as the next
+ *      sibling, which is what #711's reporter saw.
+ *   2. THE NUMBER SUDDENLY MATTERS. In a flat list the numbers after the first
+ *      are ignored: `1. / 7. / 3.` renders 1, 2, 3, because a list's start comes
+ *      from its FIRST item and the renderer counts from there. Tab moves a line
+ *      to exactly the one position where its number is read — the first item of
+ *      a new sub-list — so the `2.` that Enter wrote, and that had been
+ *      invisible all along, renders as `2.`.
+ *
+ * So Tab has to indent to the parent's content column AND renumber, and the
+ * renumbering cannot stop at the moved line: the siblings it left behind in the
+ * parent list are now 1, 3, 4.
+ *
+ * WHAT IS COPIED FROM MARKDOWN ALL IN ONE, AND WHAT IS NOT
+ *
+ * The shape is `vscode-markdown`'s (`src/listEditing.ts`: `indent()` +
+ * `fixMarker()`), which is the de-facto standard for this key — its adaptive
+ * indentation is the same "align to the parent's marker width" rule, and its
+ * `lookUpwardForMarker` is the same upward scan for a sibling. Three deliberate
+ * divergences:
+ *
+ *   - MAIO's sibling test compares the caret's indentation against the previous
+ *     item's DIGITS (`prevLeadingSpace + prevMarker`), not against its content
+ *     column, so under `1. x` it reads indentation 2 as nested when CommonMark
+ *     needs 3. That is invisible in MAIO because MAIO only ever writes 3, and
+ *     very visible here, where every document already carries the indentation
+ *     the old Tab produced.
+ *   - MAIO renumbers a list's FIRST item too, so `5. 6. 7.` — a list that
+ *     legitimately starts at 5 — silently becomes 1, 2, 3 on a Tab elsewhere in
+ *     the document. Here the number is only forced on the line the user is
+ *     moving; a first item nobody touched keeps what it says, and every scan
+ *     that fails to find a sibling therefore degrades to "leave it alone"
+ *     rather than to "write 1".
+ *   - Block quotes are respected. MAIO has no concept of them, which is the
+ *     same defect Obsidian still has inside callouts, and this app has had
+ *     quote-aware list handling since #700.
+ *
+ * WHAT IS NOT SUPPORTED, STATED RATHER THAN DISCOVERED
+ *
+ *   - A CHILD DOES NOT TRAVEL WITH ITS PARENT. Tab on an item that already has
+ *     a sub-list under it moves one line, so the sub-list is left at what is now
+ *     its parent's own level and becomes its sibling. MAIO behaves the same way;
+ *     Obsidian, whose editor holds a real tree, moves the subtree. Doing it here
+ *     means deciding where an item's children END, which is the fenced-code
+ *     problem `blockEnter` documents one function up.
+ *   - THE WALK IS O(LIST), not O(edit). Every ordered item below the moved one
+ *     is re-derived, because one of them changing can change the next; only the
+ *     lines that actually differ end up in the edit, but all of them are read.
+ *     Measured on a flat ordered list: 2 ms at 500 items, 5 ms at 5 000, 22 ms
+ *     at 20 000. Tab is not Enter — it moves a whole line and the user expects
+ *     the document to change — so this stays until a list long enough to feel it
+ *     turns up in a real document.
+ *   - THE SEPARATOR AFTER THE MARKER IS NOT RE-PADDED. Renumbering `10.` to `9.`
+ *     shortens the marker by one column, so text hand-aligned under it is off by
+ *     one until the user fixes it. MAIO pads the separator to hold the content
+ *     column still; this module keeps the separator the user typed, which is the
+ *     rule the whole module already follows.
+ */
+
+/**
+ * The two things this module asks of a document — the shape Monaco's
+ * `ITextModel` already has, so `Editor.svelte` passes the model itself and a
+ * test passes an object literal. `utils/tableEditing.ts` asks for the same two
+ * for the same reason: a scan outward from the caret is O(list), where
+ * `getLinesContent()` would be O(document) on every keystroke.
+ */
+export type ListDocument = {
+	getLineCount(): number;
+	getLineContent(line: number): string;
+};
+
+/**
+ * A replacement for one line range, and where the caret goes in it.
+ *
+ * Deliberately the same record as `TableEdit`: both keys end at the same
+ * `executeEdits` in `Editor.svelte`, and giving them one shape is what lets that
+ * be one function instead of two.
+ */
+export type ListEdit = {
+	/** 1-based inclusive line range to replace. */
+	readonly startLine: number;
+	readonly endLine: number;
+	/** The lines as they should be. `lines[0]` is the line that moved. */
+	readonly lines: readonly string[];
+	readonly caretLine: number;
+	readonly caretColumn: number;
+};
+
+/**
+ * A tab stop, in columns. CommonMark's own figure: a tab advances to the next
+ * multiple of four, which is not the same as "four columns" once a space
+ * precedes it.
+ */
+const TAB_STOP = 4;
+
+/** How many columns `text` occupies, counting a tab to the next tab stop. */
+function columnsOf(text: string): number {
+	let width = 0;
+	for (const character of text) {
+		width = character === '\t' ? width + TAB_STOP - (width % TAB_STOP) : width + 1;
+	}
+	return width;
+}
+
+/**
+ * The block-quote markers a line opens with, separated from the indentation
+ * that follows them.
+ *
+ * Each `>` takes AT MOST ONE space with it, which is the rule that makes the
+ * split meaningful: in `>   - item` the quote is `> ` and the list is indented
+ * by two, so the item is nested inside the quote's list rather than sitting at
+ * its margin. `LIST_MARKER_PREFIX` cannot answer this on its own — its
+ * `QUOTE_MARKER` is greedy and swallows all three spaces.
+ */
+const QUOTE_PREFIX = /^(?:[ \t]*>[ \t]?)*/;
+
+function splitQuote(prefix: string): { quote: string; indent: string } {
+	const quote = QUOTE_PREFIX.exec(prefix)?.[0] ?? '';
+	return { quote, indent: prefix.slice(quote.length) };
+}
+
+/** The leading whitespace and quote markers of ANY line, list item or not. */
+const LINE_PREFIX = new RegExp(String.raw`^(${LIST_MARKER_PREFIX})`);
+
+/**
+ * One line, reduced to what the two scans below ask about it.
+ *
+ * `indent` and `content` are columns INSIDE the quote — measured from after the
+ * last `>` — because that is where a quoted list's own margin is.
+ */
+type Row = {
+	readonly depth: number;
+	readonly indent: number;
+	/** The column an item's content starts at; `indent` again when there is none. */
+	readonly content: number;
+	readonly blank: boolean;
+	readonly item: ListItem | null;
+	/** The ordered marker's number, or null for a bullet and for a non-item. */
+	readonly number: number | null;
+};
+
+function rowOf(line: string): Row {
+	const item = parseListItem(line);
+	const { quote, indent } = splitQuote(item ? item.prefix : (LINE_PREFIX.exec(line)?.[1] ?? ''));
+	const depth = (quote.match(/>/g) ?? []).length;
+	const indentWidth = columnsOf(indent);
+
+	return {
+		depth,
+		indent: indentWidth,
+		content: item ? columnsOf(`${indent}${item.marker}${item.spacing}`) : indentWidth,
+		blank: line.trim() === '',
+		item,
+		number: item && ORDERED_ONLY.test(item.marker) ? Number(item.marker.slice(0, -1)) : null,
+	};
+}
+
+/** An item's line, rebuilt with a different prefix and a different marker. */
+function rebuild(item: ListItem, prefix: string, marker: string): string {
+	return `${prefix}${marker}${item.spacing}${item.box ?? ''}${item.boxSpacing}${item.content}`;
+}
+
+/** The same item wearing a different number, delimiter and spacing untouched. */
+function withNumber(item: ListItem, number: number): string {
+	return rebuild(item, item.prefix, `${number}${item.marker.slice(-1)}`);
+}
+
+/**
+ * The item this one follows at its own level, or null when it is the first of
+ * its list — which is the one question renumbering asks.
+ *
+ * A blank line is skipped: a loose list is still one list. A line that is NOT a
+ * list item ends the scan only when it is no deeper than the caret's own
+ * indentation, so an item's own wrapped paragraph is scanned past and the prose
+ * before the list is not.
+ *
+ * `lineAt` rather than the document, because the cascade below has already
+ * rewritten some of these lines and every later scan has to see the rewrite.
+ */
+function siblingAbove(
+	lineAt: (line: number) => string,
+	from: number,
+	depth: number,
+	indent: number,
+): Row | null {
+	for (let line = from - 1; line >= 1; line--) {
+		const row = rowOf(lineAt(line));
+		if (row.blank) continue;
+		if (row.depth !== depth) return null;
+
+		if (row.item) {
+			// Reaching that item's content column means it is the PARENT, so
+			// there is no sibling above and this line is the first of its list.
+			if (indent >= row.content) return null;
+			if (indent >= row.indent) return row;
+			// Deeper than this line: something nested inside an earlier sibling.
+			continue;
+		}
+
+		if (row.indent <= indent) return null;
+	}
+	return null;
+}
+
+/**
+ * The indentation, in columns, the line should move to — null for "it cannot
+ * move", which is a key that does nothing rather than a key that inserts
+ * whitespace.
+ *
+ * Tab looks for the SIBLING above and takes its content column: nesting under a
+ * previous item is the only thing indenting a list item can mean, so the first
+ * item of a list has nowhere to go (Tab there is a no-op in Obsidian and in
+ * every outliner). Shift+Tab looks for the PARENT and takes its margin, which
+ * lands the line on a level that exists rather than `tabSize` columns to the
+ * left of one.
+ */
+function targetIndent(doc: ListDocument, line: number, here: Row, back: boolean): number | null {
+	for (let above = line - 1; above >= 1; above--) {
+		const row = rowOf(doc.getLineContent(above));
+		if (row.blank) continue;
+		if (row.depth !== here.depth) break;
+
+		if (row.item) {
+			if (here.indent >= row.content) return back ? row.indent : null;
+			if (!back && here.indent >= row.indent) return row.content;
+			continue;
+		}
+
+		if (row.indent <= here.indent) break;
+	}
+
+	// Nothing above owns this line. Shift+Tab still has somewhere to go if the
+	// line is indented at all; Tab has nothing to nest under.
+	return back && here.indent > 0 ? 0 : null;
+}
+
+/**
+ * The shallowest column an ordered item's content can start at, and therefore
+ * the shallowest a line can be indented and still be INSIDE one: `1. ` is three
+ * columns. Used to end the downward walk — after a blank line, a line shallower
+ * than this is a new block, and the list it follows is over.
+ */
+const LIST_CONTENT_MIN = 3;
+
+/**
+ * Tab / Shift+Tab on a list item: the line at its new level, with every ordered
+ * number that the move invalidated rewritten. Null when the line is not a list
+ * item, or when it has no level to move to.
+ *
+ * THE RANGE IS AS SHORT AS THE EDIT. The walk downward continues past lines it
+ * does not change — an item's own paragraphs, a nested bullet list — but the
+ * range ends at the last line that actually differs, so the undo step and the
+ * dirty-diff cover what moved and nothing else.
+ */
+export function shiftListItem(
+	doc: ListDocument,
+	line: number,
+	column: number,
+	back: boolean,
+): ListEdit | null {
+	const source = doc.getLineContent(line);
+	const item = parseListItem(source);
+	if (!item) return null;
+
+	const here = rowOf(source);
+	const target = targetIndent(doc, line, here, back);
+	if (target === null || target === here.indent) return null;
+
+	const edited = new Map<number, string>();
+	const lineAt = (at: number) => edited.get(at) ?? doc.getLineContent(at);
+
+	const { quote } = splitQuote(item.prefix);
+	const prefix = `${quote}${' '.repeat(target)}`;
+
+	// The moved line is the one line whose number may be FORCED, because it is
+	// the one line that has just changed what its number MEANS: an item with a
+	// sibling above it is counted by the renderer, and an item without one starts
+	// a list at whatever it says. Landing without a sibling therefore writes 1 —
+	// unless the line had no sibling before the move either, in which case it was
+	// already a list's start and `5.` is a start, not a mistake.
+	const sibling = siblingAbove(lineAt, line, here.depth, target);
+	const first = sibling?.number == null;
+	const started = first && siblingAbove(lineAt, line, here.depth, here.indent) === null;
+	const number = first ? (started ? here.number : 1) : sibling!.number! + 1;
+	const marker = here.number === null ? item.marker : `${number}${item.marker.slice(-1)}`;
+	const shifted = rebuild(item, prefix, marker);
+	edited.set(line, shifted);
+
+	const lines = [shifted];
+	let last = line;
+	let afterBlank = false;
+
+	for (let below = line + 1; below <= doc.getLineCount(); below++) {
+		const text = doc.getLineContent(below);
+		const row = rowOf(text);
+
+		if (row.blank) {
+			afterBlank = true;
+			lines.push(text);
+			continue;
+		}
+		if (row.depth !== here.depth) break;
+		if (afterBlank && row.indent < LIST_CONTENT_MIN && !row.item) break;
+		afterBlank = false;
+
+		if (row.number === null) {
+			lines.push(text);
+			continue;
+		}
+
+		// No sibling means this item is the first of its own list, and a first
+		// item nobody moved keeps the number it says: `5. 6. 7.` is a list that
+		// starts at five, not a list that is wrong.
+		const previous = siblingAbove(lineAt, below, row.depth, row.indent);
+		const fixed =
+			previous?.number == null || previous.number + 1 === row.number
+				? text
+				: withNumber(row.item!, previous.number + 1);
+		if (fixed !== text) {
+			edited.set(below, fixed);
+			last = below;
+		}
+		lines.push(fixed);
+	}
+
+	// The caret keeps its place in the text: everything before the content moved
+	// by the same amount, so the caret does too.
+	const head = prefix.length + marker.length - item.prefix.length - item.marker.length;
+
+	return {
+		startLine: line,
+		endLine: last,
+		lines: lines.slice(0, last - line + 1),
+		caretLine: line,
+		caretColumn: Math.max(1, column + head),
+	};
+}


### PR DESCRIPTION
## What this is

Closes #711, reported by @eli-yip against 2.7.4 on Windows 11: after Enter continues `1. something` as `2. `, Tab produces `  2. ` instead of starting the nested list at `  1. `.

Tab on a list item now nests it inside the item above it and renumbers; Shift+Tab is the same edit with the sign flipped, so an item leaving a sub-list takes the number of the list it rejoins.

```
before                     after
1. something               1. something
␣␣2.                       ␣␣␣1.
3. c                       2. c
```

## Mechanism

Tab sent `editor.action.indentLines`, which moves the line by the editor's `tabSize` and does not touch the marker. Two independent CommonMark rules make each half wrong on its own:

1. **Nesting is a column, not a tab.** An item nests inside the one above only when its indentation reaches that item's *content* column — 2 for `- `, 3 for `1. `, 4 for `10. `. With `tabSize` at 2 under a `1. ` parent the line moves two columns and nothing nests; the renderer reads the next sibling, which is the state the reporter was left in. At `tabSize` 4 it does nest, which is when the second rule bites.
2. **The number suddenly matters.** In a flat list every number after the first is ignored — `1. / 7. / 3.` renders 1, 2, 3, because the start comes from the first item and the renderer counts from there. Tab moves a line to the one position where its number *is* read: the first item of a new sub-list. So the `2. ` that Enter wrote, invisible for as long as the item stayed flat, renders as `2.`.

Rendered through `marked` from `node_modules`, which is the same CommonMark rule comrak follows:

```
1. something\n   2. b   →   <ol><li>something<ol start="2"><li>b
1. something\n   1. b   →   <ol><li>something<ol><li>b
```

That is also why Enter's own numbering has never shown a defect: at a flat position the number it writes is not read by anything.

`shiftListItem` in `utils/listEditing.ts` is the whole decision as a pure function of the document and the caret — the shape `blockEnter` and `tableEditing.ts` already have, so `node --test` runs it and `Editor.svelte` keeps a keybinding and one `executeEdits`. It does the three edits that make up one level change: indent to the parent's content column, renumber the moved line, and renumber the siblings it left behind in the parent list.

## What was considered and rejected

**Indent by `tabSize` and renumber separately.** The smaller diff, and it leaves half of #711 in place: at `tabSize` 2 the item still fails to nest, so the renumbering has nothing to renumber. The width has to come from the parent's marker.

**Markdown All in One's rules verbatim.** The shape is MAIO's (`indent()` + `fixMarker()`), which is the de-facto standard for this key in VS Code, and its "adaptive" indentation is the same rule. Three divergences, each because MAIO gets away with something this app cannot:

- MAIO's sibling test compares the caret's indentation against the previous item's *digits*, not against its content column, so under `1. x` it reads indentation 2 as nested where CommonMark needs 3. Invisible in MAIO, which only ever writes 3; very visible here, where existing documents already carry the 2-space indentation the old Tab produced.
- MAIO renumbers a list's *first* item too, so a list that legitimately starts at `5.` becomes `1.` on a Tab elsewhere in the document. Here the number is only forced on the line the user is moving, and every scan that finds no sibling leaves the number alone. `5. 6. 7.` survives.
- MAIO has no concept of block quotes — the same defect Obsidian still has inside callouts (forum.obsidian.md/t/99212). This app has had quote-aware list handling since #700, so the `>` stays put and the indentation goes after it.

**Renumbering nothing, i.e. leaving Tab as a whitespace key.** CodeMirror 6's `lang-markdown` does exactly that: it has `renumberList`, but binds it to Enter and Backspace and ships no Tab command at all. That is a coherent position — and not one this app can take, because #604 already gave Tab the list meaning. Binding the key and then not renumbering is the only combination that is wrong in both directions.

## Scope

Deliberately left alone, all stated in the module comment:

- **A child does not travel with its parent.** Tab on an item that already has a sub-list moves one line, so the sub-list becomes its sibling. MAIO behaves the same way; Obsidian moves the subtree because it holds a real tree. Doing it here means deciding where an item's children end, which is the fenced-code-block problem `blockEnter` documents one function up.
- **The separator after the marker is not re-padded.** Renumbering `10.` to `9.` shortens the marker by a column, so text hand-aligned under it is off by one. MAIO pads the separator to hold the content column still; this module keeps the separator the user typed, which is the rule it already follows for Enter.
- **A multi-line selection still gets Monaco's own Tab**, which indents every line and renumbers none. One edit at the primary selection would drop what the other carets were doing.
- **The walk is O(list), not O(edit)**: every ordered item below the moved one is re-derived, because one changing can change the next. 2 ms at 500 items, 5 ms at 5 000, 22 ms at 20 000 — Tab moves a whole line and the user expects the document to change, so this is not Enter's latency budget.
- **Enter is untouched.** `blockEnter` still writes `2. ` after `1. x`; that answer is correct at the position Enter leaves it in.

A list item's Tab no longer falls through to a core command at all. The two refusals — Tab on the first item of a list, Shift+Tab on an item already at the margin — are both "there is no other level", and handing them to `indentLines` or `outdent` would move the line into a column that nests under nothing, which is half of the reported defect. The key does nothing instead, as it does in Obsidian and in every outliner.

## Tests

`npm test` 979 pass / 0 fail; `npm run check` 0 errors; `cargo test` 164 pass; `npm audit` 0 vulnerabilities.

Nine new cases in `scripts/listContinuation.test.ts`: seven call `shiftListItem` directly (the reported case verbatim, parents of width 2/3/4, the cascade, a list that starts at five, quoted lists, the list boundary, the caret, both refusals), two run the extracted handlers against the stub editor and assert the edit rather than the trigger. `scripts/tableEditing.test.ts` keeps its dispatch-order assertions — table, then list, then the key — with the middle branch's new payload.

**Reverting the fix and keeping the tests:** with the two handlers restored to `indentLines` / `outdent` and everything else left in place, 4 of the 82 tests in those two files go red. The pure cases cannot be run against the old code at all — the function they call did not exist — so what they pin is the new behaviour, not the old defect.

## Verification

Built as a desktop test app on macOS 15 (Apple silicon) and driven by hand: the reported sequence, a `10.`-wide parent, `5. 6. 7.`, Shift+Tab back out, and a list inside a block quote.

Not verified: Windows and Linux, which is where the report came from — nothing here touches platform code, but the keybinding guards (`!editorTabMovesFocus`, `!suggestWidgetVisible`) are only reasoned about, not run, on any platform. `npm run test:vitest` fails 14 tests on my machine (tabs, window tags, settings persistence) and does so identically on a clean checkout of 5e245cb, so it is neither this branch nor master — CI's `test` job runs the same suite and is green here. Local environment, and not chased down as part of this.
