### PR TITLE
The snap publish step calls a command snapcraft still has

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -173,4 +173,18 @@ jobs:
           SNAP_FILE="${snaps[0]}"
 
           gh release upload "$TAG" "$SNAP_FILE" --clobber
-          snapcraft push "$SNAP_FILE" --release stable
+
+          # `upload`, not `push`. snapcraft 8 turned the old name into a hard
+          # error -- "The 'push' command was renamed to 'upload'", exit 64 --
+          # and the step above installs whatever `snap install snapcraft
+          # --classic` currently serves, so the command this line calls stopped
+          # existing without a commit here.
+          #
+          # It last worked on 2026-06-03: markpad 2.6.11, revision 15, which is
+          # still what the Snap Store serves. Every run after that died earlier,
+          # in the build, and the swallowing this workflow's header describes
+          # reported it as success. #561 removed that and #577/#579 fixed the
+          # build, so v2.7.4 was the first release to reach this line -- and it
+          # failed here, in run 31775835301, after packing
+          # markpad_2.7.4_amd64.snap green.
+          snapcraft upload "$SNAP_FILE" --release stable

--- a/scripts/releaseWorkflow.test.ts
+++ b/scripts/releaseWorkflow.test.ts
@@ -273,10 +273,18 @@ test('a package manager is not published from inside the platform matrix', () =>
 	// Matched on the push commands rather than on step names, because the
 	// property is "the build matrix has no irreversible external effect", and a
 	// renamed step would still have one.
+	//
+	// `snapcraft upload` was `snapcraft push` here until snapcraft 8 removed
+	// that name. Worth being honest about what this assertion is: it pins the
+	// string the workflow uses, so it went on passing for the whole time the
+	// command it named did not exist. Nothing runnable from `npm test` can
+	// check the other half -- the tool is installed by the job, from the store,
+	// at release time. See publish-packages.yml.
+	assert.doesNotMatch(workflow, /snapcraft (pack|push|upload)/);
 	assert.doesNotMatch(workflow, /choco push/);
-	assert.doesNotMatch(workflow, /snapcraft (pack|push)/);
 	assert.match(publishWorkflow, /choco push/);
-	assert.match(publishWorkflow, /snapcraft push/);
+	assert.match(publishWorkflow, /snapcraft upload/);
+	assert.doesNotMatch(publishWorkflow, /snapcraft push/);
 });
 
 test('package managers are published from a release a human published', () => {
@@ -418,7 +426,7 @@ test('the package managers we recommend are the ones we publish to', () => {
 	const releaseBody = sliceBetween(workflow, "echo '## Download'", 'RELEASE_BODY');
 	for (const [name, install, push] of [
 		['Chocolatey', /choco install markpad-app/, /choco push/],
-		['Snap', /snap install markpad/, /snapcraft push/],
+		['Snap', /snap install markpad/, /snapcraft upload/],
 	] as const) {
 		const publishes = push.test(publishWorkflow);
 		assert.equal(

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,6 +28,7 @@ website: https://markpad.sftwr.dev
 donation: https://github.com/sponsors/alecdotdev
 source-code: https://github.com/sftwrdotdev/Markpad
 issues: https://github.com/sftwrdotdev/Markpad/issues
+contact: https://github.com/sftwrdotdev/Markpad/issues
 
 confinement: strict
 base: core24
@@ -44,6 +45,12 @@ apps:
       - network-bind
       - wayland
       - home
+      # `home` reaches $HOME and nothing else, so a note kept on a USB stick or
+      # a second-drive mount is invisible to the app, with no way for the user
+      # to grant it. This does not auto-connect -- it takes one
+      # `sudo snap connect markpad:removable-media` -- but without the plug
+      # declared here there is nothing to connect. #562.
+      - removable-media
 
 parts:
   # The snap packages the .deb the release already shipped. It does not build


### PR DESCRIPTION
## What is broken

v2.7.4 shipped on 2026-08-14. The Snap Store still serves **2.6.11, revision 15, from 2026-06-03** — six versions and eleven days behind, and nobody has reported it, because from outside a stale snap looks identical to a current one: snapd checks daily and tells the user they are up to date.

The snap job in [run 31775835301](https://github.com/sftwrdotdev/Markpad/actions/runs/31775835301) got further than any run since June. It built:

```
Packed markpad_2.7.4_amd64.snap
gh release upload …                       ← the .snap is on the v2.7.4 release page
snapcraft push … --release stable
  The 'push' command was renamed to 'upload'.
  Recommended resolution: Use 'upload' instead.
  exit 64
```

`snapcraft push` has been in the workflow since February and last succeeded on 2026-06-03. snapcraft 8 turned the old name from a warning into a hard error; the job runs `snap install snapcraft --classic`, so it takes whatever the store serves and the command it calls stopped existing with no commit here.

It stayed hidden because the build failed first and the swallowed error reported success. #561 removed the swallowing, #577 and #579 fixed the build — which is what let v2.7.4 reach this line at all.

## What changes

`push` → `upload`. Same arguments; only the command was renamed.

Two assertions in `releaseWorkflow.test.ts` matched on the literal `snapcraft push`, so they were updated. Worth being explicit about their limit, since it is the reason 972 passing tests said nothing: they pin the string this repository writes, not the command the tool has. Nothing runnable from `npm test` can check the second half — snapcraft is installed by the job, from the store, at release time. That is recorded in the test rather than left to be rediscovered.

## And the decision this was waiting on: the snap stays

@alecdotdev posted the Metrics tab in #562. Reading it against the table in that issue:

```
Weekly active devices — by version, past year
     ┌ 100 ─────────────────────────────────
 173 │            2.6.11 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ← today
 137 │      ╭────────────▓ 137
     └──────┴──────────────────────────────┘
          Jun 7                        Aug 22
```

~170, which is the "three figures or more, keep it" branch. The stronger half is the slope: the figure rose about 25% across the three months the channel was dead, with no version churn to explain it. That is not people who have not uninstalled — those are new installs, arriving now, landing on a June build. Waiting a week after 2.7.4 to re-read the number, as I suggested in that thread, is no longer necessary; the shape answers it.

So this also does the follow-up that branch attached to keeping the snap:

- **`removable-media`.** `home` reaches `$HOME` and nothing else, so a note on a USB stick or a second-drive mount was invisible to the app with no way for the user to grant it. It does not auto-connect — it takes one `sudo snap connect markpad:removable-media` — but without the plug declared there is nothing to connect.
- **`contact:`**, the one metadata warning the linter reports in the pack.

The other half of that branch, "stop recompiling", was #579.

## What this does not do

Nothing moves the check earlier. #601 removed the pull-request snap check, so `snapcraft.yaml` and this job are still first executed against a tag that has already been published — this defect is exactly that arrangement's failure mode, and the fix does not change it. Raised in #562, not re-argued here.

It also does not recover 2.7.4. Once this merges, `publish-packages.yml` → Run workflow → `v2.7.4` uploads the snap that is already attached to that release; the Chocolatey job checks the feed, finds `markpad-app` 2.7.4 published, and skips itself, which is what that check was added for.

Tests: 980 pass. Both edited assertions were checked by reverting the command and watching them fail.
