### PR TITLE
feat(editor): ${filename} in the image directory, so a folder can belong to one document (#714)

### DIFF
--- a/scripts/imageEmbed.test.ts
+++ b/scripts/imageEmbed.test.ts
@@ -7,6 +7,7 @@ import {
 	documentParentDir,
 	encodeImageDestination,
 	imageEmbed,
+	resolveImageDirectory,
 } from '../src/lib/utils/imageEmbed.js';
 import { resolveDocumentRelativePath } from '../src/lib/utils/markdown.js';
 import { readSource } from './sourceTree.js';
@@ -179,6 +180,33 @@ test('documentParentDir refuses a path with no directory in it', () => {
 	assert.equal(documentParentDir('note.md'), null);
 });
 
+test('${filename} expands to the document name, so each document can own its images', () => {
+	assert.equal(
+		resolveImageDirectory('${filename}.assets', '/home/u/notes/trip.md'),
+		'trip.assets',
+	);
+	assert.equal(
+		resolveImageDirectory('${filename}.assets', 'C:\\notes\\trip.md'),
+		'trip.assets',
+	);
+	// The extension comes off at the last dot; a leading dot is a name, not an
+	// extension.
+	assert.equal(resolveImageDirectory('${filename}', '/n/archive.tar.md'), 'archive.tar');
+	assert.equal(resolveImageDirectory('${filename}', '/n/.gitignore'), '.gitignore');
+	// No token, no expansion: the setting stays the literal folder name it has
+	// always been, and an empty one still means the default.
+	assert.equal(resolveImageDirectory('img', '/n/trip.md'), 'img');
+	assert.equal(resolveImageDirectory('', '/n/trip.md'), DEFAULT_IMAGE_DIRECTORY);
+});
+
+test('a $ in the document name is not read as a replacement pattern', () => {
+	// `String.replace` reads `$&` and `$'` in the *replacement* as the match and
+	// the text after it, so a document named `$&.md` would have written the
+	// literal token back out and created a folder called `${filename}.assets`.
+	assert.equal(resolveImageDirectory('${filename}.assets', '/n/$&.md'), '$&.assets');
+	assert.equal(resolveImageDirectory('${filename}', "/n/$'.md"), "$'");
+});
+
 test('Editor.svelte writes an image link through this module only', () => {
 	// The two call sites — paste (`save_image`) and drop (`copy_file_to_img`) —
 	// carried verbatim copies of this logic 300 lines apart, and the space-only
@@ -189,4 +217,13 @@ test('Editor.svelte writes an image link through this module only', () => {
 	assert.equal(source.includes('%20'), false, 'a hand-rolled space escape is back');
 	assert.match(source, /imageEmbed\(relPath\)/);
 	assert.equal(source.includes(`|| "${DEFAULT_IMAGE_DIRECTORY}"`), false);
+	// Three call sites read the image directory — paste, drop, and the path
+	// completion that lists the folder's contents. Expanding `${filename}` at
+	// two of them and not the third would offer completions out of a folder
+	// named after the literal token, which exists nowhere.
+	assert.equal(
+		source.includes('settings.imageDirectory ||'),
+		false,
+		'a call site resolves the image directory itself',
+	);
 });

--- a/scripts/imageUndoKeepsFile.spec.ts
+++ b/scripts/imageUndoKeepsFile.spec.ts
@@ -64,7 +64,7 @@ const { lineEndingLabel } = await import('../src/lib/utils/tabModels.js');
 const { countWords } = await import('../src/lib/utils/wordCount.js');
 // The real module, not a stub: the embed these tests match against is the one
 // it writes, and its escaping is pinned separately in imageEmbed.test.ts.
-const { DEFAULT_IMAGE_DIRECTORY, documentParentDir, imageEmbed } = await import(
+const { documentParentDir, imageEmbed, resolveImageDirectory } = await import(
 	'../src/lib/utils/imageEmbed.js'
 );
 
@@ -238,7 +238,7 @@ type Component = {
  * the statements that run are the component's own.
  */
 const factorySource = ts.transpileModule(
-	`const __component = (invoke, settings, tabManager, monaco, editor, lineEndingLabel, countWords, DEFAULT_IMAGE_DIRECTORY, documentParentDir, imageEmbed) => {
+	`const __component = (invoke, settings, tabManager, monaco, editor, lineEndingLabel, countWords, resolveImageDirectory, documentParentDir, imageEmbed) => {
 		let wordCount = 0;
 		let currentLanguage = 'markdown';
 		let lineEnding = 'LF';
@@ -309,7 +309,7 @@ function createComponent(backend: Backend, editor: unknown): Component {
 		editor: unknown,
 		lineEndingLabel: unknown,
 		countWords: unknown,
-		defaultImageDirectory: unknown,
+		resolveImageDir: unknown,
 		parentDir: unknown,
 		embed: unknown,
 	) => Component;
@@ -322,7 +322,7 @@ function createComponent(backend: Backend, editor: unknown): Component {
 		editor,
 		lineEndingLabel,
 		countWords,
-		DEFAULT_IMAGE_DIRECTORY,
+		resolveImageDirectory,
 		documentParentDir,
 		imageEmbed,
 	);

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -40,9 +40,9 @@
 		type BufferLine,
 	} from '../utils/lineCoordinates.js';
 	import {
-		DEFAULT_IMAGE_DIRECTORY,
 		documentParentDir,
 		imageEmbed,
+		resolveImageDirectory,
 	} from '../utils/imageEmbed.js';
 
 	// Monaco is ~86% of the startup JavaScript (a 4.4 MB chunk, ~360ms of
@@ -685,8 +685,10 @@
 						tab.path.lastIndexOf("/"),
 					);
 					const parentDir = tab.path.substring(0, lastSlash);
-					const imgDirName =
-						settings.imageDirectory || DEFAULT_IMAGE_DIRECTORY;
+					const imgDirName = resolveImageDirectory(
+						settings.imageDirectory,
+						tab.path,
+					);
 
 					try {
 						const [currentEntries, imgEntries] = await Promise.all([
@@ -1945,8 +1947,10 @@
 					const tabPath = tabManager.activeTab.path;
 					const parentDir = documentParentDir(tabPath);
 					if (parentDir !== null) {
-						const imgDirName =
-							settings.imageDirectory || DEFAULT_IMAGE_DIRECTORY;
+						const imgDirName = resolveImageDirectory(
+							settings.imageDirectory,
+							tabPath,
+						);
 						const relPath = (await invoke("save_image", {
 							parentDir,
 							filename,
@@ -2268,7 +2272,10 @@
 		if (parentDir === null) return;
 
 		try {
-			const imgDirName = settings.imageDirectory || DEFAULT_IMAGE_DIRECTORY;
+			const imgDirName = resolveImageDirectory(
+				settings.imageDirectory,
+				tabPath,
+			);
 			const relPath = (await invoke("copy_file_to_img", {
 				srcPath: path,
 				parentDir,

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1068,6 +1068,7 @@
 								style="width: 120px;"
 								bind:value={settings.imageDirectory}
 								placeholder="img"
+								title={t('settings.imageDirectoryHint', settings.language)}
 							/>
 						</div>
 

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -118,6 +118,7 @@ export const translations: Record<LanguageCode, Translation> = {
             language: 'Language',
             highlightColor: 'Highlight Color',
             imageDirectory: 'Image Directory',
+            imageDirectoryHint: 'Folder for pasted and dropped images, created next to the document. Use ${filename} for the document\'s own name: ${filename}.assets gives every document its own folder instead of one shared img/.',
             scaleMacOSScreenshots: 'Scale macOS Screenshots',
             reduceSizeBy50: 'Reduce size by 50%',
             toolbar: 'Toolbar',

--- a/src/lib/utils/imageEmbed.ts
+++ b/src/lib/utils/imageEmbed.ts
@@ -93,3 +93,38 @@ export function encodeImageDestination(relPath: string): string {
 export function imageEmbed(relPath: string): string {
 	return `![alt](${encodeImageDestination(relPath)})`;
 }
+
+/** The one token `imageDirectory` expands. Spelled as Typora and SoloMD spell it. */
+const FILENAME_TOKEN = '${filename}';
+
+/**
+ * The folder this document's images go in: the `imageDirectory` setting, with
+ * `${filename}` standing for the document's own name.
+ *
+ * Without the token every document in a directory shares one `img/`, which is
+ * what #714 asked to be rid of: `${filename}.assets` next to `notes/trip.md`
+ * is `notes/trip.assets`, one image folder per document. The token is spelled
+ * the way Typora and SoloMD spell it, because a user arriving from either
+ * types what worked there.
+ *
+ * What comes back is a path *component*, not a path. `trip.assets` still has
+ * to pass Rust's `safe_path_component`, which refuses separators, `.`, `..`
+ * and absolute paths so the folder cannot leave the document's directory —
+ * and that guard is why this function special-cases no stem of its own. A file
+ * named `..md` expands to `.`, and Rust is the one that says no.
+ *
+ * The substitution is `split`/`join` rather than `String.replace` because the
+ * replacement is a filename the user chose: `replace` reads `$&` and `$'` in a
+ * replacement string as backreferences, so a document named `$&.md` would put
+ * `${filename}.assets` on disk verbatim.
+ */
+export function resolveImageDirectory(setting: string, documentPath: string): string {
+	const template = setting || DEFAULT_IMAGE_DIRECTORY;
+	if (!template.includes(FILENAME_TOKEN)) return template;
+	const base = documentPath.split(/[/\\]/).pop() ?? documentPath;
+	const dot = base.lastIndexOf('.');
+	// `.gitignore` is all name and no extension: only a dot with something in
+	// front of it separates the two.
+	const stem = dot > 0 ? base.slice(0, dot) : base;
+	return template.split(FILENAME_TOKEN).join(stem);
+}


### PR DESCRIPTION
Second half of #714. The session-persistence half is a separate conversation and is not touched here.

`imageDirectory` is read literally, so every document in a folder shares one `img/`. A directory of notes accumulates one flat pile of screenshots with nothing saying which document any of them belongs to, and renaming or moving a document takes none of its images with it.

## What changed

`${filename}` in that setting now expands to the document's name without its extension. `${filename}.assets` next to `notes/trip.md` writes to `notes/trip.assets`; each document gets its own folder. A setting without the token is still the literal folder name it has always been, and an empty setting still means `img`, so nothing changes for anyone who does not type the token.

Three call sites read the setting — paste (`save_image`), drop (`copy_file_to_img`), and the path completion that lists the image folder for `![](…` suggestions. All three go through one `resolveImageDirectory` now.

## Choices

**The token is spelled `${filename}` because Typora and SoloMD spell it that way.** This request comes from people migrating off those, and the string they already have in their config is `${filename}.assets`. Inventing a different spelling would mean every one of them has to be told about it.

**Rust is unchanged, and that is the safety argument, not a convenience.** The expansion produces a path *component*, not a path: `trip.assets` still goes through `safe_path_component`, which refuses separators, `.`, `..` and absolute paths, and `resolve_image_directory` still asserts the result stays inside the document's directory. That guard is also why this function special-cases no stem of its own — a document named `..md` expands to `.` and Rust is the one that refuses it, rather than a second validator in TypeScript that could disagree with the first.

**Flat templates only.** `./images/${filename}/` would require relaxing that constraint to allow separators, which is a different change with a different review. `${filename}.assets` — the form the issue asks for, and Typora's own default — needs none of it.

**Substitution is `split`/`join`, not `String.replace`.** The replacement is a filename the user chose, and `replace` reads `$&` and `$'` in a replacement string as backreferences: a document named `$&.md` would have created a folder called `${filename}.assets` on disk, containing the literal token. Pinned by a test.

**One function rather than three inline expansions.** The completion site is the one that makes this more than style: expanding at paste and drop but not there would list a directory named after the literal token, which exists nowhere, so image-path suggestions would silently return nothing for exactly the users who enabled the feature. A source assertion now fails if a call site resolves `settings.imageDirectory` by hand again.

**The hint is English-only.** The other 25 locales fall back to English, which `i18nCoverage.test.ts` documents as the supported path — the alternative is that no English string can be added without 25 translations first. It rides on the input's `title`, the tooltip pattern `FindBar.svelte` already uses; `Settings.svelte` has no description-text pattern, and inventing the first one there is a UI decision for its own PR. The placeholder stays `img` on purpose: it describes what an empty setting does, and `${filename}.assets` in that slot would say otherwise.

## Not in this change

- **Rename.** A renamed document leaves its assets folder behind under the old name. Typora moves the folder and rewrites the links; that is the larger half of per-document folders and needs its own design (what happens on a collision, on a partial move, on a folder the user has since edited).
- **Failure reporting.** A rejected or failed image write still only reaches `console.error`, as it did before for a full disk or a read-only directory. Unchanged behavior, worth fixing separately.
- **Existing images.** Nothing migrates; the setting applies to images written after it changes.

## Tests

982 `node --test` green, `svelte-check` clean. New: two behavior tests over the expansion (Windows paths, the last-dot rule, `.gitignore`-style names, no-token and empty settings, and the `$&` case) and one source assertion that no call site resolves the setting inline.
