### PR TITLE
ci(macos): a certificate without an identity stops the release, instead of shipping unsigned

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,6 +408,20 @@ jobs:
             echo "No MACOS_CERTIFICATE secret; leaving the bundle unsigned (unchanged behaviour)."
             exit 0
           fi
+
+          # The certificate is set, so this release is meant to be signed, and
+          # the early exit above no longer covers a configuration that is only
+          # half there. The identity is the value with nothing downstream to
+          # catch it: a wrong one stops `codesign` with "no identity found",
+          # while an empty one is exported as an empty APPLE_SIGNING_IDENTITY,
+          # and whether `tauri build` then errors or simply signs nothing is not
+          # this step's to know. Refusing here makes it not matter. A missing
+          # password needs no check of its own -- `security import` fails on it.
+          if [ -z "${MACOS_SIGNING_IDENTITY:-}" ]; then
+            echo "::error::MACOS_CERTIFICATE is set but MACOS_SIGNING_IDENTITY is empty. Set all three secrets or none -- RELEASING.md one-time setup step 6."
+            exit 1
+          fi
+
           KEYCHAIN="$RUNNER_TEMP/markpad-signing.keychain"
           KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
           CERTIFICATE="$RUNNER_TEMP/certificate.p12"

--- a/scripts/releaseWorkflow.test.ts
+++ b/scripts/releaseWorkflow.test.ts
@@ -424,6 +424,17 @@ test('a macOS release without the signing secrets still builds', () => {
 	assert.match(step, /echo "APPLE_SIGNING_IDENTITY=[^"]*" >> "\$GITHUB_ENV"/);
 });
 
+test('a signing identity that is only half configured stops the release', () => {
+	// The early exit above is for a repository that has never set up signing at
+	// all. It reads one of the three secrets, so a set certificate and an empty
+	// identity walks straight past it and exports an empty
+	// APPLE_SIGNING_IDENTITY -- and a green build that shipped unsigned is the
+	// exact outcome this step exists to prevent, since it reaches users as
+	// folder access being asked for all over again.
+	const step = sliceBetween(workflow, 'Import macOS signing certificate', 'Build MacOS (Universal)');
+	assert.match(step, /if \[ -z "\$\{MACOS_SIGNING_IDENTITY:-\}" \]; then[\s\S]*?exit 1/);
+});
+
 test('RELEASING.md names the signing secrets the workflow reads', () => {
 	// Whoever configures the secrets works from the runbook and never opens the
 	// workflow, so a rename on either side sends them to create a secret nothing


### PR DESCRIPTION
## What this covers

[#707](https://github.com/sftwrdotdev/Markpad/pull/707) made signing optional by reading one of its three secrets: with `MACOS_CERTIFICATE` empty the step prints a line and exits, and the release is byte-for-byte what it was. That covers a repository that never set signing up. It does not cover the configuration in between — certificate set, identity missing — which walks past that exit and exports an empty `APPLE_SIGNING_IDENTITY`.

The two halves fail differently, and only one of them is safe:

- A **wrong** identity stops `codesign` with `no identity found`, and the build goes red where anyone can see it.
- An **empty** one is never looked up at all. Whether `tauri build` errors or simply signs nothing is the pinned CLI's business, not this step's — and a green build that shipped unsigned is the exact outcome the step exists to prevent. It reaches users as folder access being asked for all over again, with nothing on the release page to show it.

## What changes

One guard, immediately after the early exit:

```bash
if [ -z "${MACOS_SIGNING_IDENTITY:-}" ]; then
  echo "::error::MACOS_CERTIFICATE is set but MACOS_SIGNING_IDENTITY is empty. Set all three secrets or none -- RELEASING.md one-time setup step 6."
  exit 1
fi
```

All three secrets or none. The password gets no guard of its own, deliberately: `security import` fails on a wrong or missing one two lines later, so a second check there would only duplicate an error that already exists. The identity is the one value with nothing downstream to catch it.

## The rest of the path is measured, not assumed

The signing step had never run on a runner — #707 was verified by re-signing an installed bundle by hand. I dispatched the full release workflow on a fork with a throwaway self-signed certificate. The macOS job went green and the `.dmg` it produced carries:

```
designated => identifier "com.alecdotdev.markpad" and certificate leaf = H"b2f627f4fbf143a7349d9b9fa8b1cff65518de47"
Authority=markpad-dryrun-codesign
flags=0x10000(runtime)
```

That leaf hash is the certificate's, not the code's, which is #209's fix in the form it will actually ship. The same run confirmed `generate-update-feed` refuses to publish a feed when a platform's signature is missing, and a `publish-packages` dispatch confirmed [#715](https://github.com/sftwrdotdev/Markpad/pull/715)'s `snapcraft upload` is accepted — it packs `markpad_2.7.4_amd64.snap` and reaches authentication, rather than the exit 64 the old `push` gave.

## Not changed

- The early exit and the test that guards it. A repository with no signing secrets still builds exactly as it does today.
- Nothing about Gatekeeper. The app stays un-notarized either way.
- `RELEASING.md`. The three secrets and the runbook are the same; this only makes a half-finished step 6 fail loudly instead of quietly.

Tests: 985 pass. The new one fails if the guard is removed (checked by removing it).
