### PR TITLE
ci(release): a build cannot write into a version that is already published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,44 @@ jobs:
         shell: bash
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
+      # `create-release` composes the release for `v<version from package.json>`,
+      # and softprops/action-gh-release documents what it does when that tag
+      # already has one: "the existing release will be updated". The matrix then
+      # uploads with `--clobber`, and `generate-update-feed` overwrites
+      # `latest.json`. So a dispatch from a master that was never bumped does not
+      # fail and does not create anything -- it rewrites the release users are
+      # downloading right now, with a build of whatever master holds today, and
+      # every gate this pipeline has is downstream of that: the draft, the asset
+      # check, and clicking Publish all come after the write.
+      #
+      # The tag and the version are two facts that nothing else compares. This
+      # compares them against the one place a released version is recorded.
+      #
+      # It fails closed. An answer that is not "no release" and not "a draft" --
+      # including a network error or a rate limit -- stops the run, because the
+      # direction this guard protects is the one where proceeding is expensive
+      # and waiting five minutes is not.
+      - name: This version has not already been released
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="v${{ steps.get_version.outputs.version }}"
+
+          if answer=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft 2>&1); then
+            if [ "$(printf '%s' "$answer" | jq -r '.isDraft')" != "true" ]; then
+              echo "::error::$TAG is already published. This run would rewrite that release's assets and its updater feed, not create a new one. Bump the version first -- npm run release X.Y.Z, RELEASING.md per-release step 1."
+              exit 1
+            fi
+            echo "::notice::$TAG already has a draft release. This run writes into it, which is the recovery path."
+          elif printf '%s' "$answer" | grep -qi 'not found'; then
+            echo "$TAG has no release yet."
+          else
+            echo "::error::Could not establish whether $TAG is already released, so this run stops rather than guess: $answer"
+            exit 1
+          fi
+
       # Every Markpad up to v2.7.0 has the pre-transfer endpoint compiled in and
       # reaches the current feed only through GitHub's transfer redirect, which a
       # repository or fork at the old location voids permanently. RELEASING.md §5

--- a/scripts/releaseWorkflow.test.ts
+++ b/scripts/releaseWorkflow.test.ts
@@ -236,6 +236,25 @@ test('the updater feed publishes the keys an installed Markpad can ask for', () 
 	}
 });
 
+test('a release build cannot write into a version that is already published', () => {
+	// The release is composed for `v<version from package.json>`, and
+	// softprops/action-gh-release updates an existing release for that tag rather
+	// than refusing it. So a dispatch from an unbumped master rewrites the
+	// release users are downloading, and every gate this pipeline has -- the
+	// draft, the asset check, clicking Publish -- is downstream of that write.
+	const step = sliceBetween(workflow, 'This version has not already been released', 'endpoint old installs');
+	assert.match(step, /gh release view "\$TAG"/);
+	assert.match(step, /isDraft/);
+	// Fails closed: an unusable answer stops the run instead of assuming there is
+	// no release. Two exits, one for published and one for cannot-tell.
+	assert.equal((step.match(/exit 1/g) ?? []).length, 2);
+	// And it has to come before the step that does the writing.
+	assert.ok(
+		workflow.indexOf('This version has not already been released') < workflow.indexOf('- name: Create Release'),
+		'the guard runs after the release it guards has been created',
+	);
+});
+
 test('the updater endpoint names the repository RELEASING.md documents', () => {
 	// The endpoint is compiled into every installed copy, so getting it wrong is
 	// only discoverable by a user who stops being offered updates. It was left


### PR DESCRIPTION
## The hazard

Cutting a release writes the version in two places that nothing compares:

```
npm run release 2.7.5   → package.json = 2.7.5    ← the workflow reads this
git tag v2.7.5          → tag          = v2.7.5   ← nothing reads this
Actions → Run workflow  → composes the release for v<package.json>
```

RELEASING.md step 2 pushes the tag by hand, but `create-release` never looks at it — it builds `tag_name: v${{ version from package.json }}` and creates the tag itself. The manual tag only happens to match.

When they don't match, the run does not fail and does not create anything. It **rewrites the previous release**:

| step | what it does to an already-published `v2.7.4` |
|---|---|
| `softprops/action-gh-release` | *"If a tag already has a GitHub release, the existing release will be updated"* |
| the matrix's `gh release upload … --clobber` | replaces that release's assets with a build of today's master |
| `generate-update-feed` | overwrites `latest.json`, which is what installed copies ask |

Every gate this pipeline has is downstream of that write. The draft, the asset check and clicking **Publish** all come after it. This is the same shape as the Chocolatey push #561 moved out of the matrix — an irreversible side effect placed before the thing that decides whether a release happens at all — except the target here is the release page itself.

It needs no exotic mistake: dispatching from master before merging the bump, or after it, is one Actions click either way, and the workflow gives the same green run for both.

## What changes

One step in `create-release`, before anything is written. It asks the one place a released version is recorded:

- **no release for that tag** → proceed, which is every normal release.
- **a draft** → proceed, and say so. Writing into a draft is the documented recovery path when one platform fails and the release is re-run.
- **published** → stop, and name the fix (`npm run release X.Y.Z`).

**It fails closed.** An answer that is neither of the first two — a network error, a rate limit — stops the run rather than assuming there is no release. That is the opposite of the legacy-endpoint check two steps below, which warns on a flake and continues; the difference is what each failure costs. That one costs a release. This one costs the last release.

## What this is not

- **Not the tag trigger.** #562 §3 asks whether pushing a tag should start the build. This deliberately does not answer that: it removes the hazard that made the two-facts problem matter, and leaves the trigger exactly as it is. Whatever the answer to that question turns out to be, this guard holds either way.
- **Not a version-number policy.** It does not check that the version went *up*, only that it is not already out. Cutting 2.7.6 before 2.7.5 is a judgement call; overwriting 2.7.4 is not.

Tests: 986 pass. The new one fails if the guard is removed (checked by removing it), and asserts it runs *before* `Create Release` rather than only that it exists.
