### PR TITLE
fix(export): the PDF re-render sends the config that keeps Mermaid labels

### DIFF
--- a/scripts/mermaidDiagramLabels.test.ts
+++ b/scripts/mermaidDiagramLabels.test.ts
@@ -90,6 +90,7 @@ const WITHOUT_A_DOM = { isSupported: DOMPurify.isSupported, sanitize: typeof DOM
 DOMPurify.sanitize = (html: string) => html;
 
 const { renderRichContent } = await import('../src/lib/utils/richContent.ts');
+const { renderDiagramsForPrint } = await import('../src/lib/utils/mermaidPrint.ts');
 const { resetDiagramCache } = await import('../src/lib/utils/diagramCache.ts');
 
 interface Corpus {
@@ -150,8 +151,16 @@ function sourceposOf(index: number): string {
 	return `${start}:1-${start + 5}:3`;
 }
 
+interface RenderedDiagrams {
+	diagrams: Map<string, ShimElement>;
+	/** The article the diagrams live in, as the export hands it to the print pass. */
+	root: ShimElement;
+	/** The same Mermaid stand-in the preview configured, singleton like the real one. */
+	mermaid: ReturnType<typeof libraries>['mermaid'];
+}
+
 /** Runs the real preview pipeline over one code block per captured diagram. */
-async function renderDiagrams(): Promise<Map<string, ShimElement>> {
+async function renderDiagrams(): Promise<RenderedDiagrams> {
 	resetDiagramCache();
 	const root = (globalThis as any).document.createElement('div');
 	root.innerHTML = Object.values(CORPUS.diagrams)
@@ -161,9 +170,10 @@ async function renderDiagrams(): Promise<Map<string, ShimElement>> {
 		)
 		.join('');
 
+	const libs = libraries();
 	await renderRichContent({
 		roots: [root as any],
-		libraries: libraries() as any,
+		libraries: libs as any,
 		mermaidTheme: 'neutral',
 		idFactory: (index: number) => `diagram-${index}`,
 		onError: (error) => assert.fail(`renderRichContent reported: ${error}`),
@@ -171,7 +181,24 @@ async function renderDiagrams(): Promise<Map<string, ShimElement>> {
 
 	const containers = root.querySelectorAll('.mermaid-diagram');
 	assert.equal(containers.length, Object.keys(CORPUS.diagrams).length, 'every code block must become a diagram');
-	return new Map(Object.keys(CORPUS.diagrams).map((name, index) => [name, containers[index]]));
+	return {
+		diagrams: new Map(Object.keys(CORPUS.diagrams).map((name, index) => [name, containers[index]])),
+		root,
+		mermaid: libs.mermaid,
+	};
+}
+
+/** Every captured label of `name`, present as SVG text under `container`. */
+function assertLabelsSurvived(name: string, container: ShimElement, what: string) {
+	assert.equal(
+		container.querySelectorAll('foreignObject').length,
+		0,
+		`${name}: ${what} carries its labels in foreignObject, whose HTML children DOMPurify removes regardless of ADD_TAGS — Mermaid must be initialized with htmlLabels: false`,
+	);
+	const labels = svgTextLabels(container);
+	for (const label of CORPUS.diagrams[name].labels) {
+		assert.ok(labels.some((text) => text.includes(label)), `${name}: "${label}" is missing from ${what}`);
+	}
 }
 
 /** The text of every SVG-native `<text>` element, which no filter touches. */
@@ -211,30 +238,59 @@ test('the captured corpus is a real before/after pair', () => {
 });
 
 test('the preview asks Mermaid for labels a sanitizer cannot delete', async () => {
-	const diagrams = await renderDiagrams();
+	const { diagrams } = await renderDiagrams();
 
-	for (const [name, diagram] of Object.entries(CORPUS.diagrams)) {
+	for (const name of Object.keys(CORPUS.diagrams)) {
 		const container = diagrams.get(name)!;
 
 		// The load-bearing assertion. `foreignObject` is the only route by which
 		// Mermaid puts HTML inside the SVG, and HTML inside an SVG is exactly what
 		// DOMPurify's HTML_INTEGRATION_POINTS check deletes — so a diagram with
 		// none of it has nothing the diagram filter can take away.
-		assert.equal(
-			container.querySelectorAll('foreignObject').length,
-			0,
-			`${name}: the rendered diagram still carries its labels in foreignObject, whose HTML children DOMPurify removes regardless of ADD_TAGS — renderRichContent must initialize Mermaid with htmlLabels: false`,
-		);
-
-		const labels = svgTextLabels(container);
-		for (const label of diagram.labels) {
-			assert.ok(labels.some((text) => text.includes(label)), `${name}: "${label}" is missing from the rendered diagram`);
-		}
+		assertLabelsSurvived(name, container, 'the rendered diagram');
 
 		// Mermaid's `<style>` carries the diagram's fills and strokes, and is the
 		// reason the diagram filter cannot be the document policy.
 		assert.equal(container.querySelectorAll('style').length, 1, `${name}: the diagram must keep its own stylesheet`);
 	}
+});
+
+/**
+ * The export re-renders every diagram with a light theme before printing, and
+ * `mermaid.initialize` replaces the site config rather than merging into it —
+ * so the print pass sends its own config, and a key the preview set does not
+ * survive into it. Sending `{startOnLoad, theme}` there put the labels straight
+ * back into `foreignObject` for the render that becomes the PDF: on screen and
+ * in an exported HTML file the diagram was fine, and its text vanished the
+ * moment the print preview appeared (#717).
+ *
+ * The stand-in answers `render()` from the config it was last initialized with,
+ * so this fails on the real symptom rather than on the spelling of a call.
+ */
+test('the PDF re-render keeps the labels the preview asked for', async () => {
+	const { diagrams, root, mermaid } = await renderDiagrams();
+
+	const restore = await renderDiagramsForPrint({
+		root: root as any,
+		mermaid: mermaid as any,
+		sanitizeSvg: (svg: string) => svg,
+		screenTheme: 'dark',
+		idFactory: (index: number) => `print-${index}`,
+		onError: (error) => assert.fail(`renderDiagramsForPrint reported: ${error}`),
+	});
+
+	for (const name of Object.keys(CORPUS.diagrams)) {
+		assertLabelsSurvived(name, diagrams.get(name)!, 'the diagram re-rendered for print');
+	}
+
+	// The restore puts the screen rendering back, and leaves the singleton
+	// configured for the screen — the next preview pass must not inherit the
+	// print config either.
+	restore();
+	for (const name of Object.keys(CORPUS.diagrams)) {
+		assertLabelsSurvived(name, diagrams.get(name)!, 'the diagram restored after print');
+	}
+	assert.equal((mermaid.config as Record<string, unknown>).htmlLabels, false, 'the restore must leave the screen config in place');
 });
 
 /**
@@ -246,7 +302,7 @@ test('the preview asks Mermaid for labels a sanitizer cannot delete', async () =
  * unannotated pixels get attributed to whatever block is nearest instead.
  */
 test('a rendered diagram answers for the source lines it replaced', async () => {
-	const diagrams = await renderDiagrams();
+	const { diagrams } = await renderDiagrams();
 
 	Object.keys(CORPUS.diagrams).forEach((name, index) => {
 		assert.equal(

--- a/scripts/mermaidPrintTheme.test.ts
+++ b/scripts/mermaidPrintTheme.test.ts
@@ -201,10 +201,13 @@ test('the PDF export wraps the print render and always restores', () => {
 	// One theme decision, shared by the screen render and the restore. Asserted
 	// as "both options are fed the same expression" rather than as the literal
 	// `currentMermaidTheme()`: what must not drift is that the two agree, and the
-	// private helper producing the value is free to be renamed or inlined.
+	// private helper producing the value is free to be renamed or inlined. The
+	// rest of the config is free too — it moved into `mermaidConfig` so the print
+	// pass could not send a different one — so the match reaches into the call
+	// rather than requiring an object literal in it.
 	assert.match(
 		richContent,
-		/mermaid\.initialize\(\{[^}]*\btheme:\s*\w+\.mermaidTheme\b/,
+		/mermaid\.initialize\([^)]*\w+\.mermaidTheme\b/,
 		'the shared renderer must use the theme it was handed, not resolve its own',
 	);
 	const screenTheme = viewer.match(/\bscreenTheme:\s*([^,\n]+),/);

--- a/src/lib/utils/mermaidPrint.ts
+++ b/src/lib/utils/mermaidPrint.ts
@@ -22,9 +22,36 @@ const SOURCE_ATTR = 'data-mermaid-source';
 
 const MERMAID_PRINT_THEME = 'neutral';
 
+export interface MermaidConfig {
+	startOnLoad: boolean;
+	theme: string;
+	htmlLabels: boolean;
+}
+
 interface MermaidRenderer {
-	initialize(config: { startOnLoad: boolean; theme: string }): void;
+	initialize(config: MermaidConfig): void;
 	render(id: string, source: string): Promise<{ svg: string }>;
+}
+
+/**
+ * The only place in the app that says how Mermaid is configured, because
+ * `initialize` is not a merge. `setSiteConfig` rebuilds the config from
+ * Mermaid's defaults on every call (`assignWithDepth({}, defaultConfig)`, then
+ * the caller's keys on top of that), so a key one caller sends is gone the
+ * moment another caller initializes without it.
+ *
+ * That is what `htmlLabels: false` is doing here. It keeps a diagram's text in
+ * the picture: with Mermaid's default every flowchart, class, state, ER,
+ * mindmap, block and kanban label is HTML inside a `<foreignObject>`, and
+ * `sanitizeDiagramSvg` — like any DOMPurify — deletes HTML children of an SVG
+ * element, so the labels arrive as empty shapes. The preview learned that in
+ * `renderRichContent`; the print re-render below did not, and re-themed the
+ * diagrams straight back into empty shapes on the way to the PDF (#717).
+ * Handing both callers the same object is what stops the two from drifting
+ * again. See scripts/mermaidDiagramLabels.test.ts for the measurement.
+ */
+export function mermaidConfig(theme: string): MermaidConfig {
+	return { startOnLoad: false, theme, htmlLabels: false };
 }
 
 /**
@@ -87,7 +114,7 @@ export async function renderDiagramsForPrint(context: PrintDiagramContext): Prom
 
 	const idFactory = context.idFactory ?? ((index: number) => `mermaid-print-${index}-${Math.floor(Math.random() * 10000)}`);
 
-	mermaid.initialize({ startOnLoad: false, theme: context.printTheme ?? MERMAID_PRINT_THEME });
+	mermaid.initialize(mermaidConfig(context.printTheme ?? MERMAID_PRINT_THEME));
 
 	for (const [index, element] of diagrams.entries()) {
 		const source = readDiagramSource(element);
@@ -106,7 +133,7 @@ export async function renderDiagramsForPrint(context: PrintDiagramContext): Prom
 	return () => {
 		if (restored) return;
 		restored = true;
-		mermaid.initialize({ startOnLoad: false, theme: context.screenTheme });
+		mermaid.initialize(mermaidConfig(context.screenTheme));
 		for (const snapshot of snapshots) {
 			snapshot.element.innerHTML = snapshot.html;
 		}

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -5,7 +5,7 @@ import {
 	storeDiagramTemplate,
 	templateDiagramSvg,
 } from './diagramCache.js';
-import { rememberDiagramSource } from './mermaidPrint.js';
+import { mermaidConfig, rememberDiagramSource } from './mermaidPrint.js';
 import { highlightedCode, renderedMath } from './richContentCache.js';
 
 /**
@@ -227,16 +227,12 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 
 	const codeBlocks = roots.flatMap((root) => selfAndDescendants(root, 'pre code'));
 
-	// `htmlLabels: false` is what keeps a diagram's text in the picture. With
-	// Mermaid's default (`true`) every label is an HTML `<div>`/`<span>` inside a
-	// `<foreignObject>`, and `sanitizeDiagramSvg` — like any DOMPurify — deletes
-	// HTML children of SVG elements outright, so the diagrams arrived as empty
-	// shapes. Turning it off makes Mermaid emit SVG `<text>`, which no sanitizer
-	// objects to. Measured against mermaid 11.16.0: this one root-level key is
-	// enough for every diagram type it ships (the per-diagram `htmlLabels` keys
-	// are deprecated in 11.x and the root one takes precedence over them).
+	// The config itself lives in `mermaidPrint.ts` — `initialize` replaces the
+	// site config rather than merging into it, so the two callers that write to
+	// this singleton have to send the same keys or the last one wins. See
+	// `mermaidConfig` for what `htmlLabels: false` is buying.
 	//
-	// Only when there is something to draw: `initialize` deep-merges and installs
+	// Only when there is something to draw: `initialize` builds and installs
 	// a site config, which measures at ~2.5ms in Chromium, and this function runs
 	// once per keystroke. A document with no diagram in it was paying that on
 	// every character. Asking first is one selector over a list already in hand.
@@ -246,7 +242,7 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 	// be a claim about a global another module also writes to.
 	const hasDiagram = codeBlocks.some((block) => block.classList.contains('language-mermaid'));
 	if (hasDiagram) {
-		mermaid.initialize({ startOnLoad: false, theme: options.mermaidTheme, htmlLabels: false });
+		mermaid.initialize(mermaidConfig(options.mermaidTheme));
 	}
 
 	let diagramIndex = 0;


### PR DESCRIPTION
## What this is

Exporting a document with a Mermaid diagram to PDF produced the diagram's
shapes with nothing in them. Not mis-coloured text — no text: the labels were
absent from the PDF and were not selectable. The same diagram on screen and in
an exported HTML file was fine. Reported by @Guardiancelte in #717 on Windows
11 / 2.7.4; it reproduces on every platform, because nothing in the mechanism
is platform-specific.

Closes #717.

## Mechanism

Paper needs a light diagram, and Mermaid bakes its theme into the SVG it emits,
so the export re-renders every diagram with the neutral theme before printing
(`renderDiagramsForPrint`). That re-render sent `{startOnLoad, theme}`.

`mermaid.initialize` is not a merge. `setSiteConfig` rebuilds the config from
Mermaid's own defaults on every call and lays the caller's keys on top:

```js
// mermaid 11.16.0, dist/chunks/mermaid.core/chunk-WYO6CB5R.mjs:4862
var setSiteConfig = (conf) => {
  siteConfig = assignWithDepth_default({}, defaultConfig);
  siteConfig = assignWithDepth_default(siteConfig, conf);
```

So `htmlLabels: false` — which the preview sends, and which is the whole reason
diagram labels survive `sanitizeDiagramSvg` — was gone for exactly the render
that becomes the PDF. With the default back in force the labels are HTML inside
a `<foreignObject>`, and DOMPurify deletes HTML children of an SVG element
whatever `ADD_TAGS` says, so what reached the printer was
`<foreignObject width="37.98" height="24"></foreignObject>`.

That is the same defect as the one fixed in the preview, on the one path that
did not go through the fixed call site. It hits flowchart, class, state, ER,
requirement, mindmap, block and kanban; sequence, gantt, pie, gitGraph and the
rest use SVG `<text>` already and were unaffected — which is why the report is
a flowchart.

Both callers now take their config from one function, rather than the second
one repeating a key it has to remember. The alternative — recolouring Mermaid's
output from the print stylesheet instead of re-rendering — was rejected when
this path was written and the reasons have not changed: the class names differ
per diagram type and drift between releases.

## Scope

Only the config the print pass sends. The print theme, the restore, the
sanitizer's allowlist and the preview are untouched.

`htmlLabels: false` is not narrowed to the diagram types that need it, though
that is where the defect is: the root key is documented as taking precedence
over the deprecated per-diagram ones, a diagram type added by a future Mermaid
release gets the safe setting for free, and the types that already use `<text>`
are unaffected by it.

## Tests

`scripts/mermaidDiagramLabels.test.ts` gains one test. It drives the real print
pass over the same captured mermaid 11.16.0 corpus the preview test uses, whose
stand-in answers `render()` from the config it was last initialized with — so
the assertion is on the labels being in SVG `<text>` with no `foreignObject`
left, not on the spelling of a call. It also checks the restore leaves the
screen config in place, so the next preview pass does not inherit the print
one.

Restore the old print config and that test goes red on its own, with the
preview test still green (`the diagram re-rendered for print carries its labels
in foreignObject`). Revert the shared config function instead and both go red,
which is the point of there being one.

`scripts/mermaidPrintTheme.test.ts` has a source-shape assertion pinning that
the shared renderer initializes with the theme it was handed rather than
resolving its own. Its anchor is the theme expression; it now reaches into the
call instead of requiring an object literal in it, since the rest of the config
moved out.

986 node tests, 164 cargo tests, `npm run check` clean, `npm audit` clean.
`npm run test:vitest` is green on this branch apart from failures that
reproduce with the change stashed (`platformSource`, `viewerKeymap`,
`truncatedBufferGuard`), so they are not this change's.
