### PR TITLE
fix(save): a buffer with no file has no baseline to have moved

### DIFF
--- a/scripts/untitledFirstSaveWrites.spec.ts
+++ b/scripts/untitledFirstSaveWrites.spec.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+// The first save of an untitled buffer writes a file that does not exist yet.
+// The external-change guard (#692) asks the disk "has this file changed since
+// I last saw it?" before every overwrite, and answers "changed" when the read
+// fails — correct for a file the tab has written before, and the wrong
+// question entirely for a path the Save dialog has only just named. The read
+// failed because nothing was there, the write was refused, and the conflict
+// bar went up on a tab whose Reload has no file to reload. Every retry, under
+// any name, was refused the same way: a new document could not be saved at all.
+//
+// The stub is what let that ship. It answered a read of an unknown path with
+// `''` instead of rejecting, so under test the missing file looked like an
+// empty one and the guard compared two empty strings. Reads here reject the
+// way `read_file_content_checked` does.
+
+const disk = new Map<string, string>();
+const writes: string[] = [];
+/** What the Save dialog returns next. `null` is the user pressing Cancel. */
+let nextSaveTarget: string | null = null;
+/** Tabs the session raised the conflict bar for. */
+const conflicts: string[] = [];
+
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string, args: any) => {
+		if (cmd === 'canonicalize_path') return Promise.resolve(args.path);
+		if (cmd === 'read_file_content_checked') {
+			const content = disk.get(args.path);
+			return content === undefined
+				? Promise.reject(new Error('No such file or directory (os error 2)'))
+				: Promise.resolve([content, false, 'UTF-8']);
+		}
+		if (cmd === 'save_file_content') {
+			writes.push(args.path);
+			disk.set(args.path, args.content);
+			return Promise.resolve(null);
+		}
+		if (cmd === 'plugin:dialog|save') return Promise.resolve(nextSaveTarget);
+		if (cmd === 'get_os_type') return Promise.resolve('macos');
+		return Promise.resolve(null);
+	},
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async (raw: string) => raw,
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: () => {},
+		onDiskChangedUnderSave: (tabId: string) => void conflicts.push(tabId),
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+		onPartialCopySaved: () => {},
+	});
+}
+
+function reset() {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+	localStorage.clear();
+	disk.clear();
+	writes.length = 0;
+	conflicts.length = 0;
+	nextSaveTarget = null;
+}
+
+test('the first save of an untitled buffer writes the file the dialog named', async () => {
+	reset();
+	const session = makeSession();
+	tabManager.addTab('');
+	const tabId = tabManager.activeTabId!;
+	tabManager.updateTabRawContent(tabId, 'draft');
+
+	nextSaveTarget = '/notes/Untitled 1.md';
+	assert.equal(await session.saveContent(tabId), true);
+	assert.deepEqual(writes, ['/notes/Untitled 1.md']);
+	assert.deepEqual(conflicts, [], 'a file that never existed cannot have changed under the save');
+
+	const tab = tabManager.tabs.find((item) => item.id === tabId)!;
+	assert.equal(tab.path, '/notes/Untitled 1.md');
+	assert.equal(tab.isDirty, false, 'the buffer is on disk, so nothing is unsaved');
+});
+
+test('saving an untitled buffer onto a file that already exists is the dialog’s question, not ours', async () => {
+	// The Save dialog asked "replace?" and the user answered it. A second
+	// refusal here, from a baseline this tab never had, would make an untitled
+	// buffer unable to land on any path the user actually wanted.
+	reset();
+	const session = makeSession();
+	disk.set('/notes/existing.md', 'somebody else');
+	tabManager.addTab('');
+	const tabId = tabManager.activeTabId!;
+	tabManager.updateTabRawContent(tabId, 'draft');
+
+	nextSaveTarget = '/notes/existing.md';
+	assert.equal(await session.saveContent(tabId), true);
+	assert.equal(disk.get('/notes/existing.md'), 'draft');
+	assert.deepEqual(conflicts, []);
+});
+
+test('a tab that has a file still refuses to overwrite a changed one', async () => {
+	// The guard the fix narrows, still doing its job: the exemption is for a
+	// tab with no file, not for a save with no check.
+	reset();
+	const session = makeSession();
+	disk.set('/notes/a.md', 'original');
+
+	await session.loadMarkdown('/notes/a.md');
+	const tabId = tabManager.activeTabId!;
+	tabManager.updateTabRawContent(tabId, 'mine');
+	disk.set('/notes/a.md', 'theirs');
+
+	assert.equal(await session.saveContent(tabId), false);
+	assert.deepEqual(conflicts, [tabId]);
+	assert.equal(disk.get('/notes/a.md'), 'theirs', 'their text is still there');
+});

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -172,6 +172,16 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 	 */
 	async function fileDiffersFromBaseline(tab: Tab, path: string): Promise<boolean> {
 		if (!path || tab.isTruncated) return true;
+		// An untitled buffer is a version OF nothing, so there is no baseline to
+		// have moved and nothing here to protect. Asking anyway refused the first
+		// save of every new document: the path the Save dialog just returned
+		// names no file yet, the read fails, and "unreadable means changed" —
+		// safe for a file the tab has written before — turned the write into a
+		// conflict the user could not answer. Reload has no file to reload, so
+		// the bar stayed up and every retry, under any name, was refused the
+		// same way. The dialog has already asked about replacing an existing
+		// file, which is the question this one would be a worse version of.
+		if (!tab.path) return false;
 		try {
 			// The same read the reload does, so the two strings are comparable:
 			// decoded with the file's own encoding rather than assumed UTF-8.


### PR DESCRIPTION
## What this is

In 2.7.5, a new document cannot be saved. Ctrl+S on an untitled buffer opens the Save dialog, the user names the file, and nothing is written: the buffer stays dirty, the conflict bar goes up, and closing the tab asks about unsaved changes. Renaming and trying again is refused the same way, so the document has no exit but the clipboard. Reported by @PathGao on macOS 2.7.5; the path is platform-independent.

Files already on disk are unaffected — their baseline matches, so their saves go through as before.

## Mechanism

`fileDiffersFromBaseline` (#698) compares the file on disk against `tab.originalContent` before every overwrite, and treats an unreadable file as changed:

```
Ctrl+S on an untitled tab
  └─ Save dialog → targetPath = /notes/Untitled 1.md
       └─ fileDiffersFromBaseline(tab, targetPath)
            └─ read_file_content_checked → Err (nothing there yet)
                 └─ catch → true  ("changed")
                      └─ onDiskChangedUnderSave → save returns false
```

"Unreadable means changed" is right for a file this tab has written before — mid-write or gone are both reasons to stop and ask. It is not a question that can be asked about a path the dialog produced one line earlier, which names no file by construction. And the bar it raises is unanswerable here: `resolveExternalChangeByReloading` returns on `!tab.path`, so Reload does nothing, and only "keep mine" (`allowOverwriteOnce`) lets the next save through.

## What changed

`fileDiffersFromBaseline` answers `false` for a tab with no path. An untitled buffer is a version OF nothing, so there is no baseline for a third party to have moved.

Considered instead: skipping the call in `saveContent` when the dialog produced the path. Same condition (`saveContent` opens the dialog exactly when `!tab.path`), but it leaves the wrong answer inside the predicate for the next caller to find, and short-circuiting past `overwriteAllowed.delete` would strand an authorization. Also considered treating "file does not exist" as unchanged in the `catch`: that widens the hole for a tab whose file was deleted underneath it, which is a case the guard should keep refusing.

Saving an untitled buffer onto a file that *does* exist is the one case that looks like an overwrite. The Save dialog has already asked "replace?" and the user answered it; this check would be a second, worse copy of that question, asked against a baseline this tab never had. That is what the second test pins.

## Scope

Only the untitled case. The guard still refuses an overwrite when a tab's own file moved under it (third test), and Save As is untouched — it never had this check, which is why it kept working and is the workaround for anyone on 2.7.5.

## Tests

`scripts/untitledFirstSaveWrites.spec.ts`, 3 tests. Reverting the fix and keeping the tests turns 2 of the 3 red (the first save, and the save onto an existing file); the third — a real tab still refusing a changed file — is green either way by design, since it is the behavior being preserved.

The stub is why this shipped. Existing specs answer a read of an unknown path with `''` instead of rejecting, so under test the missing file looked like an empty one and the guard compared two empty strings. This file's stub rejects the way `read_file_content_checked` does.

## Verification

`npm audit` clean, `npm run check` 817 files / 0 errors, `npm test` 987 pass, `cargo test` unchanged (no Rust touched). `npm run test:vitest` adds 3 passing and no new failures; that suite already has 14 failures on a clean `origin/master` (tab navigation history, window tags, settings persistence, undo history) which this branch neither causes nor fixes.

Not verified by hand. A macOS release build of this branch exists and nobody has driven it yet; the manual check to run is new document, type, Ctrl+S, no rename, and see the file appear with the tab clean. Nothing in the path is platform-specific, and Windows and Linux were not tried either.

