### PR TITLE
A wrapped line starts where it should, not one space in

### DIFF
--- a/scripts/scrollSyncBlockMapping.test.ts
+++ b/scripts/scrollSyncBlockMapping.test.ts
@@ -44,7 +44,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { installShimDom, parseHtml, NODE_ELEMENT, type ShimElement } from './renderProtocolDom.ts';
+import {
+	installShimDom,
+	parseHtml,
+	NODE_ELEMENT,
+	NODE_TEXT,
+	type ShimElement,
+	type ShimText,
+} from './renderProtocolDom.ts';
 
 installShimDom();
 
@@ -1434,6 +1441,22 @@ test('a short paragraph is left alone', () => {
 	// them would be DOM nobody can see the benefit of, and most paragraphs in a
 	// document are short.
 	assert.deepEqual(anchorsOf(renderParagraph(10, 2)), []);
+});
+
+test('the newline behind a break stays in front of the anchor', () => {
+	// comrak writes a newline after every `<br>`, and a browser drops it only
+	// while it is still at the start of the line. The anchor is an
+	// `inline-block` — a box — so an anchor in front of that newline turns it
+	// into a space BETWEEN two boxes, and every wrapped line of the paragraph
+	// renders with an indent nobody typed (#725).
+	const anchors = anchorsOf(renderParagraph(10, 4));
+	assert.equal(anchors.length, 3);
+	for (const { element } of anchors) {
+		const gap = element.previousSibling;
+		assert.equal(gap?.nodeType, NODE_TEXT, 'an anchor sits behind the whitespace, not in front of it');
+		assert.match((gap as ShimText).nodeValue, /^\s+$/);
+		assert.equal((gap.previousSibling as ShimElement | null)?.tagName, 'BR');
+	}
 });
 
 test('the <br> itself is untouched', () => {

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -552,9 +552,25 @@ function processSoftLineAnchors(root: Element, doc: Document) {
 			anchor.className = "source-line-anchor";
 			anchor.setAttribute("data-sourcepos", `${line}:1-${line}:1`);
 			anchor.setAttribute("aria-hidden", "true");
+			// Behind the newline comrak writes after the `<br>`, not in front of
+			// it. That newline is collapsible whitespace, and a browser drops it
+			// only while it is still at the START of the line: put a box — and
+			// `inline-block` is what makes this one a box — in front of it, and
+			// it becomes a space BETWEEN two boxes and is drawn. Every wrapped
+			// line of a paragraph long enough to qualify then opens with an
+			// indent nobody typed. Splitting the text node leaves the whitespace
+			// on the break's side, where it goes on collapsing away.
+			//
 			// `insertBefore` rather than `after`: it is the older API, and the
 			// render-protocol DOM the tests drive implements it.
-			br.parentNode?.insertBefore(anchor, br.nextSibling);
+			const follows = br.nextSibling;
+			const text = follows?.nodeType === Node.TEXT_NODE ? follows : null;
+			const lead = text ? /^\s+/.exec(text.nodeValue ?? "") : null;
+			if (text && lead) {
+				text.nodeValue = (text.nodeValue ?? "").slice(lead[0].length);
+				br.parentNode?.insertBefore(doc.createTextNode(lead[0]), text);
+			}
+			br.parentNode?.insertBefore(anchor, follows);
 		}
 	}
 }


### PR DESCRIPTION
## What this is

A paragraph of three or more source lines rendered every line but its first with a leading space in the preview. The Markdown has no such space. Reported by @PathGao with a screenshot of a plain CJK document, where the indent is unmistakable because every line starts at a different place from the one above it.

No issue filed for it.

## Mechanism

Not the block patcher (#632), which was the first suspect — this predates it. `render.hardbreaks` makes comrak end every source line with `<br />` **followed by a newline**, and that newline is collapsible whitespace. A browser drops it, but only under one condition: it has to still be at the *start of the line*. CSS Text 3 removes a sequence of collapsible spaces at the beginning of a line; it does not remove one that follows a box.

`processSoftLineAnchors` (#541) inserts a `<span class="source-line-anchor">` beside each `<br>` so a soft line break has something with an `offsetTop` for split-view scroll sync to resolve to. That span is `display: inline-block` — being a box is the whole point of it, since a `<br>` generates none — and it was inserted with `insertBefore(anchor, br.nextSibling)`, which lands it in front of comrak's newline. The newline was then a space *between two boxes*, which is drawn.

Measured in Chromium, three paragraphs identical but for where the anchor sits, x of the first glyph on the second line:

```
line one<br />\nline two                    →  8.0px   (no anchor)
line one<br /><span></span>\nline two      →  8.0 + one space   ← what shipped
line one<br />\n<span></span>line two      →  8.0px
```

The anchor now goes behind the leading whitespace: the text node is split so the newline stays on the break's side of it. `previewAnchor` reads only `offsetTop` off the anchor, and that is the same on either side of a zero-width space.

## Scope

The `<br>` is still untouched, for the reason the existing comment gives. Nothing about which blocks qualify for anchors (`LINE_ANCHOR_MIN_SPAN`) changed, so short paragraphs — which never had the defect, having no anchors — render exactly as before.

`splitText` would have been the obvious way to split the text node; the render-protocol DOM the tests drive doesn't implement it, so the split is done with `createTextNode` + `insertBefore`, the two APIs that module already restricts itself to.

## Tests

`the newline behind a break stays in front of the anchor` in scripts/scrollSyncBlockMapping.test.ts, beside the anchors' other tests. It walks the anchors of a four-line paragraph and asserts each one's previous sibling is whitespace and the node before *that* is the `<br>`.

Revert the fix and keep the test: it goes red (`an anchor sits behind the whitespace, not in front of it`). The other 30 tests in that file stay green either way, which is the point — they pin where the anchors are in the source, and nothing about that changed.

## Verification

```
npm audit          found 0 vulnerabilities
npm run check      816 files, 0 errors, 0 warnings
npm test           987 pass, 0 fail
npm run test:vitest 401 pass, 0 fail   (not in the list above, but test.yml runs it)
cargo test         164 pass, 0 fail
```

Not verified: the pixel behaviour was measured in Chromium, not in the WKWebView the macOS app actually renders in. The rule involved is plain CSS whitespace collapsing rather than anything engine-specific, but I did not put the built app in front of it and count pixels.