### PR TITLE
fix(tabs): a tab switch shows the document it already rendered, instead of rebuilding it

### DIFF
--- a/scripts/editorPdfExport.test.ts
+++ b/scripts/editorPdfExport.test.ts
@@ -367,8 +367,11 @@ test('the refresh actually lands before the print', () => {
 	assert.match(body_, /await renderMarkdownPreview\(rawContent, tab\.path[,)]/);
 	assert.match(body_, /tabManager\.updateTabContent\(tabId, processed\)/);
 	// Mermaid, KaTeX and highlight.js all replace nodes asynchronously. The
-	// on-screen path fires and forgets; the export cannot.
-	assert.match(body_, /await renderRichContent\(\)/);
+	// on-screen path fires and forgets; the export cannot. The argument is not
+	// pinned for the same reason the renderer's trailing ones are not: the
+	// roots are which document to enrich — one host per open tab now, so the
+	// export names the one it is printing — and this test is about the `await`.
+	assert.match(body_, /await renderRichContent\(/);
 	assert.equal(body_.match(/await tick\(\)/g)?.length, 2, 'flush before and after the rich pass');
 });
 

--- a/scripts/foldLayout.test.ts
+++ b/scripts/foldLayout.test.ts
@@ -47,14 +47,40 @@ test('the find-bar fold re-aim delay outlasts the CSS fold transition', () => {
 test('preview lifecycle starts and cleans up fold observation', () => {
 	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
-	assert.match(viewer, /observeFoldLayout\((?:markdownBody|body)\)/);
+	assert.match(viewer, /const host = previewBlocks;[\s\S]*?observeFoldLayout\(host\)/);
 	assert.match(viewer, /observation\.stop\(\)/);
+});
+
+// The direction the previous spelling could not state. `observeFoldLayout` used
+// to be handed `markdownBody`, and that was right while the article held one
+// document; it now holds one `.markdown-blocks` host per open tab, all but one
+// of them `display: none`. `updateFoldHeights` walks its root, measures each
+// wrapper with `getBoundingClientRect().height` — 0 for everything in a hidden
+// subtree — and writes what it measured into `--fold-content-height`, which
+// styles.css resolves to the wrapper's `height`. A walk rooted at the article
+// therefore collapses every fold of every background tab, and the reader sees
+// it a frame after switching back, because `scheduleUpdate` defers through
+// `requestAnimationFrame` and that runs in the step AFTER the ResizeObserver
+// delivery that would correct it.
+//
+// This cannot be a behaviour test: jsdom has no layout, so every rect is 0
+// whether or not the element is displayed, and the visible and the hidden case
+// are indistinguishable to it. The proposition is an absence — "nothing ever
+// measures from the article" — so it is pinned as one.
+test('fold measurement is rooted at the visible host, never at the article holding every tab', () => {
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
+
+	assert.doesNotMatch(
+		viewer,
+		/observeFoldLayout\(\s*markdownBody/,
+		'observing the article would measure every hidden tab and write zero heights into it',
+	);
 });
 
 test('fold measurement pauses while the preview pane is hidden by edit mode', () => {
 	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
-	assert.match(viewer, /if \(!body \|\| \(isEditing && !isSplit\)\) return;/);
+	assert.match(viewer, /if \(!host \|\| \(isEditing && !isSplit\)\) return;/);
 });
 
 // The observation used to be torn down and rebuilt on every render, which is

--- a/scripts/foldStatePerDocument.spec.ts
+++ b/scripts/foldStatePerDocument.spec.ts
@@ -192,7 +192,7 @@ function tocEntries(body: HTMLElement, folds: Set<string>): string[] {
 
 	const component = mount(Toc, {
 		target,
-		props: { markdownBody: body, previewRevision: 1, foldOverrides: new Set(folds) },
+		props: { markdownBody: body, contentRoot: body, previewRevision: 1, foldOverrides: new Set(folds) },
 	});
 	flushSync();
 	const entries = Array.from(target.querySelectorAll('.toc-link')).map((el) => el.textContent!.trim());

--- a/scripts/previewSanitize.test.ts
+++ b/scripts/previewSanitize.test.ts
@@ -128,8 +128,15 @@ test('the preview sanitizes through the shared policy, not a local config', () =
 	// Why the footnote sink is allowed, pinned as a direction rather than as a
 	// spelling: the tooltip body is read out of the rendered document, never
 	// built from a string the sanitizer has not seen.
+	//
+	// `previewBlocks` and not `markdownBody`, and the difference is the whole
+	// point of the assertion rather than a rename. The article now holds one
+	// host per open tab, and `previewBlocks` is the one `patchPreviewBlocks` was
+	// handed above — so this pins the tooltip to the exact element the sanitized
+	// string was parsed into, where the previous spelling only reached the box
+	// containing it.
 	const footnote = sliceBetween(viewerSource, "anchor.hasAttribute('data-footnote-ref')", 'isFootnote: true');
-	assert.match(footnote, /markdownBody\?\.querySelector/, 'the footnote body is found in the rendered document');
+	assert.match(footnote, /previewBlocks\?\.querySelector/, 'the footnote body is found in the rendered document');
 	assert.match(footnote, /\.innerHTML/, 'and taken from the DOM the shared sanitizer already filtered');
 	assert.doesNotMatch(footnote, /rawContent/, 'never from the unrendered buffer');
 

--- a/scripts/tabSwitchIsNotARender.test.ts
+++ b/scripts/tabSwitchIsNotARender.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+/**
+ * The switch-time transition suppression is a contract between two files, and
+ * both halves fail silently on their own.
+ *
+ * The viewer adds a class to `.layout-container`, forces a style recalculation
+ * so the new pane geometry commits while transitions are off, and removes it —
+ * in one statement, before the first paint of the switch. The rule that makes
+ * the class mean anything lives in `styles.css`.
+ *
+ * Neither half can be a behaviour test: the ordering being asserted is
+ * "the class is on the element during the browser's style recalculation", and
+ * jsdom has no style recalculation to be inside of.
+ *
+ * The interesting failure is the third assertion. Svelte deletes scoped
+ * selectors it cannot see applied in the markup, and this class is applied
+ * through `classList` — so moving these rules into the component's `<style>`
+ * block, which is where they look like they belong, compiles them away and
+ * restores every animation with nothing going red.
+ */
+test('a tab switch commits the new pane geometry with transitions off', () => {
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
+	const styles = readSource('src/styles.css');
+
+	// The viewer's half: add, force the recalculation, remove. The forced read
+	// between the two is the mechanism, not a formality — without it the class
+	// is added and removed within one style computation and suppresses nothing.
+	assert.match(
+		viewer,
+		/classList\.add\('tab-switching'\);\s*void [\w.]+\.offsetHeight;\s*[\w.]+\.classList\.remove\('tab-switching'\);/,
+		'the viewer must add the class, force a style recalculation, and remove it in one statement',
+	);
+
+	// The stylesheet's half, and that it reaches the pane — the element whose
+	// 0.3s flex slide is the motion being suppressed.
+	const rule = styles.match(/([^}]*\.layout-container\.tab-switching[^{]*)\{([^}]*)\}/);
+	assert.ok(rule, 'styles.css must carry a .tab-switching rule');
+	assert.match(rule[1], /\.layout-container\.tab-switching \.pane\b/, 'and it must reach .pane');
+	assert.match(rule[2], /transition:\s*none\s*!important/, 'and it must switch transitions off');
+
+	// And that it did not migrate into the component, where Svelte would prune
+	// it. `classList.add('tab-switching')` is a string, not a selector, so the
+	// check is for the leading dot.
+	assert.doesNotMatch(
+		viewer,
+		/\.tab-switching/,
+		'the rule must stay in styles.css: a scoped selector for an imperatively added class is compiled away',
+	);
+});
+
+/**
+ * The preview DOM belongs to the tab, not to the viewer.
+ *
+ * A single `.markdown-blocks` for every tab is what made a switch the worst
+ * case `blockPatch.ts` has: two documents share no block keys, so the diff
+ * replaced essentially every node, `renderRichContent` ran over the whole
+ * document again, every fold re-measured, and the reading position was then
+ * restored against a layout that was still settling.
+ *
+ * `tabSwitchKeepsPreviewDom.spec.ts` runs the mechanism that makes the switch
+ * free — re-patching a host that already holds that document changes nothing —
+ * but it supplies its own two hosts, so it stays green against a viewer that
+ * has gone back to sharing one. This is the half that does not: the host must
+ * be minted inside a keyed `{#each}` over the tabs, which is also what makes
+ * Svelte destroy it with its tab and keeps the set of hosts from drifting from
+ * the set of tabs the way a hand-kept registry can.
+ */
+test('the preview holds one document host per tab, not one for all of them', () => {
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
+
+	const each = viewer.match(
+		/\{#each tabManager\.tabs as tab \(tab\.id\)\}([\s\S]*?)\{\/each\}/g,
+	);
+	assert.ok(each, 'the viewer must render per-tab preview hosts from a keyed each over the tabs');
+
+	const hostBlock = each.find((block) => block.includes('markdown-blocks'));
+	assert.ok(
+		hostBlock,
+		'.markdown-blocks must be minted per tab — one shared host makes every switch a full rebuild',
+	);
+	assert.match(
+		hostBlock,
+		/style:display=\{tab\.id === tabManager\.activeTabId \? null : 'none'\}/,
+		'only the active tab\'s host may be displayed, and the hidden ones must cost no layout',
+	);
+
+	// And that nothing kept a single binding beside it. The whole property is
+	// that there is no element the viewer can write two documents into.
+	assert.doesNotMatch(
+		viewer,
+		/bind:this=\{previewBlocks\}/,
+		'previewBlocks is the derived pointer at the active tab\'s host, never a binding of its own',
+	);
+});

--- a/scripts/tabSwitchKeepsPreviewDom.spec.ts
+++ b/scripts/tabSwitchKeepsPreviewDom.spec.ts
@@ -1,0 +1,107 @@
+import { beforeEach, expect, test } from 'vitest';
+
+import { patchPreviewBlocks } from '../src/lib/utils/blockPatch.js';
+
+/**
+ * Switching tabs must not rebuild the document being switched to.
+ *
+ * The preview used to have ONE `.markdown-blocks` host for every tab, so a
+ * switch handed that host the other document's markup. Two documents share no
+ * block keys, so the diff replaced essentially every node: `renderRichContent`
+ * ran over the whole document again, the folds re-measured, and the reading
+ * position was restored against a layout that was still settling. That is one
+ * cause with three symptoms — a visible reload, motion, and a position that
+ * moved after it had been restored.
+ *
+ * There is a host per tab now, and this is the property that makes the switch
+ * free. It is a property of `patchPreviewBlocks` plus the per-host memo it
+ * keeps (`renderedKeys`, a `WeakMap` keyed on the container), not of any new
+ * module: re-patching a host that already holds that document matches every key
+ * and changes nothing.
+ *
+ * What this cannot check is the wiring in `MarkdownViewer.svelte` that gives
+ * each tab its own host — that component cannot be mounted outside Tauri. What
+ * it does check is the mechanism the wiring depends on, and it is the half that
+ * would fail silently: a keying change in `blockPatch.ts` would still look
+ * correct on screen and quietly put the whole cost back.
+ */
+
+function doc(title: string, paragraphs: string[]): string {
+	const blocks = paragraphs
+		.map((text, i) => `<p data-sourcepos="${i + 3}:1-${i + 3}:${text.length}">${text}</p>`)
+		.join('');
+	return (
+		`<h1 data-sourcepos="1:1-1:${title.length}" id="${title}">${title}</h1>` +
+		`<div class="foldable-content-wrapper"><div class="content-inner">${blocks}</div></div>`
+	);
+}
+
+const A = doc('alpha', ['one', 'two', 'three']);
+const B = doc('beta', ['four', 'five']);
+
+let hostA: HTMLElement;
+let hostB: HTMLElement;
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	hostA = document.createElement('div');
+	hostB = document.createElement('div');
+	document.body.append(hostA, hostB);
+});
+
+test('re-showing a tab replaces no nodes and asks for no enrichment', () => {
+	patchPreviewBlocks(hostA, A);
+	patchPreviewBlocks(hostB, B);
+
+	const backToA = patchPreviewBlocks(hostA, A);
+
+	expect(backToA.replaced).toBe(0);
+	expect(backToA.inserted).toEqual([]);
+});
+
+test('the nodes the reader was looking at are the same objects afterwards', () => {
+	patchPreviewBlocks(hostA, A);
+	const before = [...hostA.querySelectorAll('.content-inner > p')];
+
+	patchPreviewBlocks(hostB, B);
+	patchPreviewBlocks(hostA, A);
+
+	const after = [...hostA.querySelectorAll('.content-inner > p')];
+	expect(after).toEqual(before);
+	// Identity, not equality: a rebuilt tree passes `toEqual` on the markup and
+	// is still a different set of boxes with different layout.
+	after.forEach((node, i) => expect(node).toBe(before[i]));
+});
+
+test('each host remembers its own document, so neither switch disturbs the other', () => {
+	patchPreviewBlocks(hostA, A);
+	patchPreviewBlocks(hostB, B);
+	patchPreviewBlocks(hostA, A);
+	patchPreviewBlocks(hostB, B);
+
+	expect(hostA.querySelector('h1')!.textContent).toBe('alpha');
+	expect(hostB.querySelector('h1')!.textContent).toBe('beta');
+});
+
+test('a document that changed while its tab was hidden is patched, not rebuilt, on the way back', () => {
+	patchPreviewBlocks(hostA, A);
+	const wrapper = hostA.querySelector('.foldable-content-wrapper')!;
+
+	// What a background render does: the tab's `content` is rewritten while the
+	// host is off screen. The host is untouched until the tab is shown again.
+	const edited = doc('alpha', ['one', 'two EDITED', 'three']);
+	const patch = patchPreviewBlocks(hostA, edited);
+
+	expect(patch.inserted.length).toBe(1);
+	expect(hostA.querySelector('.foldable-content-wrapper')).toBe(wrapper);
+	expect(hostA.textContent).toContain('two EDITED');
+});
+
+test('the same host given a different document does replace everything — the case being avoided', () => {
+	patchPreviewBlocks(hostA, A);
+	const patch = patchPreviewBlocks(hostA, B);
+
+	expect(patch.replaced).toBeGreaterThan(0);
+	// Without this the three tests above would pass against a patch function
+	// that never replaces anything at all.
+});

--- a/scripts/tocDocumentPasses.spec.ts
+++ b/scripts/tocDocumentPasses.spec.ts
@@ -74,7 +74,7 @@ function harness(html: string): Harness {
 		return queryAll(selector);
 	};
 
-	const props = runeProps({ markdownBody: body, previewRevision: 1 });
+	const props = runeProps({ markdownBody: body, contentRoot: body, previewRevision: 1 });
 	const component = mount(Toc, { target, props });
 	flushSync();
 

--- a/scripts/tocRenderSignal.spec.ts
+++ b/scripts/tocRenderSignal.spec.ts
@@ -30,7 +30,7 @@ function harness() {
 
 	// Mount time: the article exists and is still empty, which is exactly what
 	// the component sees in the flush the preview is first patched in.
-	const props = runeProps({ markdownBody: body, previewRevision: 0 });
+	const props = runeProps({ markdownBody: body, contentRoot: body, previewRevision: 0 });
 	const component = mount(Toc, { target, props });
 	flushSync();
 

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -140,9 +140,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let isFocused = $state(true);
 	
 	let markdownBody: HTMLElement | null = $state(null);
+	let layoutContainerEl: HTMLElement | null = $state(null);
 	/**
-	 * The element holding the rendered document, and the only part of the
-	 * preview Svelte does not manage.
+	 * One element per tab holding that tab's rendered document, and the only
+	 * part of the preview Svelte does not manage.
 	 *
 	 * `{@html sanitizedHtml}` used to sit here, which meant every keystroke threw
 	 * the article away and built a new one — the defect three rounds of fixes
@@ -151,9 +152,64 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	 * has to be exclusive: Svelte's `{@html}` tracks the first and last node it
 	 * inserted and removes everything between them on the next update, which a
 	 * diff that removes either end quietly breaks. The front-matter panel stays
-	 * Svelte's, in the article, outside this element.
+	 * Svelte's, in the article, outside these elements.
+	 *
+	 * ## Why there is one per tab and not one for the preview
+	 *
+	 * `blockPatch.ts` exists because a rebuilt tree does not lay out to the
+	 * pixels the tree it replaced did, and its header comment says the only
+	 * stable tree is the one that is not rebuilt. That argument was applied to
+	 * the keystroke and not to the tab switch, and a single host made the switch
+	 * the worst case it has: two documents share no block keys, so the diff
+	 * replaced essentially every node, `renderRichContent` ran over the whole
+	 * document again (highlight.js and display maths are memoised;
+	 * `renderMathInElement` is not, and a Mermaid diagram has to be
+	 * re-identified), and the reading position was then restored against a
+	 * layout that was still settling. Reload, motion, and a position that moved
+	 * afterwards — one cause.
+	 *
+	 * Keeping a host per tab is what VS Code does for text editors (one widget,
+	 * `setModel` plus the saved view state — see `utils/tabModels.ts`, which
+	 * already holds that shape for the Monaco side) and what Obsidian does for
+	 * its tabs, where every leaf's container stays in the DOM and a switch is a
+	 * `display` toggle. Re-activating a tab re-runs the patch against a host
+	 * that already holds that document, every key matches, and `patch.inserted`
+	 * comes back empty: no nodes replaced, no enrichment, nothing to re-measure.
+	 *
+	 * `renderedKeys` in `blockPatch.ts` is a `WeakMap` keyed on the container,
+	 * so each host remembers what it was last given on its own, and a host that
+	 * Svelte destroys with its tab takes its entry with it. That is also why
+	 * there is no reconciliation here of the kind `retainTabModels` needs: a
+	 * keyed `{#each}` over `tabManager.tabs` creates and destroys these divs
+	 * with the tabs themselves, so the set of live hosts cannot drift from the
+	 * set of live tabs the way a hand-kept registry can.
+	 *
+	 * ## Only the active host is ever patched
+	 *
+	 * A tab's `content` can be rewritten while it is off screen — a window
+	 * restore renders every restored tab, a cross-window arrival renders itself,
+	 * the background completion of a large file lands whenever it lands, and the
+	 * first-stage read in `documentSession` resolves after three awaits that a
+	 * switch can happen inside. None of those patch anything: the effect below
+	 * reads the ACTIVE tab's host and the active tab's HTML, so a background
+	 * tab's DOM is brought up to date when it is next shown, against whatever
+	 * its `content` says by then.
+	 *
+	 * That is not only laziness. A hidden host must not be written into, because
+	 * measuring inside one is wrong in a way that is invisible until the tab is
+	 * shown again: `getBoundingClientRect().height` is 0 for everything in a
+	 * `display: none` subtree, and `foldLayout.updateFoldHeights` writes what it
+	 * measures into `--fold-content-height`, which `styles.css` resolves to the
+	 * wrapper's `height`. A single write there collapses a hidden document's
+	 * folds to nothing, and the reader sees it a frame after switching back.
+	 * Patching only the visible host, and observing only the visible host (see
+	 * the fold effect below), is what keeps the measurement and the layout it
+	 * measures in the same place.
 	 */
-	let previewBlocks: HTMLElement | null = $state(null);
+	let previewHosts = $state<Record<string, HTMLElement | null>>({});
+	let previewBlocks = $derived(
+		tabManager.activeTabId ? (previewHosts[tabManager.activeTabId] ?? null) : null,
+	);
 	let foldLayout: FoldLayoutObservation | null = null;
 	
 	const highlightColorMap: Record<string, string> = {
@@ -880,8 +936,42 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 	}
 
+	/**
+	 * A tab switch is not a state change inside one view, and must not be drawn
+	 * as one.
+	 *
+	 * Nearly everything about the layout is a property of the TAB — `isEditing`,
+	 * `isSplit`, `splitRatio`, and `isMarkdown` off the path — so switching to a
+	 * tab in another mode changes exactly the values that toggling that mode
+	 * inside one tab changes, and the transitions written for the toggle fire
+	 * for the switch: `.pane` slides its `flex` over 0.3s, `.layout-container`
+	 * and `.editor-pane` slide their padding, the outline wrapper slides its
+	 * box-shadow and edges. Three hundred milliseconds of the text reflowing
+	 * under the reader, on a gesture whose whole content is "show me the other
+	 * document".
+	 *
+	 * The suppression is `foldLayout.ts`'s, for the same reason and in the same
+	 * shape: suppress, let the new values commit, restore. The class is added
+	 * through the element rather than through a `class:` directive because the
+	 * ordering is the entire mechanism — this effect runs after Svelte has
+	 * written the new `flex` into the DOM and before the browser has recomputed
+	 * style, so a class that lands in a later flush would land after the
+	 * transitions had already started. Reading `offsetHeight` forces that
+	 * recompute here, while the transitions are off; removing the class then
+	 * re-arms them against values that are already current, so nothing animates.
+	 *
+	 * It is deliberately not a `$state` flag that some later effect clears. A
+	 * window with no end is one an interrupted switch leaves open, and this one
+	 * closes in the same statement that opens it.
+	 */
 	$effect(() => {
 		const _ = tabManager.activeTabId;
+		const container = untrack(() => layoutContainerEl);
+		if (container) {
+			container.classList.add('tab-switching');
+			void container.offsetHeight;
+			container.classList.remove('tab-switching');
+		}
 		showHome = false;
 		findOpen = false;
 	});
@@ -1243,18 +1333,42 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	});
 
 	$effect(() => {
-		const body = markdownBody;
-		if (!body || (isEditing && !isSplit)) return;
+		const host = previewBlocks;
+		if (!host || (isEditing && !isSplit)) return;
 
-		// Keyed on the article, not on the document it is showing. This used to
-		// depend on `sanitizedHtml` and so tore the observation down and rebuilt
-		// it on every keystroke — and a fresh `ResizeObserver.observe` delivers an
-		// initial observation, so every fold in the document re-measured per
-		// character whether or not anything about it had changed. A keystroke no
-		// longer reaches here at all: the blocks the patch left alone keep the
-		// registration they already had, and the ones it inserted are handed to
-		// `observe` by the patch effect above.
-		const observation = observeFoldLayout(body);
+		// Keyed on the visible host, not on the document it is showing and not on
+		// the article that contains every tab's host.
+		//
+		// Not the document: this used to depend on `sanitizedHtml` and so tore the
+		// observation down and rebuilt it on every keystroke — and a fresh
+		// `ResizeObserver.observe` delivers an initial observation, so every fold
+		// in the document re-measured per character whether or not anything about
+		// it had changed. A keystroke still does not reach here: the host is the
+		// same element for as long as the tab is on screen, the blocks the patch
+		// left alone keep the registration they already had, and the ones it
+		// inserted are handed to `observe` by the patch effect above.
+		//
+		// Not the article, and this is the half that is new. `updateFoldHeights`
+		// walks its root, measures each wrapper's content with
+		// `getBoundingClientRect().height`, and writes that number into
+		// `--fold-content-height`, which `styles.css` resolves to the wrapper's
+		// `height`. In a `display: none` subtree every one of those rects is
+		// empty, so a walk rooted at the article would write `0px` onto every
+		// fold of every tab that is not on screen. Nothing looks wrong until the
+		// reader switches back, and then the whole document is collapsed for the
+		// frame it takes a fresh observation to correct it: `ResizeObserver`
+		// reports a target that leaves a hidden subtree, but `scheduleUpdate`
+		// defers through `requestAnimationFrame`, and that callback runs in the
+		// step AFTER the one that delivered the observation.
+		//
+		// So the observation follows the host that is displayed, and a hidden
+		// host is not observed at all. Its wrappers keep the inline heights they
+		// were last measured at, which are still right — nothing in a hidden
+		// document changes size — and re-registering on the way back in costs one
+		// batched re-measure of the one document being shown. That is a switch,
+		// not a keystroke, and it is the price of never measuring a box that is
+		// not being laid out.
+		const observation = observeFoldLayout(host);
 		foldLayout = observation;
 
 		return () => {
@@ -1529,8 +1643,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	 * and the read above is what makes a tab switch swap the whole set.
 	 */
 	const foldHost: FoldHost = {
+		// The active tab's host, not the article. `foldState` answers both of its
+		// questions with `root.querySelectorAll('[data-fold-key]')`, and the
+		// article holds a host per open tab — so from there a fold key would
+		// resolve against whichever document happened to be earlier in the DOM.
 		get root() {
-			return markdownBody ?? null;
+			return previewBlocks ?? null;
 		},
 		get folds() {
 			return foldOverrides;
@@ -1545,9 +1663,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (id.startsWith('^')) {
 			id = id.substring(1);
 		}
+		// Looked up in the visible host and scrolled on the article. Heading ids
+		// are minted per document, so with a host per open tab the same `#id`
+		// exists once per tab that has that heading; the article would hand back
+		// whichever came first in the DOM, which is not the document on screen.
 		const el =
-			(markdownBody?.querySelector(`[id="${CSS.escape(id)}"]`) as HTMLElement | null) ||
-			(markdownBody?.querySelector(`[name="${CSS.escape(id)}"]`) as HTMLElement | null);
+			(previewBlocks?.querySelector(`[id="${CSS.escape(id)}"]`) as HTMLElement | null) ||
+			(previewBlocks?.querySelector(`[name="${CSS.escape(id)}"]`) as HTMLElement | null);
 		if (el && markdownBody) {
 			if (options.pushHistory !== false) pushScrollHistory();
 			markdownBody.scrollTo({ top: anchorScrollTop(markdownBody, el), behavior: jumpBehavior });
@@ -2309,7 +2431,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			// Awaited, unlike the on-screen path: Mermaid, KaTeX and
 			// highlight.js all replace nodes asynchronously, and the diagram
 			// re-theming below reads the nodes this produces.
-			await renderRichContent();
+			//
+			// Scoped to the tab being exported. Omitting the roots means the
+			// article, which now holds a host per open tab, so an export would
+			// re-typeset and re-draw every open document to print one.
+			await renderRichContent(previewBlocks ? [previewBlocks] : undefined);
 			await tick();
 		} catch (error) {
 			// Printing the stale DOM is still better than not printing, but the
@@ -2332,7 +2458,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// preview exports unreadable diagrams. Rebuild them light for the
 		// duration of the export rather than trying to recolour the output.
 		const restoreDiagrams = await renderDiagramsForPrint({
-			root: markdownBody,
+			// The tab being exported, not every open tab's diagrams.
+			root: previewBlocks,
 			mermaid,
 			sanitizeSvg: sanitizeDiagramSvg,
 			screenTheme: currentMermaidTheme(),
@@ -2684,9 +2811,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 					if (selection) invoke('clipboard_write_text', { text: selection });
 				} }] : []),
 				{ label: t('menu.selectAll', settings.language), onClick: () => {
-					if (!markdownBody) return;
+					// The document on screen. Selecting the article would select
+					// every open tab's text, including the hosts that are hidden.
+					if (!previewBlocks) return;
 					const range = document.createRange();
-					range.selectNodeContents(markdownBody);
+					range.selectNodeContents(previewBlocks);
 					const selection = window.getSelection();
 					selection?.removeAllRanges();
 					selection?.addRange(range);
@@ -2712,7 +2841,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			if (rawHref.startsWith('#')) {
 				let id = rawHref.substring(1);
 				if (id.startsWith('^')) id = id.substring(1);
-				const el = markdownBody?.querySelector(`[id="${CSS.escape(id)}"]`) as HTMLElement | null;
+				const el = previewBlocks?.querySelector(`[id="${CSS.escape(id)}"]`) as HTMLElement | null;
 				if (el) {
 					// Use data-label if it's a block anchor, otherwise use textContent
 					let text = el.getAttribute('data-label') || el.textContent || '';
@@ -2729,8 +2858,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			// footnote references: show footnote content instead of URL
 			if (anchor.hasAttribute('data-footnote-ref') || anchor.closest('[data-footnote-ref]') || rawHref.match(/#fn-|#fnref-|#user-content-fn/)) {
 				const fnId = rawHref.replace(/^#/, '');
-				const fnLi = markdownBody?.querySelector(`#${CSS.escape(fnId)}`) ||
-				              markdownBody?.querySelector(`li#${CSS.escape(fnId)}`);
+				const fnLi = previewBlocks?.querySelector(`#${CSS.escape(fnId)}`) ||
+				              previewBlocks?.querySelector(`li#${CSS.escape(fnId)}`);
 				if (fnLi) {
 					// clone to remove backref arrow from tooltip
 					const clone = fnLi.cloneNode(true) as HTMLElement;
@@ -3714,6 +3843,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				onwheel={handleWheel}
 				role="presentation">
 				<div class="layout-container" 
+					bind:this={layoutContainerEl}
 					class:split={isSplit} 
 					class:editor-on-right={isSplit && settings.splitEditorSide === 'right'} 
 					class:editing={isEditing} 
@@ -3790,7 +3920,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 						<FindBar
 							bind:this={findBar}
 							bind:open={findOpen}
-							{markdownBody}
+							contentRoot={previewBlocks}
 							onunfold={(key: string) => revealFold(foldHost, key)}
 							language={settings.language} />
 
@@ -3910,8 +4040,24 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 										</details>
 									{/if}
-									<!-- Filled by the block patch, not by Svelte: see `previewBlocks`. -->
-									<div class="markdown-blocks" bind:this={previewBlocks}></div>
+									<!--
+										One host per tab, all mounted, only the active one displayed:
+										see `previewHosts`. The children are filled by the block patch,
+										not by Svelte.
+
+										`display` and not `visibility`, `opacity` or a zero height. A
+										hidden host must cost no layout — that is the point — and it is
+										also what keeps `@media print` in styles.css correct without
+										listing these divs: a `display: none` subtree does not print,
+										so the export captures the tab on screen rather than every open
+										document concatenated.
+									-->
+									{#each tabManager.tabs as tab (tab.id)}
+										<div
+											class="markdown-blocks"
+											style:display={tab.id === tabManager.activeTabId ? null : 'none'}
+											bind:this={previewHosts[tab.id]}></div>
+									{/each}
 								</article>
 								{#if tabManager.activeTabId && loadingTabs.includes(tabManager.activeTabId) && isAtBottom}
 								<div class="loading-chip" transition:fly={{ y: 20, duration: 300, easing: cubicOut }}>
@@ -3976,6 +4122,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 								<Toc
 									activeLine={tocActiveLine} 
 										{markdownBody} 
+										contentRoot={previewBlocks}
 										{previewRevision}
 										onBeforeJump={pushScrollHistory} 
 										{foldOverrides} 
@@ -4852,6 +4999,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	.layout-container.toc-resizing .toc-toggle-floating {
 		transition: none !important;
 	}
+
 
 	.layout-container.has-pinned-toc.toc-on-left {
 		padding-left: var(--toc-width);

--- a/src/lib/components/FindBar.svelte
+++ b/src/lib/components/FindBar.svelte
@@ -15,12 +15,21 @@
 
 	let {
 		open = $bindable(false),
-		markdownBody,
+		contentRoot,
 		onunfold,
 		language,
 	} = $props<{
 		open: boolean;
-		markdownBody: HTMLElement | null;
+		/**
+		 * The element holding the document being read — the active tab's
+		 * `.markdown-blocks`, not the `.markdown-body` article around it. The
+		 * article now holds one such host per open tab and all but one of them
+		 * are `display: none`, so a search rooted there would count, highlight
+		 * and step through matches in documents the reader cannot see. Find
+		 * never needs the scroller: it reveals a match with `scrollIntoView` on
+		 * the mark itself.
+		 */
+		contentRoot: HTMLElement | null;
 		/** Open the fold with this key. Only the owner of the fold state can. */
 		onunfold?: (key: string) => void;
 		/**
@@ -99,7 +108,7 @@
 	 * function.
 	 */
 	function revealFoldsAround(mark: HTMLElement): boolean {
-		const root = markdownBody as HTMLElement | null;
+		const root = contentRoot as HTMLElement | null;
 		if (!root) return false;
 
 		// Outermost first, so a nested fold is already on screen by the time its
@@ -110,7 +119,7 @@
 	}
 
 	export function clearHighlights() {
-		const root = markdownBody as HTMLElement | null;
+		const root = contentRoot as HTMLElement | null;
 		if (!root) return;
 		const marks = Array.from(
 			root.querySelectorAll(`mark.${FIND_MARK_CLASS}`),
@@ -150,7 +159,7 @@
 	}
 
 	function applyHighlights() {
-		if (!markdownBody) {
+		if (!contentRoot) {
 			matchCount = 0;
 			activeIndex = -1;
 			truncated = false;
@@ -164,7 +173,7 @@
 			return;
 		}
 
-		const root = markdownBody;
+		const root = contentRoot;
 		const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
 			acceptNode(node: Node) {
 				const text = (node as Text).nodeValue;
@@ -227,7 +236,7 @@
 	}
 
 	function getMarks(): HTMLElement[] {
-		const root = markdownBody as HTMLElement | null;
+		const root = contentRoot as HTMLElement | null;
 		if (!root) return [];
 		return Array.from(
 			root.querySelectorAll(`mark.${FIND_MARK_CLASS}`),

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -8,8 +8,21 @@
 	import { anchorScrollTop } from '../utils/previewAnchor.js';
 	import type { RendererLine } from '../utils/lineCoordinates.js';
 
-	let { markdownBody, previewRevision, activeLine = null, onBeforeJump, foldOverrides, ontoggleFold, oncopyref, oncontext, onjump, onshowTooltip, onhideTooltip } = $props<{
+	let { markdownBody, contentRoot, previewRevision, activeLine = null, onBeforeJump, foldOverrides, ontoggleFold, oncopyref, oncontext, onjump, onshowTooltip, onhideTooltip } = $props<{
+		/**
+		 * The `.markdown-body` article — the scrolling box, and nothing else.
+		 * Every jump and the scroll listener go through this one.
+		 */
 		markdownBody: HTMLElement | null;
+		/**
+		 * The active tab's `.markdown-blocks`, which is where the headings
+		 * actually are. The article holds one host per open tab and all but one
+		 * are `display: none`, so an outline scanned from the article would list
+		 * every open document's headings at once. The two are separate props
+		 * because this component needs both halves and they are different
+		 * elements: read the outline out of the host, scroll the article.
+		 */
+		contentRoot: HTMLElement | null;
 		/**
 		 * How many documents the preview DOM has been given. Read as a signal and
 		 * never for its value: it says the article now HOLDS the document, which
@@ -97,16 +110,39 @@
 	/** How long a jump's own smooth scroll is given to settle. */
 	const CLICK_LOCK_MS = 600;
 
+	/**
+	 * Whether the entries about to be rendered belong to a different document
+	 * than the ones on screen, and so must not be animated into place.
+	 *
+	 * `transition:slide` on each entry is for the outline changing WITHIN a
+	 * document — folding a section away takes its headings with it, and they
+	 * should leave the way they arrived. A tab switch replaces the list wholly:
+	 * every old entry plays its outro and every new one its intro, 240ms of the
+	 * outline churning for a gesture that only asked to see another document.
+	 *
+	 * The signal is the host's identity, not a flag the viewer passes down.
+	 * There is one `.markdown-blocks` per open tab, so `contentRoot` changing to
+	 * a different element IS the switch, observed at the only moment that
+	 * matters — the scan that produces the new list. A flag would have to be
+	 * raised and lowered around that moment by someone else, and a window with
+	 * two ends is one an interrupted switch can leave open.
+	 */
+	let scannedRoot: HTMLElement | null = null;
+	let documentChanged = $state(false);
+
 	$effect(() => {
 		// The dependency, and the whole reason this runs. An empty document is
 		// not a special case: the scan below finds nothing in it and clears the
 		// outline the same way a document with no headings does.
 		void previewRevision;
 
-		if (markdownBody) {
+		documentChanged = contentRoot !== scannedRoot;
+		scannedRoot = contentRoot;
+
+		if (contentRoot) {
 			const result: TocItem[] = [];
 
-			const entries = markdownBody.querySelectorAll(ENTRY_SELECTOR) as NodeListOf<HTMLElement>;
+			const entries = contentRoot.querySelectorAll(ENTRY_SELECTOR) as NodeListOf<HTMLElement>;
 			for (const el of Array.from(entries)) {
 				if (el.classList.contains('block-id-anchor')) {
 					result.push({ id: el.id, text: el.getAttribute('data-label') || el.id, foldKey: '', level: 0, isBlock: true, line: sourceLineOf(el.dataset.sourcepos) });
@@ -336,7 +372,7 @@
 	import { cubicOut } from 'svelte/easing';
 
 	function jumpTo(id: string) {
-		const el = markdownBody?.querySelector(`[id="${CSS.escape(id)}"]`) as HTMLElement | null;
+		const el = contentRoot?.querySelector(`[id="${CSS.escape(id)}"]`) as HTMLElement | null;
 		if (el && markdownBody) {
 			onBeforeJump?.();
 			// lock active id immediately so scroll handler doesn't override
@@ -404,7 +440,7 @@
 		<ul class="toc-list">
 			{#each visibleItems as item (item.id)}
 				<li 
-					transition:slide={{ duration: 240, easing: cubicOut }}
+					transition:slide={{ duration: documentChanged ? 0 : 240, easing: cubicOut }}
 					class="toc-item {item.isBlock ? 'block-item' : `level-${item.level}`}" 
 					style="padding-left: {(Math.max(1, item.level || 2) - 1) * 10 + 8}px !important">
 					{#if item.isBlock}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1388,6 +1388,41 @@ body {
 	background-color: var(--color-accent-fg);
 }
 
+/*
+ * A tab switch is not a state change inside one view, and must not be drawn as
+ * one. `MarkdownViewer.svelte` adds this class to `.layout-container`, forces a
+ * style recalculation so the new geometry commits with the transitions off, and
+ * removes it again — all in one statement, before the browser has painted once.
+ * See the effect that does it for why the ordering is the whole mechanism.
+ *
+ * The list is every element whose transition is driven by a value belonging to
+ * the TAB rather than to something the user just did: `.pane` (flex, from
+ * `isEditing` / `isSplit` / `splitRatio`), `.layout-container` and
+ * `.editor-pane` (padding, from `has-pinned-toc`, gated on `isMarkdown`), and
+ * the outline wrapper (edges and shadow, from `is-overhanging`, computed from
+ * `isEditing` and `isSplit`). Each of those animations is worth keeping for the
+ * gesture it was written for: toggling edit mode inside a tab should slide,
+ * arriving at a tab that was already in edit mode should not, because nothing
+ * moved — the reader asked to see another document, not to watch this one
+ * change shape.
+ *
+ * HERE AND NOT IN THE COMPONENT'S `<style>`, and this is not a matter of taste.
+ * Svelte prunes scoped selectors it cannot see applied in the markup, and this
+ * class is added through `classList` precisely because a `class:` directive
+ * would land in a later flush than the geometry it has to precede. Written
+ * there, these five rules are deleted at compile time and every transition
+ * comes back with nothing failing — which is what
+ * `scripts/tabSwitchMotion.test.ts` is for. `!important` beats the scoped
+ * declarations regardless of the extra class Svelte adds to their specificity.
+ */
+.layout-container.tab-switching,
+.layout-container.tab-switching .pane,
+.layout-container.tab-switching .editor-pane,
+.layout-container.tab-switching .toc-overlay-wrapper,
+.layout-container.tab-switching .toc-toggle-floating {
+	transition: none !important;
+}
+
 /* print styles for pdf export */
 @media print {
 	@page {


### PR DESCRIPTION
## What this is

Switching tabs reloaded the document being switched to: the preview flashed as it
rebuilt, the panes animated, and the reading position landed somewhere other than
where it was left. Reported by @PathGao against 2.7.5.

## Mechanism

Two causes, one per symptom group.

**The rebuild.** The preview had one `.markdown-blocks` host for every tab
(`MarkdownViewer.svelte`), so a switch handed that host the other document's
markup. `blockPatch.ts` keys blocks on their markup, and two documents share no
keys — so the diff descended the whole tree and replaced essentially every node,
`renderRichContent` ran over the entire document again (highlight.js and display
maths are memoised; `renderMathInElement` is not, ~11ms on `katex-stress.md`, and
a cached Mermaid diagram still has to be re-identified), every fold re-measured,
and only then did the restore effect write `scrollTop` — into a layout that was
still settling. `blockPatch.ts`'s own header says "the only stable tree is the one
that is not rebuilt"; that argument had been applied to the keystroke and not to
the switch, where it is the worst case rather than the best one.

There is a host per tab now, all mounted in the article, only the active one
displayed. This is what Obsidian does — `updateTabDisplay` in its `app.js` ends
with `containerEl.toggle(isActive)` and appends every child's container to the tab
container, and its stylesheet has no transition on any of `workspace-leaf`,
`view-content` or `markdown-preview` — and it is the shape `utils/tabModels.ts`
already holds for the Monaco side. No new registry: a keyed `{#each}` over
`tabManager.tabs` creates and destroys the hosts with the tabs, and `renderedKeys`
in `blockPatch.ts` is a `WeakMap` keyed on the container, so each host remembers
its own document and a destroyed one takes its entry with it. Re-showing a tab
matches every key and `patch.inserted` comes back empty.

Only the active host is ever patched. Four paths rewrite a tab's `content` while
it is off screen (window restore, cross-window arrival, background completion of a
large file, and the first-stage read in `documentSession`, which resolves after
three awaits a switch can happen inside) and none of them touch the DOM; the host
is brought up to date when the tab is next shown. That is not only laziness —
`getBoundingClientRect().height` is 0 for everything in a `display: none` subtree
and `foldLayout.updateFoldHeights` writes what it measures into
`--fold-content-height`, which styles.css resolves to the wrapper's `height`. One
write there collapses a hidden document's folds to nothing. For the same reason
the fold observation follows the visible host instead of the article: hidden
wrappers keep the inline heights they were last measured at, which are still
correct, and re-registering on the way in costs one batched re-measure of the one
document being shown.

**The motion.** Nearly everything about the layout is a property of the *tab* —
`isEditing`, `isSplit`, `splitRatio`, and `isMarkdown` off the path — so arriving
at a tab in another mode changes exactly the values that toggling that mode inside
one tab changes, and the transitions written for the toggle fire for the switch:
`.pane` slides its flex over 0.3s, `.layout-container` and `.editor-pane` slide
padding, the outline wrapper slides its edges. The suppression is
`foldLayout.ts`'s, for the same reason and in the same shape — suppress, force the
recalculation, restore — held for one style recalculation and never across a
paint. It is added through `classList` rather than a `class:` directive because
the ordering is the mechanism: the effect runs after Svelte has written the new
`flex` and before style is recomputed, and a class in a later flush would land
after the transitions had started. The rule lives in `styles.css` and not in the
component, because Svelte deletes scoped selectors it cannot see applied — written
there, all five are compiled away and every animation comes back with nothing
failing.

The loudest one was not a CSS transition. The outline gives every entry
`transition:slide`, and a switch replaces the whole list, so every old entry played
its outro and every new one its intro. Svelte's transition directives ignore
`transition: none`, so `Toc.svelte` decides for itself: `contentRoot` changing to a
different element *is* the switch, observed at the scan that produces the new list.
Folding a section inside one document still animates.

Trade-offs. A per-tab `article` — one scroller each, so the browser keeps the
scroll position natively and no restore is needed — was the first design and was
dropped: it puts every fold wrapper, anchor measurement and `offsetParent` walk in
a subtree that may be hidden, cross-wires the single fold observation, and makes
`handleScroll` write the wrong tab's record. Sharing the scroller keeps
`measurePreviewBox`, `anchorScrollTop`, `getPreviewScrollMax` and the restore
effect correct as they stand, at the cost of restoring `scrollTop` by hand on a
switch — which is exact now that it lands on a settled layout. Cheaper diff,
fewer places to be wrong.

The cost of the design is memory: N open tabs hold N rendered documents' DOM.
`tabModels.ts` already accepted that shape for Monaco models with no cap, and
Obsidian accepts it too (its deferred views are about tabs never opened in a
session, not about evicting live ones). If it turns out to bite, the fix is an
eviction policy over the hosts, not a return to sharing one.

## Scope

The editor is untouched. `{#if isEditing || isSplit}` still destroys and rebuilds
the Monaco widget when the active tab changes between reading and editing mode —
the text model survives (`tabModels.ts`), so undo history is safe, but the widget,
its view state and its layout are all redone. The same principle applies and the
risk does not: a Monaco kept alive in a `display: none` pane needs its own
`layout()` handling on reveal, and the pane sits inside a container whose `zoom`
also changes on that switch. Worth doing separately, with the measurement to
justify it.

Three defects found while reading and deliberately left alone, all of them
pre-existing:

- `scrollHistory` / `scrollFuture` are one pair of arrays of raw pixel offsets,
  never cleared on a tab switch, so mouse-back in one tab pops an offset captured
  in another.
- A tab arriving from another window loses its reading position: the restore
  effect fires when `insertTransferredTab` sets the active id, which is before
  `renderTabPreviewFromRaw` fills the DOM, and nothing re-triggers it when the
  content lands.
- `documentSession.svelte.ts`'s first-stage render captures `activeId` and then
  awaits three times; its only guard is a per-tab load revision, so a switch during
  an open lands that HTML on a background tab. Harmless now that the DOM is
  per-tab, but the comment above `renderMarkdownPreview` lists three such paths
  and this is a fourth.

## Tests

`scripts/tabSwitchKeepsPreviewDom.spec.ts` runs the mechanism: two hosts, two
documents, switch back and forth, and re-showing one reports `replaced === 0` with
an empty `inserted`. It asserts node *identity* rather than equal markup — a
rebuilt tree passes on markup and is still a different set of boxes. The last case
in the file is the inverse (one host given a different document does replace
everything), without which the first three would pass against a patch function that
never replaces anything.

`scripts/tabSwitchIsNotARender.test.ts` is two source-shape assertions for the two
propositions that cannot be run. The first is a cross-file contract: the viewer
adds the class, forces the recalculation and removes it in one statement, and
`styles.css` carries the rule — plus that the rule has *not* moved into the
component, which is the failure that leaves no trace. The second is that
`.markdown-blocks` is minted inside the keyed `{#each}`; the spec above supplies
its own two hosts, so it stays green against a viewer that has gone back to
sharing one, and this is the half that does not.

Also in `foldLayout.test.ts`: an absence, that nothing passes the article to
`observeFoldLayout`. It cannot be a behaviour test — jsdom has no layout, so every
rect is 0 whether or not the element is displayed, and the visible and hidden cases
are indistinguishable to it.

Reverting each of the three fixes, tests kept:

| reverted | result |
|---|---|
| back to one shared host | `tabSwitchIsNotARender` red |
| rule moved into the component's `<style>` | `tabSwitchIsNotARender` red |
| fold observation back on the article | `foldLayout` red ×2 |

Three existing assertions changed, and in each case the anchor moved rather than
the claim. `previewSanitize.test.ts` pinned the footnote tooltip to
`markdownBody?.querySelector`; it now pins `previewBlocks?.querySelector`, which is
the element `patchPreviewBlocks` was handed two assertions earlier — a stronger
statement of the same "read out of already-sanitized DOM". `editorPdfExport.test.ts`
pinned `await renderRichContent()` with empty parentheses; the claim is the `await`,
and the roots are now which document to enrich. `foldLayout.test.ts`'s two
lifecycle anchors follow the effect's new root.

## Verification

```
npm audit          0 vulnerabilities
npm run check      821 files, 0 errors, 0 warnings
npm test           998 pass, 0 fail
npm run test:vitest 406 pass, 0 fail
cargo test         164 pass, 0 fail
```

Not verified: anything needing a running app. Both new tests are jsdom or source
text, and the three properties that matter most — that a hidden host is never
measured, that the class is on the element during the browser's style
recalculation, and that the switch no longer paints a rebuild — are all statements
about real layout, which jsdom does not have. A macOS build was driven by hand
through same-mode and cross-mode switches, find, select-all, anchor and footnote
tooltips, folds, the outline, and a PDF export. Windows and Linux were not tried;
nothing here is platform-specific, but the `display: none` interaction with
`@media print` is a rendering-engine behaviour and only WebKit was exercised.
