### PR TITLE
What X11 copies outlives the command that copied it

### DIFF
--- a/scripts/clipboardOwnershipX11.test.ts
+++ b/scripts/clipboardOwnershipX11.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource, sliceBetween } from './sourceTree.js';
+
+// #729: on Debian XFCE, everything copied out of Markpad reached an empty
+// clipboard, while pasting into it worked. X11 has no clipboard store — the
+// copying process owns the CLIPBOARD selection and serves the bytes on
+// request — and arboard tears that ownership down when the last `Clipboard`
+// handle drops, which was the moment `clipboard_write_text` returned.
+//
+// A source-shape assertion because the proposition cannot be run: the failure
+// needs an X server and a desktop without a clipboard manager, and CI has
+// neither. It names the helper on purpose; nothing but the call connects the
+// two, and the function exists for no other reason.
+test('the copy command keeps X11 clipboard ownership past its own return', () => {
+	const body = sliceBetween(
+		readSource('src-tauri/src/commands.rs'),
+		'pub fn clipboard_write_text',
+		'\n}',
+	);
+	assert.match(body, /retain_clipboard_ownership\(\)/);
+});
+
+test('the retained handle is never dropped', () => {
+	// `retain_clipboard_ownership` holding a `Clipboard` in a local would be a
+	// no-op: the point is that the handle outlives the call, so the invisible
+	// window arboard serves selection requests from is never destroyed.
+	const helper = sliceBetween(
+		readSource('src-tauri/src/commands.rs'),
+		'fn retain_clipboard_ownership',
+		'\n}',
+	);
+	assert.match(helper, /std::mem::forget\(/);
+});

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -674,8 +674,46 @@ pub fn get_os_type() -> String {
     }
 }
 
+/// Keep one `arboard::Clipboard` alive for the rest of the process, so that
+/// what we copy survives the command that copied it (#729).
+///
+/// On X11 there is no clipboard store: the copying process owns the CLIPBOARD
+/// selection and hands the bytes over when another app asks for them. arboard
+/// serves those requests from a background thread and an invisible window it
+/// destroys when the last `Clipboard` drops — which, with one built and
+/// dropped per command, is the moment `clipboard_write_text` returns. Its only
+/// parting move is to offer the data to a clipboard manager, so on a desktop
+/// that ships one (GNOME) copying appears to work and on one that does not
+/// (XFCE, the reporter's) everything Markpad copies is gone before it can be
+/// pasted. Holding an instance keeps the window and the ownership; the
+/// per-command `Clipboard::new()`s below reuse arboard's global and their drop
+/// becomes a no-op.
+///
+/// Nowhere else needs this. Wayland goes through wl-clipboard-rs, which forks
+/// a process that outlives us, and macOS and Windows write into a store the
+/// system owns.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn retain_clipboard_ownership() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static RETAINED: AtomicBool = AtomicBool::new(false);
+
+    // Racing threads would leak a second handle, not a second connection; both
+    // are `Arc`s onto the same global. Failure is not recorded, so a copy
+    // attempted before the display is reachable does not poison later ones.
+    if RETAINED.load(Ordering::Relaxed) {
+        return;
+    }
+    if let Ok(clipboard) = arboard::Clipboard::new() {
+        std::mem::forget(clipboard);
+        RETAINED.store(true, Ordering::Relaxed);
+    }
+}
+
 #[tauri::command]
 pub fn clipboard_write_text(text: String) -> Result<(), String> {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    retain_clipboard_ownership();
+
     let mut clipboard = arboard::Clipboard::new().map_err(|e| e.to_string())?;
     clipboard.set_text(text).map_err(|e| e.to_string())
 }


### PR DESCRIPTION
## What this is

Everything copied out of Markpad on X11 reaches an empty clipboard, unless the
desktop happens to run a clipboard manager. Cut is the expensive case: the text
is deleted and nothing is saved in its place. Reported by @DerLudditus on Debian
13 XFCE in #729, who also identified the two halves of the shape — paste works,
and the Windows build is fine.

Closes #729.

## Mechanism

X11 has no clipboard store. The copying process owns the CLIPBOARD selection and
serves the bytes when another app asks for them, so the data lives exactly as
long as the owner does. arboard serves those requests from a background thread
and an invisible window, and destroys both in `Drop` for the last live
`Clipboard` handle — which, with one built per command, is the moment
`clipboard_write_text` returns.

Its only parting move is `ask_clipboard_manager_to_request_our_data`, offering
the bytes to a clipboard manager. That is why the bug is not universal: GNOME
ships one and copying appears to work, XFCE does not and the selection is gone
before anything can ask for it. Windows and macOS write into a store the system
owns, and Wayland goes through wl-clipboard-rs, which forks a process that
outlives us — none of them depend on the handle.

So the fix is not in the write path. One handle is leaked on first copy, and
because arboard's Linux backend keeps its context in a refcounted global, every
later `Clipboard::new()` reuses it and its `Drop` finds a strong count above the
threshold and does nothing.

Two smaller things follow from the same arithmetic. `clipboard_read_text` and
`clipboard_read_image` build the same kind of handle, so before this a paste
racing a copy could be the drop that demolished the copy's ownership; now no
per-command drop demolishes anything. And the leaked handle is not a thread the
app did not already start: the first copy started it either way. Nothing is
created for users who never copy.

## Scope

The three clipboard commands keep building a handle per call. Routing them
through one shared instance would need a `Mutex` in managed state and a `Send`
bound that only holds on some platforms, to buy nothing — the global underneath
is already shared and already synchronised.

PRIMARY, the middle-click selection, is still not set. Markpad has never set it
and that is a feature request, not this defect.

The frontend was left alone. All six copy sites — editor copy and cut, the
preview's selection and code blocks, heading references, tab paths — already
invoke this one command, so there was no second implementation to fix.

## Tests

`scripts/clipboardOwnershipX11.test.ts`, two source-shape assertions: the copy
command calls the retaining helper, and the helper forgets the handle rather
than holding it in a local. Remove the fix and keep the tests and both go red.

They are text assertions because the proposition cannot be run — reproducing it
needs an X server and a desktop without a clipboard manager, and CI has neither.
The anchor is `retain_clipboard_ownership`, an internal name, which the template
warns about: it will go red on a rename that broke nothing. The alternative was
no guard at all on a fix whose failure mode is silent, on the one capability
class that has no workaround once the text is cut.

## Verification

```
npm audit           found 0 vulnerabilities
npm run check       820 files, 0 errors, 0 warnings
npm test            997 pass, 0 fail
npm run test:vitest 401 pass, 0 fail
cargo test          164 pass, 0 fail
```

The new code is `#[cfg]`-ed out on macOS, where I work, so `cargo check` proves
nothing about it by default. I widened the cfg to `unix`, compiled it into the
macOS build, and reverted the widening.

Not verified: the behaviour itself. I have no X11 machine, so I have not watched
a copy survive on XFCE — the claim rests on arboard 3.6.1's `Drop` and its
refcount, read rather than run. Worth a minute from someone on the reporter's
setup before this merges.
