### PR TITLE
fix(tabs): the first read of a large file measures its own tab, not the one on screen

### DIFF
--- a/scripts/firstReadMeasuresItsOwnTab.spec.ts
+++ b/scripts/firstReadMeasuresItsOwnTab.spec.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+/**
+ * Opening a large file is two reads: a 5MB slice that puts something on screen,
+ * and a background read that completes it. The slice arrives after three awaits,
+ * and the reader can switch tabs inside any of them.
+ *
+ * Every write the first stage makes is addressed by tab id, so a switch costs
+ * nothing — with a preview host per tab, the HTML lands on the tab that asked
+ * for it and is shown when that tab is next displayed. The exception was the
+ * viewport measurement: there is one article on screen and one `isAtBottom`
+ * flag, so measuring after a switch answers "does this document fit the
+ * viewport" for the tab the reader moved to, and a short one sets the flag that
+ * raises the "loading full document" chip on the tab still loading — at the top
+ * of a slice nobody has scrolled.
+ *
+ * The switch here happens inside `renderMarkdown`, which is where the real one
+ * has the most room: rendering 5MB of markdown is the longest await on the path.
+ */
+
+let handleInvoke: (cmd: string, args: any) => unknown = (cmd) => {
+	throw new Error(`unexpected invoke: ${cmd}`);
+};
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string, args: any) => Promise.resolve(handleInvoke(cmd, args)),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+const BIG = '/notes/big.md';
+const SMALL = '/notes/small.md';
+
+/** The first stage returns a slice (`isFull` false); the completion never lands. */
+function readsATruncatedFile() {
+	handleInvoke = (cmd, args) => {
+		if (cmd === 'get_os_type') return 'macos';
+		if (cmd === 'canonicalize_path') return args.path;
+		if (cmd === 'open_markdown_preview') return [args.path, 'the first five megabytes', false, false, 'UTF-8'];
+		// The background completion, left in flight: this is about the tab the
+		// first stage lands on, not about what finishes afterwards.
+		if (cmd === 'read_file_content_checked') return new Promise(() => {});
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+}
+
+function openTwoTabs() {
+	tabManager.closeAll();
+	tabManager.addTab(BIG);
+	tabManager.addTab(SMALL);
+	const big = tabManager.tabs.find((tab) => tab.path === BIG)!.id;
+	const small = tabManager.tabs.find((tab) => tab.path === SMALL)!.id;
+	tabManager.setActive(big);
+	return { big, small };
+}
+
+function makeSession(overrides: Record<string, unknown> = {}) {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async () => 'rendered',
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: (message: string, error: unknown) => {
+			throw new Error(`${message}: ${String(error)}`);
+		},
+		onDiskChangedUnderSave: () => {},
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+		onPartialCopySaved: () => {},
+		...overrides,
+	});
+}
+
+test('a switch during the first read leaves the other document unmeasured', async () => {
+	readsATruncatedFile();
+	const { big, small } = openTwoTabs();
+
+	const measuredWhileActive: (string | null)[] = [];
+	let loading: string[] = [];
+	const session = makeSession({
+		renderMarkdown: async () => {
+			tabManager.setActive(small);
+			return 'rendered';
+		},
+		setLoadingTabs: (ids: string[]) => (loading = ids),
+		measureInitialViewport: () => measuredWhileActive.push(tabManager.activeTabId),
+	});
+
+	await session.loadMarkdown(BIG);
+
+	assert.deepEqual(measuredWhileActive, [], 'the article showing the other tab is not measured');
+	// The rest of the path was already right, and stays that way: the slice and
+	// its rendered HTML are addressed by id, and so is the loading set the chip
+	// asks about.
+	assert.equal(tabManager.tabs.find((tab) => tab.id === big)!.content, 'rendered');
+	assert.equal(tabManager.tabs.find((tab) => tab.id === big)!.isTruncated, true);
+	assert.equal(tabManager.tabs.find((tab) => tab.id === small)!.content, '');
+	assert.deepEqual(loading, [big], 'the loading tab is the one that is loading, not the one on screen');
+});
+
+test('with no switch, the tab that loaded is the tab measured', async () => {
+	readsATruncatedFile();
+	const { big } = openTwoTabs();
+
+	const measuredWhileActive: (string | null)[] = [];
+	const session = makeSession({
+		measureInitialViewport: () => measuredWhileActive.push(tabManager.activeTabId),
+	});
+
+	await session.loadMarkdown(BIG);
+
+	assert.deepEqual(measuredWhileActive, [big], 'the ordinary open still measures, exactly once');
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1004,10 +1004,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	//
 	// `folds` is a parameter rather than a read of the active tab because this
 	// renders documents that are NOT on screen: a window restore renders every
-	// restored tab, a cross-window arrival renders itself, and the background
+	// restored tab, a cross-window arrival renders itself, the background
 	// completion of a large file lands long after the user may have switched
-	// away. Each of those must fold the document it is rendering, not whichever
-	// one happens to be active when the promise resolves.
+	// away, and the first-stage read in `documentSession` resolves after three
+	// awaits a switch can happen inside — the four `previewHosts` lists. Each of
+	// those must fold the document it is rendering, not whichever one happens to
+	// be active when the promise resolves.
 	async function renderMarkdownPreview(raw: string, filePath: string, folds: Set<string>) {
 		const body = getMarkdownBodyWithoutFrontMatter(raw);
 		const html = (await invoke('render_markdown', { content: body })) as string;

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -557,7 +557,18 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 						return targetTab?.path === filePath && loadRevisionByTab.get(activeId) === fullLoadRevision && !targetTab.isDirty && targetTab.isEditing === initialIsEditing && targetTab.isSplit === initialIsSplit;
 					};
 					updateLoading(activeId, true);
-					options.measureInitialViewport();
+					// Everything above addresses the tab by id, so a switch during
+					// the two reads costs nothing. This one cannot: it measures the
+					// single article on screen and writes the single `isAtBottom`
+					// flag, which gates the "loading full document" chip for
+					// whichever tab is active. Taken while another tab is showing,
+					// it answers for that document — a short one sets the flag, and
+					// switching back raises the chip at the top of a slice the
+					// reader has not scrolled. Same test as the full-load
+					// completion below, for the same reason: a measurement of the
+					// view only speaks for this load while this load's tab is the
+					// view.
+					if (tabManager.activeTabId === activeId) options.measureInitialViewport();
 					(invoke('read_file_content_checked', { path: filePath }) as Promise<[string, boolean, string]>)
 						.then(([fullContent, fullLossy, fullEncoding]) => {
 							const applyFull = () => {


### PR DESCRIPTION
Based on #730 and merges after it. #730 is what makes this the *only* thing left
wrong on this path, and the test relies on the preview host being per tab.

## What this is

Opening a large file is two reads: a slice that puts something on screen, and a
background read that completes it. The slice arrives after three awaits, and a
tab switch inside any of them left the "loading full document" chip answering for
the wrong document.

Found while auditing what else on that path reads active state, after #730 made
the preview DOM per tab.

## Mechanism

`loadMarkdown` in `sessions/documentSession.svelte.ts` captures the tab id at the
top and addresses every write by it — `setTabPathKey`, `setTabDecodedLossy`,
`setTabEncoding`, `updateTabContent`, `setTabRawContent`, `navigate`, and the
fold set. Its only guard, `isCurrentLoad()`, is a per-tab load revision: it asks
whether this is still the newest load *for this tab*, not whether that tab is
still on screen. That is the right question for all of those, because a write
addressed by id does not care what is displayed.

`measureInitialViewport()` was the one call that does. There is one `<article>`
on screen — #730 made the block hosts per tab, not the scroller — and one
module-level `isAtBottom`, and the flag gates the chip for whatever tab is
active. Called after a switch, it measures the document the reader moved to and
stores the answer for the one still loading. A short document fits the viewport,
so the flag goes true, and switching back raises the chip at the top of a slice
nobody has scrolled.

It is the only writer that can install a stale `true` and leave it there. The
flag's other writer is `handleScroll`, and a tab switch restores a different
scroll offset, which fires a scroll and corrects it.

The fix is the guard the full-load completion twenty lines below already uses,
for the same reason: a measurement of the view speaks for a load only while that
load's tab is the view.

## Scope

Cosmetic, and it self-heals on the reader's next scroll. It is here because it is
the last active-state read on a path where everything else is addressed by id,
and because that asymmetry is the kind that grows a second instance.

Deliberately left alone: the tab-management block near the top of `loadMarkdown`
reads `tabManager.activeTab` after `await canonicalizePath`. That is the function
deciding *which* tab the load is for, not acting on behalf of a tab it has
already chosen, and the window is one IPC round trip.

Also corrected the comment above `renderMarkdownPreview` in
`MarkdownViewer.svelte`. It listed three paths that render for a tab that is not
on screen; this is a fourth, and `foldsForTab(activeId)` on this path is an
instance of the rule that comment exists to explain. #730's `previewHosts`
comment already names four, so the two now agree.

## Tests

`scripts/firstReadMeasuresItsOwnTab.spec.ts` drives the real
`createDocumentSession` against a stubbed backend and switches tabs inside
`renderMarkdown` — the longest await on the path, and where a real switch has the
most room. One test asserts nothing is measured for the tab the reader left, and
that the slice, its HTML and the loading set still land on the loading tab; a
control asserts an ordinary open still measures exactly once.

Revert the guard, keep the tests: the first goes red — `measuredWhileActive`
receives the other tab's id instead of nothing. The control stays green either
way, which is the point of it.

## Verification

```
npm audit            0 vulnerabilities
npm run check        822 files, 0 errors, 0 warnings
npm test             998 pass, 0 fail
npm run test:vitest  408 pass, 0 fail
cargo test           164 pass, 0 fail
```

Not verified: the symptom on screen. Seeing it needs a markdown file over the
truncation threshold and a hand-timed tab switch in a running build. The claim
here is reasoned from the flag's two writers and its single consumer, and
reproduced in jsdom against the real session — not observed in the app.
