### PR TITLE
fix(tabs): the preview's in-page back/forward stacks belong to the tab, not the window

### DIFF
--- a/scripts/lossyDecodeSaveGuard.test.ts
+++ b/scripts/lossyDecodeSaveGuard.test.ts
@@ -216,6 +216,8 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		isScrollSynced: false,
 		hasReplacementChars: true,
 		encoding: 'UTF-8',
+		scrollHistory: [],
+		scrollFuture: [],
 		foldOverrides: new Set<string>(),
 		...overrides,
 	};

--- a/scripts/scrollHistoryPerTab.spec.ts
+++ b/scripts/scrollHistoryPerTab.spec.ts
@@ -1,0 +1,339 @@
+/**
+ * The preview's in-page back/forward stacks belong to the document they were
+ * measured in.
+ *
+ * They hold raw `markdownBody.scrollTop` pixels — where the reader was standing
+ * before each anchor jump — and the viewer held ONE pair for the whole window.
+ * Nothing emptied it on a tab switch, and a tab switch reloads nothing, so a
+ * jump in a long document left an offset behind that the next mouse-back in
+ * whatever tab the reader landed on would scroll to. A long document followed
+ * by a short one is the visible case: the short one has no such offset to be
+ * at, so it goes as far as it can and stops somewhere the reader has never
+ * been. The only reset was `resetScrollHistory`, an option of `loadMarkdown`,
+ * which fires for a document LOAD and not for a switch.
+ *
+ * These stacks are not `Tab.history`/`historyIndex`, which is the FILE the tab
+ * points at and is what the mouse falls through to when there is no jump left
+ * to undo. Both are exercised below, because the fall-through is the half a
+ * per-tab stack changes: a tab with a stale offset never reached it.
+ *
+ * Everything here runs the REAL `TabManager` — the same `pushScrollHistory`,
+ * `popScrollHistoryBack` and `popScrollHistoryForward` the viewer calls, the
+ * real `navigate`/`goBack`/`goForward`, the real serialization and the real
+ * cross-window snapshot. Nothing asserts on the text of an implementation file.
+ *
+ * WHAT IS NOT THE REAL THING, AND WHY. `handleMouseUp` lives in
+ * MarkdownViewer.svelte and is not exported; `mouseButton` below is its three
+ * lines, restated. What it stands in for is one `markdownBody.scrollTop` read —
+ * jsdom has no layout, so the offsets here are supplied rather than measured,
+ * which is also why this file asks "which offset comes back" and never "where
+ * does the preview end up".
+ */
+
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin. Only the Tauri backend is stubbed — importing the store boots
+// the settings singleton, which asks for the OS type.
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { snapshotTab, buildTransferredTab } = await import('../src/lib/utils/tabTransfer.js');
+
+// ------------------------------------------------------------------ the wiring
+
+type Direction = 'back' | 'forward';
+
+/**
+ * What the mouse's back and forward buttons do, as `handleMouseUp` wires them:
+ * pop the tab's in-page stack first, and move to another DOCUMENT only when
+ * that tab has no jump left to walk. `at` is where the reader is standing,
+ * which the viewer reads off the preview container.
+ */
+function mouseButton(direction: Direction, at: number): { scrolledTo: number } | { openedFile: string | null } {
+	const id = tabManager.activeTabId!;
+	const pos =
+		direction === 'back'
+			? tabManager.popScrollHistoryBack(id, at)
+			: tabManager.popScrollHistoryForward(id, at);
+	if (pos !== null) return { scrolledTo: pos };
+	return { openedFile: direction === 'back' ? tabManager.goBack(id) : tabManager.goForward(id) };
+}
+
+/** An anchor jump: the reader was at `at`, and is about to be somewhere else. */
+function jumpFrom(at: number) {
+	tabManager.pushScrollHistory(tabManager.activeTabId!, at);
+}
+
+function reset() {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+}
+
+const stackOf = (id: string) => tabManager.tabs.find((t) => t.id === id)!.scrollHistory;
+const futureOf = (id: string) => tabManager.tabs.find((t) => t.id === id)!.scrollFuture;
+
+/** A long document and a short one, a jump made in the long one, landing on the short. */
+function jumpInLongThenSwitchToShort() {
+	reset();
+	tabManager.addTab('/notes/long.md', '# Long\n');
+	const long = tabManager.activeTabId!;
+	tabManager.addTab('/notes/short.md', '# Short\n');
+	const short = tabManager.activeTabId!;
+
+	tabManager.setActive(long);
+	jumpFrom(8400);
+
+	tabManager.setActive(short);
+	return { long, short };
+}
+
+// ------------------------------------------------- the switch the bug was about
+
+test('a back click in one document does not scroll to an offset measured in another', () => {
+	const { short } = jumpInLongThenSwitchToShort();
+
+	const result = mouseButton('back', 0);
+
+	assert.deepEqual(stackOf(short), []);
+	assert.ok(!('scrolledTo' in result), 'the short document has no jump of its own to go back to');
+});
+
+test('with no jump of its own, back moves the tab to the previous FILE instead', () => {
+	reset();
+	tabManager.addTab('/notes/long.md', '# Long\n');
+	const long = tabManager.activeTabId!;
+	jumpFrom(8400);
+
+	tabManager.addTab('/notes/short.md', '# Short\n');
+	const short = tabManager.activeTabId!;
+	tabManager.navigate(short, '/notes/other.md');
+
+	assert.deepEqual(mouseButton('back', 0), { openedFile: '/notes/short.md' });
+	// ...and the tab that DID jump still has its own offset waiting.
+	assert.deepEqual(stackOf(long), [8400]);
+});
+
+test('the offset is still there when the reader comes back to the document they jumped in', () => {
+	const { long } = jumpInLongThenSwitchToShort();
+
+	tabManager.setActive(long);
+
+	assert.deepEqual(mouseButton('back', 200), { scrolledTo: 8400 });
+});
+
+test('forward is per tab too', () => {
+	const { long, short } = jumpInLongThenSwitchToShort();
+
+	tabManager.setActive(long);
+	mouseButton('back', 200);
+	assert.deepEqual(futureOf(long), [200]);
+
+	tabManager.setActive(short);
+	assert.deepEqual(futureOf(short), []);
+	assert.ok(!('scrolledTo' in mouseButton('forward', 0)));
+});
+
+test('two tabs jumped in keep their own offsets, in their own order', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(100);
+	jumpFrom(200);
+
+	tabManager.addTab('/notes/b.md', '# B\n');
+	const b = tabManager.activeTabId!;
+	jumpFrom(900);
+
+	tabManager.setActive(a);
+	assert.deepEqual(mouseButton('back', 250), { scrolledTo: 200 });
+	assert.deepEqual(mouseButton('back', 200), { scrolledTo: 100 });
+
+	tabManager.setActive(b);
+	assert.deepEqual(mouseButton('back', 950), { scrolledTo: 900 });
+});
+
+test('an untitled buffer has a stack of its own', () => {
+	reset();
+	tabManager.addNewTab();
+	const untitled = tabManager.activeTabId!;
+	jumpFrom(300);
+
+	tabManager.addTab('/notes/a.md', '# A\n');
+	assert.deepEqual(stackOf(tabManager.activeTabId!), []);
+
+	tabManager.setActive(untitled);
+	assert.deepEqual(mouseButton('back', 400), { scrolledTo: 300 });
+});
+
+test('closing a tab takes its offsets with it', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(500);
+	tabManager.addTab('/notes/b.md', '# B\n');
+
+	tabManager.closeTab(a);
+	tabManager.addTab('/notes/a.md', '# A\n');
+
+	assert.deepEqual(stackOf(tabManager.activeTabId!), []);
+});
+
+// ------------------------------------- repointing the tab at another document
+
+test('following a link drops the offsets of the document left behind', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+
+	tabManager.navigate(a, '/notes/b.md');
+
+	assert.deepEqual(stackOf(a), []);
+	assert.ok(!('scrolledTo' in mouseButton('back', 0)));
+});
+
+test('going back to the previous file drops them', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	tabManager.navigate(a, '/notes/b.md');
+	jumpFrom(4000);
+
+	assert.equal(tabManager.goBack(a), '/notes/a.md');
+	assert.deepEqual(stackOf(a), []);
+});
+
+test('going forward again drops them', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	tabManager.navigate(a, '/notes/b.md');
+	tabManager.goBack(a);
+	jumpFrom(4000);
+
+	assert.equal(tabManager.goForward(a), '/notes/b.md');
+	assert.deepEqual(stackOf(a), []);
+});
+
+test('the forward stack goes with them', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+	mouseButton('back', 4200);
+	assert.deepEqual(futureOf(a), [4200]);
+
+	tabManager.navigate(a, '/notes/b.md');
+
+	assert.deepEqual(futureOf(a), []);
+});
+
+test('Save As keeps them, because the document on screen has not changed', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+
+	tabManager.updateTabPath(a, '/notes/copy.md');
+
+	assert.deepEqual(mouseButton('back', 4200), { scrolledTo: 4000 });
+});
+
+test('renaming the file on disk keeps them', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+
+	tabManager.renameTab(a, '/notes/renamed.md');
+
+	assert.deepEqual(mouseButton('back', 4200), { scrolledTo: 4000 });
+});
+
+test('a reload in place drops them, because the text they were measured in is gone', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+
+	tabManager.clearScrollHistory(a);
+
+	assert.deepEqual(stackOf(a), []);
+	assert.deepEqual(futureOf(a), []);
+});
+
+// -------------------------------------------------------------- the stack itself
+
+test('a new jump abandons the forward stack, as every history does', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(100);
+	mouseButton('back', 500);
+	assert.deepEqual(futureOf(a), [500]);
+
+	jumpFrom(700);
+
+	assert.deepEqual(futureOf(a), []);
+});
+
+test('back and forward walk the same offsets in both directions', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	jumpFrom(100);
+	jumpFrom(400);
+
+	assert.deepEqual(mouseButton('back', 900), { scrolledTo: 400 });
+	assert.deepEqual(mouseButton('back', 400), { scrolledTo: 100 });
+	assert.deepEqual(mouseButton('forward', 100), { scrolledTo: 400 });
+	assert.deepEqual(mouseButton('forward', 400), { scrolledTo: 900 });
+});
+
+test('a tab remembers the last fifty jumps and drops the oldest', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	for (let i = 1; i <= 55; i += 1) jumpFrom(i);
+
+	assert.equal(stackOf(a).length, 50);
+	assert.equal(stackOf(a)[0], 6);
+	assert.equal(stackOf(a)[49], 55);
+});
+
+// ------------------------------------------------ what deliberately does not travel
+
+test('a restored window opens with no offsets to walk', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	jumpFrom(4000);
+	const saved = tabManager.serializeState();
+
+	reset();
+	tabManager.restoreState(saved);
+
+	const restored = tabManager.tabs.find((t) => t.path === '/notes/a.md')!;
+	assert.deepEqual(restored.scrollHistory, []);
+	assert.deepEqual(restored.scrollFuture, []);
+});
+
+test('a tab moved to another window arrives with none either', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+
+	const arrived = buildTransferredTab(
+		snapshotTab(tabManager.tabs.find((t) => t.id === a)!),
+		[],
+		'Untitled',
+	);
+
+	assert.deepEqual(arrived.scrollHistory, []);
+	assert.deepEqual(arrived.scrollFuture, []);
+});

--- a/scripts/tabTransfer.test.ts
+++ b/scripts/tabTransfer.test.ts
@@ -41,6 +41,8 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		isScrollSynced: true,
 		hasReplacementChars: false,
 		encoding: 'UTF-8',
+		scrollHistory: [],
+		scrollFuture: [],
 		foldOverrides: new Set<string>(),
 		...overrides,
 	};

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -344,9 +344,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 	}
 
-	// in-page scroll position history for mouse 4/5 nav
-	let scrollHistory: number[] = [];
-	let scrollFuture: number[] = [];
 	let zoomData = $state<{ src?: string; html?: string } | null>(null);
 
 	// What a document with no tab behind it has folded. Never written to — every
@@ -819,8 +816,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		setShowHome: (value) => (showHome = value),
 		currentFile: () => currentFile,
 		resetScrollHistory: () => {
-			scrollHistory = [];
-			scrollFuture = [];
+			if (tabManager.activeTabId) tabManager.clearScrollHistory(tabManager.activeTabId);
 		},
 		renderMarkdown: renderMarkdownPreview,
 		afterLoad: tick,
@@ -1716,7 +1712,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (!resolved) return;
 
 		tabManager.addTab(resolved);
-		await loadMarkdown(resolved, { skipTabManagement: true, resetScrollHistory: true });
+		await loadMarkdown(resolved, { skipTabManagement: true });
 		if (target.hash) {
 			await scrollToAnchorWhenReady(target.hash, { pushHistory: false }, resolved);
 		}
@@ -3174,42 +3170,46 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			: tabManager.goForward(activeTabId);
 
 		if (path) {
-			await loadMarkdown(path, { skipTabManagement: true, resetScrollHistory: true });
+			// No `resetScrollHistory` here, and none in `openMarkdownTargetInNewTab`
+			// either: goBack/goForward repoint the tab, so `clearReadingPosition`
+			// has already dropped its in-page stacks along with the rest of the
+			// position, and a tab opened by `addTab` never had any.
+			await loadMarkdown(path, { skipTabManagement: true });
 		}
 	}
 
+	// The in-page jump stacks belong to the tab the offsets were measured in —
+	// see `Tab.scrollHistory`. These three wrappers exist only to name that tab
+	// and to read the offset off the preview, which the store cannot see.
 	function pushScrollHistory() {
-		if (markdownBody) {
-			scrollHistory.push(markdownBody.scrollTop);
-			scrollFuture = [];
-			if (scrollHistory.length > 50) scrollHistory.shift();
+		if (markdownBody && tabManager.activeTabId) {
+			tabManager.pushScrollHistory(tabManager.activeTabId, markdownBody.scrollTop);
 		}
+	}
+
+	/**
+	 * Where an in-page back/forward would land, or null if this tab has no jump
+	 * to walk — the caller then falls through to the FILE history.
+	 */
+	function popScrollHistory(direction: 'back' | 'forward'): number | null {
+		if (!markdownBody || !tabManager.activeTabId) return null;
+		return direction === 'back'
+			? tabManager.popScrollHistoryBack(tabManager.activeTabId, markdownBody.scrollTop)
+			: tabManager.popScrollHistoryForward(tabManager.activeTabId, markdownBody.scrollTop);
 	}
 
 	async function handleMouseUp(e: MouseEvent) {
-		if (e.button === 3) {
-			// Back
-			e.preventDefault();
-			// try in-page scroll history first
-			if (scrollHistory.length > 0 && markdownBody) {
-				scrollFuture.push(markdownBody.scrollTop);
-				const pos = scrollHistory.pop()!;
-				isProgrammaticScroll = true;
-				markdownBody.scrollTo({ top: pos, behavior: jumpBehavior });
-			} else {
-				await navigateFileHistory('back');
-			}
-		} else if (e.button === 4) {
-			// Forward
-			e.preventDefault();
-			if (scrollFuture.length > 0 && markdownBody) {
-				scrollHistory.push(markdownBody.scrollTop);
-				const pos = scrollFuture.pop()!;
-				isProgrammaticScroll = true;
-				markdownBody.scrollTo({ top: pos, behavior: jumpBehavior });
-			} else {
-				await navigateFileHistory('forward');
-			}
+		if (e.button !== 3 && e.button !== 4) return;
+		const direction = e.button === 3 ? 'back' : 'forward';
+		e.preventDefault();
+		// In-page scroll history first; only a tab with no jump left to undo
+		// moves to another document.
+		const pos = popScrollHistory(direction);
+		if (pos !== null && markdownBody) {
+			isProgrammaticScroll = true;
+			markdownBody.scrollTo({ top: pos, behavior: jumpBehavior });
+		} else {
+			await navigateFileHistory(direction);
 		}
 	}
 

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -12,6 +12,16 @@ export type LoadMarkdownOptions = {
 	navigate?: boolean;
 	skipTabManagement?: boolean;
 	preserveEditState?: boolean;
+	/**
+	 * Drop the receiving tab's in-page jump stacks (`Tab.scrollHistory`).
+	 *
+	 * Only the two reloads ask for it: the tab keeps the document it already
+	 * had, so nothing repoints it and `clearReadingPosition` never runs, but
+	 * the text underneath is about to be replaced by whatever is on disk now
+	 * and the recorded offsets describe the version being thrown away. A caller
+	 * that changes which document a tab holds does not belong here — that route
+	 * clears the stacks with the rest of the reading position.
+	 */
 	resetScrollHistory?: boolean;
 	/**
 	 * Read the file even though the tab that will receive it holds unsaved
@@ -411,6 +421,12 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		let existing = null;
 		let pendingNavigateTabId: string | null = null;
 		try {
+			// The second arm predates the stacks being per tab and is kept as it
+			// was: this runs before tab management, so the tab it reaches is the
+			// one being LEFT, and opening another file has always cleared the
+			// in-page stacks of whatever was on screen. Narrowing that to "only
+			// the tab whose text actually changes" is a behaviour change on its
+			// own terms, not part of making the stacks per tab.
 			if (loadOptions.resetScrollHistory || filePath !== options.currentFile()) {
 				options.resetScrollHistory();
 			}

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -168,6 +168,37 @@ export interface Tab {
 	 */
 	scrollPercentage: number;
 	anchorLine: RendererLine;
+	/**
+	 * Where the reader was standing before each in-page jump, and where they
+	 * came back from — the two stacks the mouse's back and forward buttons
+	 * walk. Raw preview pixels, in the same space as `scrollTop`: pushed by
+	 * every anchor jump (a heading in the outline, a link into the same
+	 * document), popped by `popScrollHistoryBack` / `popScrollHistoryForward`.
+	 *
+	 * Nothing to do with `history` / `historyIndex` above, which are the FILE
+	 * this tab points at. These two never leave the current document.
+	 *
+	 * Per tab for the reason the position fields above are per tab: an offset
+	 * only means anything in the document it was measured in. One window-wide
+	 * pair meant a back click in a short document scrolled it to an offset
+	 * recorded in a long one, because a tab switch reloads nothing and so reset
+	 * nothing.
+	 *
+	 * Cleared with the rest of the reading position when the tab is repointed
+	 * at another file — see `clearReadingPosition`. A reload of the SAME
+	 * document in place is a separate trigger and clears them separately; see
+	 * `resetScrollHistory` in documentSession.
+	 *
+	 * Neither persisted nor carried between windows: pixels measured in one
+	 * container are wrong in a container of another height, which is already
+	 * why `scrollTop` is the last resort of the restore cascade. A stack of
+	 * them is not worth a schema entry. See `serializeState` and tabTransfer.ts.
+	 *
+	 * Required, like `foldOverrides`: every consumer pushes and pops, so a
+	 * construction site that forgot one would hand them `undefined`.
+	 */
+	scrollHistory: number[];
+	scrollFuture: number[];
 	isSplit: boolean;
 	splitRatio: number;
 	isScrollSynced: boolean;
@@ -288,6 +319,9 @@ export interface Tab {
 	pathKey?: string;
 }
 
+/** How many in-page jumps back a tab remembers. See `Tab.scrollHistory`. */
+const SCROLL_HISTORY_LIMIT = 50;
+
 class TabManager {
 	tabs = $state<Tab[]>([]);
 	activeTabId = $state<string | null>(null);
@@ -346,6 +380,12 @@ class TabManager {
 	 * that the user never folded in the text now on screen — the failure this
 	 * per-tab state exists to remove. Scroll degrades (you scroll); a fold
 	 * hides text.
+	 *
+	 * Nor are `scrollHistory`/`scrollFuture`. Those are pixels too, but unlike
+	 * `scrollTop` they are not a position to approximate — they are a record of
+	 * jumps the reader made in a session that has ended, in a window that may
+	 * come back a different size. Restoring them would arm the back button with
+	 * offsets nobody in this session created.
 	 */
 	serializeState(): string {
 		const stateData = {
@@ -423,6 +463,9 @@ class TabManager {
 					// exactly why the read side has to re-declare what came back.
 					// `serializeState` wrote a renderer line; this says so again.
 					anchorLine: asRendererLine(typeof saved.anchorLine === 'number' ? saved.anchorLine : 0),
+					// Not persisted — see serializeState.
+					scrollHistory: [],
+					scrollFuture: [],
 					isSplit: saved.isSplit === true,
 					splitRatio: typeof saved.splitRatio === 'number' ? saved.splitRatio : 0.5,
 					isScrollSynced: saved.isScrollSynced === true,
@@ -564,6 +607,8 @@ class TabManager {
 			editorViewState: null,
 			scrollPercentage: 0,
 			anchorLine: asRendererLine(0),
+			scrollHistory: [],
+			scrollFuture: [],
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
@@ -605,6 +650,8 @@ class TabManager {
 			editorViewState: null,
 			scrollPercentage: 0,
 			anchorLine: asRendererLine(0),
+			scrollHistory: [],
+			scrollFuture: [],
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
@@ -642,6 +689,8 @@ class TabManager {
 			editorViewState: null,
 			scrollPercentage: 0,
 			anchorLine: asRendererLine(0),
+			scrollHistory: [],
+			scrollFuture: [],
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
@@ -864,6 +913,64 @@ class TabManager {
 	}
 
 	/**
+	 * The in-page back/forward stacks — see `Tab.scrollHistory`. Three methods
+	 * rather than a field the viewer reaches into, because the tab they belong
+	 * to is the thing that used to be got wrong: the viewer holds the offsets
+	 * of the document ON SCREEN, and the only way to be sure of that is to name
+	 * the tab on every push and every pop.
+	 *
+	 * `from` is where the reader is standing right now, which the caller has
+	 * and this file does not. Popping records it on the opposite stack, so back
+	 * and forward walk the same path in both directions.
+	 */
+	pushScrollHistory(id: string, from: number) {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (!tab) return;
+		tab.scrollHistory.push(from);
+		tab.scrollFuture = [];
+		// A reader who has jumped fifty times is not going back to the first
+		// one, and the stack is per tab now — a window full of documents would
+		// otherwise keep every offset any of them ever had.
+		if (tab.scrollHistory.length > SCROLL_HISTORY_LIMIT) tab.scrollHistory.shift();
+	}
+
+	/**
+	 * Where to scroll back to, or null if this tab has no in-page jump to undo
+	 * — which is the caller's cue to fall through to the FILE history
+	 * (`goBack`), a different thing entirely.
+	 */
+	popScrollHistoryBack(id: string, from: number): number | null {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (!tab || tab.scrollHistory.length === 0) return null;
+		tab.scrollFuture.push(from);
+		return tab.scrollHistory.pop()!;
+	}
+
+	/** The mirror of `popScrollHistoryBack`; falls through to `goForward`. */
+	popScrollHistoryForward(id: string, from: number): number | null {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (!tab || tab.scrollFuture.length === 0) return null;
+		tab.scrollHistory.push(from);
+		return tab.scrollFuture.pop()!;
+	}
+
+	/**
+	 * This tab still holds the same document, but its text has been replaced
+	 * from disk — a reload, or the "Reload" answer to an external change. The
+	 * offsets describe a document that is gone, so they go with it.
+	 *
+	 * Separate from `clearReadingPosition`, which answers a different question
+	 * (the tab now holds a DIFFERENT document) and is reached from the three
+	 * navigation routes rather than from a load.
+	 */
+	clearScrollHistory(id: string) {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (!tab) return;
+		tab.scrollHistory = [];
+		tab.scrollFuture = [];
+	}
+
+	/**
 	 * Replace this tab's fold overrides. Callers build a NEW set rather
 	 * than mutating the old one — see `Tab.foldOverrides`.
 	 */
@@ -1062,6 +1169,13 @@ class TabManager {
 	 * source line, and the line the reader left in one file names an unrelated
 	 * block in the next one.
 	 *
+	 * `scrollHistory`/`scrollFuture` are here for the same reason one step
+	 * removed: they are not where the reader IS but where they were standing
+	 * before each jump, and an offset recorded in the document the tab has just
+	 * left is no more meaningful than the position it left. Left behind, the
+	 * next back click in the incoming document scrolls it somewhere the reader
+	 * has never been.
+	 *
 	 * Nothing here scrolls anything; a restore runs on tab activation and on
 	 * editor mount, which is why the symptom of getting this wrong shows up on
 	 * a later tab switch rather than at the moment of the navigation.
@@ -1074,6 +1188,8 @@ class TabManager {
 		tab.anchorLine = asRendererLine(0);
 		tab.scrollPercentage = 0;
 		tab.scrollTop = 0;
+		tab.scrollHistory = [];
+		tab.scrollFuture = [];
 	}
 
 	/**

--- a/src/lib/utils/tabTransfer.ts
+++ b/src/lib/utils/tabTransfer.ts
@@ -22,6 +22,13 @@ import { nextUntitledTitle } from './untitledTitle.js';
  *   open is the honest version of "this was rendered fresh here". Carrying it
  *   would mean a new required entry in the strict validator below, which is a
  *   change to make on its own terms.
+ * - `scrollHistory`/`scrollFuture`: raw preview pixels, and the destination
+ *   window is a different container of a different height — `scrollTop` only
+ *   travels because it is the LAST resort of a cascade that starts with
+ *   `anchorLine`, and a back stack has no such cascade to be wrong under.
+ *   Arriving empty means the back button walks the file history until the
+ *   reader jumps in the new window, which is what a freshly opened document
+ *   does anyway.
  */
 export interface TransferableTab {
 	path: string;
@@ -216,6 +223,9 @@ export function buildTransferredTab(
 		editorViewState: null,
 		scrollPercentage: snap.scrollPercentage,
 		anchorLine: snap.anchorLine,
+		// Not carried — see the header.
+		scrollHistory: [],
+		scrollFuture: [],
 		isSplit: snap.isSplit,
 		splitRatio: snap.splitRatio,
 		isScrollSynced: snap.isScrollSynced,


### PR DESCRIPTION
## What this is

The preview keeps an in-page scroll history — where the reader was standing
before each anchor jump — so the mouse's back and forward buttons can return
there. It was two module-level arrays in `MarkdownViewer.svelte`, one pair for
the whole window. Jump to a heading in one tab, switch to another, press
mouse-back, and the second document scrolls to an offset measured in the first.
A long document followed by a short one is the visible case: the short one has
no such offset to be at, so it goes as far as it can and stops somewhere the
reader has never been.

The stacks now live on the tab, as `Tab.scrollHistory` / `Tab.scrollFuture`,
and are pushed and popped through `TabManager` so every write names the tab
whose document the offset came from.

**Based on #730 and has to merge after it.** That branch rewrites the preview
DOM in the same file, and this sits on top of it.

## Mechanism

Two arrays at `MarkdownViewer.svelte:348-349`, written by `pushScrollHistory()`
and consumed by the mouse 4/5 handler below it. The only thing that emptied
them was the `resetScrollHistory` callback the viewer hands to
`documentSession`, which `loadMarkdown` calls — so the reset was tied to a
document LOAD. A tab switch is `tabManager.setActive`; it loads nothing, and
after #730 it does not even rebuild the DOM. Nothing on that path had any
reason to touch a pair of arrays it could not see.

The tab already owns four other fields that answer "where was the reader in
this document" (`editorViewState`, `anchorLine`, `scrollPercentage`,
`scrollTop`), and `clearReadingPosition` already clears them as a set when a
tab is pointed at a different file. The jump stacks are the same class of
state one step removed — not where the reader is, but where they were before
each jump — so they go in the same place and are cleared by the same call,
rather than getting a mechanism of their own to drift out of step with.

## Scope

**Where the state lives.** On `Tab`, not in a map keyed by tab id in the
viewer. A map would need its own cleanup on tab close and its own hook into
the document-swap routes — which live in `tabs.svelte.ts` and cannot call back
into the viewer — and that hook is exactly the second answer to a question
`clearReadingPosition` already answers.

**Neither serialization contract carries it.** `serializeState` does not write
it and `restoreState` rebuilds it empty; `tabTransfer.ts` leaves it out of
`TransferableTab` entirely, so the strict validator's required-field set is
unchanged and the tests pinning that payload still pin the same shape.
`scrollTop` travels in both because it is the last resort of a cascade that
starts with `anchorLine` — an approximation of a position, degrading to a
scroll. A stack of jump origins has no cascade to be wrong under: restored into
a window of another size, or into a session that made none of those jumps, it
would arm the back button with offsets nobody created. Both exclusions are
stated where the exclusions are already listed, next to the one for
`foldOverrides`.

**`resetScrollHistory` stays, and now means one thing.** Two of its four call
sites are reloads of the same file into the same tab — the external-change
"Reload" and "Reload from disk". Those keep the document and replace the text
under it, so nothing repoints the tab and `clearReadingPosition` never runs,
but the offsets describe the version being thrown away. The other two call
sites passed the flag on a document swap (`navigateFileHistory`) and on a tab
that was created empty a line earlier (`openMarkdownTargetInNewTab`); both are
now answered by the tab itself, so the flag is gone from them. Neither removal
changes behaviour.

**What I left as it was.** `loadMarkdown` also resets when `filePath !==
currentFile()`, and that arm runs before tab management — so the tab it reaches
is the one being left. Opening another file has always cleared the in-page
stacks of whatever was on screen, and it still does, one tab instead of the
window. Narrowing it to "only the tab whose text actually changes" would be a
better behaviour, but it makes `currentFile` a dead option and takes 16 spec
files with it; that is a change to make on its own terms, and there is a
comment at the line saying so.

**Not touched:** `Tab.history` / `historyIndex` / `navigate` / `goBack` /
`goForward` — the FILE history, a different mechanism that happens to share the
words "back" and "forward". The mouse falls through to it when a tab has no
in-page jump left, and that fall-through is tested here precisely because it is
the half a per-tab stack changes: a tab holding a stale offset never reached it.

## Tests

`scripts/scrollHistoryPerTab.spec.ts`, 19 behaviour tests against the real
`TabManager` — the same `pushScrollHistory`, `popScrollHistoryBack` and
`popScrollHistoryForward` the viewer calls, the real `navigate`/`goBack`/
`goForward`, the real `serializeState`/`restoreState`, and the real
`snapshotTab`/`buildTransferredTab`. Nothing in it matches source text.

`handleMouseUp` is not exported, so the file restates its three lines as
`mouseButton(direction, at)` — pop the tab's stack, fall through to the file
history when it is empty — and names that as a stand-in in the header, the way
`foldStatePerDocument.spec.ts` names `foldsForTab`. `at` stands in for one
`markdownBody.scrollTop` read: jsdom has no layout, so the file asks which
offset comes back and never where the preview ends up.

Reverting the fix and keeping the test:

- Put the stacks back in one window-wide pair, leaving the method signatures
  alone: **8 of 19 fail**, including "a back click in one document does not
  scroll to an offset measured in another" and "with no jump of its own, back
  moves the tab to the previous FILE instead".
- Keep the per-tab stacks but drop the two lines from `clearReadingPosition`:
  **4 of 19 fail** — the link-follow and the two file-history routes, plus the
  forward stack surviving a navigation.

## Verification

Real Node v24, from the worktree root. Baseline on `fix/tab-switch-keeps-its-dom`
before any edit, then again after:

```
npm audit                       0 vulnerabilities            (unchanged)
npx svelte-check                821 -> 822 files, 0 errors   (+1: the new spec)
node --test scripts/*.test.ts   998 pass, 0 fail             (unchanged)
npx vitest run                  406 -> 425 pass, 0 fail      (+19: the new spec)
cargo test                      164 pass, 0 fail             (unchanged)
```

What I did not verify: there is no way to run the app in this environment, so I
did not click the mouse buttons in a real window. Everything above is the store
driven directly plus the viewer's wiring read and restated. The two paths I
reasoned about rather than ran are the ones that route through
`loadMarkdown`'s pre-tab-management reset — an open of a different file, and an
empty untitled tab being repointed by `updateTabPath` — where the argument is
that the tab in question has an empty stack either way. Nothing was checked on
Windows or Linux, though nothing here is platform-specific.
