### PR TITLE
A tab dragged into another window opens where its reader left it

### DIFF
--- a/scripts/previewAnchorRestore.test.ts
+++ b/scripts/previewAnchorRestore.test.ts
@@ -429,30 +429,39 @@ test('source position ranges parse the way comrak writes them', () => {
 });
 
 /**
- * The two assertions below are source assertions, not behavior assertions: the
- * restore effect lives inside a Svelte component and cannot be imported. They
- * pin the wiring — that the component calls the measured resolver, and that the
- * top-level-only scan the rates above were measured against does not come back.
+ * The assertions below are source assertions, not behavior assertions: the
+ * restore is triggered from inside a Svelte component and that effect cannot be
+ * imported. They pin the wiring — that the component restores through the
+ * measured cascade, and that the top-level-only scan the rates above were
+ * measured against does not come back.
+ *
+ * The cascade itself moved out of the component and into
+ * `restorePreviewReadingPosition`, next to the resolvers it runs, when the
+ * arrival of a transferred tab needed to run the same one after its document
+ * lands (see tabTransferHandoff.test.ts). So "it resolves through the measured
+ * helpers" is now a behavior claim, made by calling the function — every test
+ * above this one, and the arrival tests in tabReadingPosition.spec.ts. What is
+ * left here is what a source assertion is for: that there is no second copy.
  */
 test('the viewer restores through the measured resolver', async () => {
 	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 	// Read out of the one import statement rather than matched across the whole
-	// file: `import \{[\s\S]*findAnchorElement[\s\S]*\} from '…previewAnchor.js'`
-	// starts at the first import in the file and runs past every brace in
-	// between, so forking the two resolvers into another module while leaving
-	// the rest of the import behind satisfied it.
+	// file: `import \{[\s\S]*restorePreviewReadingPosition[\s\S]*\} from
+	// '…previewAnchor.js'` starts at the first import in the file and runs past
+	// every brace in between, so forking the cascade into another module while
+	// leaving the rest of the import behind satisfied it.
 	const anchorImport = viewer.match(/import \{([^}]*)\} from '\.\/utils\/previewAnchor\.js'/);
 	assert.ok(anchorImport, 'the viewer must import from previewAnchor.js');
 	const imported = anchorImport[1].split(',').map((name) => name.trim()).filter(Boolean);
-	assert.deepEqual(
-		['findAnchorElement', 'getAnchorScrollTop'].filter((name) => !imported.includes(name)),
-		[],
-		'the restore must resolve through the measured helpers, not a fork of them',
+	assert.ok(
+		imported.includes('restorePreviewReadingPosition'),
+		'the restore must go through the shared cascade, not a fork of it',
 	);
-	assert.match(
-		viewer,
-		/const match = findAnchorElement\(body, tab\.anchorLine\);[\s\S]*body\.scrollTop = getAnchorScrollTop\(/,
-	);
+	// And the component must not grow one of its own back: the cascade is an
+	// ORDER, and a second site consulting the same three fields in a different
+	// one is a different answer for the same tab.
+	assert.doesNotMatch(viewer, /scrollTop = getAnchorScrollTop\(/);
+	assert.doesNotMatch(viewer, /tab\.scrollPercentage/);
 	assert.doesNotMatch(viewer, /Array\.from\(body\.children\)/);
 });

--- a/scripts/tabReadingPosition.spec.ts
+++ b/scripts/tabReadingPosition.spec.ts
@@ -66,7 +66,14 @@ import { test } from 'vitest';
 
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { processMarkdownHtml } = await import('../src/lib/utils/markdown.js');
-const { findAnchorElement } = await import('../src/lib/utils/previewAnchor.js');
+const {
+	findAnchorElement,
+	parseSourceposLineRange,
+	PREVIEW_ANCHOR_OFFSET,
+	restorePreviewReadingPosition,
+} = await import('../src/lib/utils/previewAnchor.js');
+type AnchorNode = Parameters<typeof findAnchorElement>[0];
+type AnchorBox = ReturnType<Parameters<typeof restorePreviewReadingPosition>[3]>;
 const { asRendererLine, lineCoordinates } = await import('../src/lib/utils/lineCoordinates.js');
 const { snapshotTab, validateTransferPayload } = await import('../src/lib/utils/tabTransfer.js');
 
@@ -378,4 +385,119 @@ test('branding both sides of a snapshot changes none of its bytes', () => {
 
 	tabManager.restoreState(tabManager.serializeState());
 	assert.equal(tabManager.tabs.find((item) => item.path === '/notes/a.md')?.anchorLine, 812);
+});
+
+/* ------------------------------------------------------------------ */
+/* the arrival of a tab from another window                            */
+/* ------------------------------------------------------------------ */
+//
+// The transfer payload carries all three fields (`tabTransfer.ts`), so the
+// destination has everything it needs — and used to open the document at the
+// top anyway, because of WHEN it asked.
+//
+// `insertTransferredTab` pushes the tab and activates it synchronously, while
+// its rendered `content` is still the `''` every construction site seeds. The
+// preview's restore effect runs on that activation, against a host holding no
+// document; `acceptTransferredTab` only awaits `renderTabPreviewFromRaw`
+// afterwards, and nothing re-triggers the effect when that document lands (it
+// depends on the tab id, the article and the path — deliberately not on the
+// render, which also fires on every debounced re-render while the reader is
+// typing in split view).
+//
+// The two tests below are the two moments, run against the REAL cascade over
+// the REAL `processMarkdownHtml` output of the document being transferred.
+// What they cannot be is a live drag: two windows and a Rust broker are not
+// reachable from here, so the sequence is replayed rather than performed, and
+// the wiring that performs it is asserted in `tabTransferHandoff.test.ts`.
+
+/**
+ * A layout in which every source line is `LINE_HEIGHT` tall.
+ *
+ * jsdom reports 0 for every offset, so the geometry is the fixture — as in
+ * `scrollSyncAcrossFolds.test.ts` and `anchorJumpUnderZoom.spec.ts`. Deriving
+ * it from the element's own `data-sourcepos` is what makes the expected
+ * scrollTop below a number this file can state rather than read back.
+ */
+const LINE_HEIGHT = 24;
+
+function measureBySourcepos(node: AnchorNode): AnchorBox {
+	const range = parseSourceposLineRange(node.getAttribute?.('data-sourcepos'));
+	if (!range) return { top: Number.NaN, height: Number.NaN };
+	return {
+		top: (range.startLine - 1) * LINE_HEIGHT,
+		height: (range.endLine - range.startLine + 1) * LINE_HEIGHT,
+	};
+}
+
+/**
+ * The article the preview scrolls. Its scroll range is passed to the restore
+ * rather than read off it, so it is stated here: nothing to scroll while the
+ * host is empty, a tall document once one has been patched in.
+ */
+function emptyPreview(): HTMLElement {
+	const host = document.createElement('div');
+	host.className = 'markdown-body';
+	return host;
+}
+
+function scrollMaxOf(host: HTMLElement): number {
+	return host.innerHTML === '' ? 0 : 40_000 - 900;
+}
+
+/** A tab that left another window with its reader parked on `anchorLine`. */
+function arriveFromAnotherWindow(anchorLine: number): Tab {
+	tabManager.addTab('/notes/b.md', DOC_B.html());
+	const source = tabManager.tabs.find((item) => item.path === '/notes/b.md')!;
+	source.scrollTop = 4820;
+	source.scrollPercentage = 0.73;
+	source.anchorLine = asRendererLine(anchorLine);
+
+	const payload = validateTransferPayload(JSON.stringify(snapshotTab(source)));
+	assert.ok(payload, 'a snapshot of a real tab must validate');
+
+	// The destination window, which has never seen this document.
+	tabManager.closeAll();
+	const id = tabManager.insertTransferredTab(payload);
+	return tabManager.tabs.find((item) => item.id === id)!;
+}
+
+/** A heading line, so the block spans one line and the interpolation is exact. */
+const ARRIVAL_LINE = DOC_B.lines[Math.floor(DOC_B.lines.length / 2)];
+
+test('a transferred tab is activated before its document exists, so the restore then has nothing to work with', () => {
+	reset();
+	const arrived = arriveFromAnotherWindow(ARRIVAL_LINE);
+
+	// The three fields survived the wire, and the tab is already the active one.
+	assert.equal(arrived.anchorLine, ARRIVAL_LINE);
+	assert.equal(arrived.scrollPercentage, 0.73);
+	assert.equal(arrived.scrollTop, 4820);
+	assert.equal(tabManager.activeTabId, arrived.id);
+	assert.equal(arrived.content, '', 'the rendered document has not been built yet');
+
+	const host = emptyPreview();
+
+	// Every entry of the cascade in turn: no block owns the line because there
+	// are no blocks, there is no scroll range for the percentage, and the pixel
+	// offset has nowhere to go. Asserted on the returned entry rather than on
+	// `host.scrollTop`, because jsdom stores whatever is assigned to `scrollTop`
+	// while a real container clamps it to a range that here is empty.
+	assert.equal(restorePreviewReadingPosition(host, arrived, scrollMaxOf(host), measureBySourcepos), 'nothing');
+	assert.equal(findAnchorElement(host, arrived.anchorLine), null);
+});
+
+test('the same cascade, run once the arriving document is in, puts the reader back', () => {
+	reset();
+	const arrived = arriveFromAnotherWindow(ARRIVAL_LINE);
+	const host = emptyPreview();
+
+	// What `renderTabPreviewFromRaw` leaves behind: the tab's own buffer through
+	// the real pipeline, patched into the host it just awaited a flush for.
+	host.innerHTML = processMarkdownHtml(DOC_B.html(), arrived.path, new Set<string>());
+
+	assert.equal(restorePreviewReadingPosition(host, arrived, scrollMaxOf(host), measureBySourcepos), 'anchor');
+	// The first entry of the cascade answered, so the answer is the anchor's:
+	// the line's own box, pinned `PREVIEW_ANCHOR_OFFSET` below the top.
+	assert.equal(host.scrollTop, (ARRIVAL_LINE - 1) * LINE_HEIGHT - PREVIEW_ANCHOR_OFFSET);
+	assert.notEqual(host.scrollTop, 0);
 });

--- a/scripts/tabTransferHandoff.test.ts
+++ b/scripts/tabTransferHandoff.test.ts
@@ -47,6 +47,34 @@ test('a failed render undoes the inserted tab', () => {
 	assert.match(accept, /if \(isDisposed\) \{\s*\n\s*tabManager\.closeTab\(id\);/);
 });
 
+test('the arriving tab is put back where its reader was, after its document lands', () => {
+	// The position travels in the payload (tabTransfer.ts) and nothing put it
+	// back. `insertTransferredTab` activates the tab synchronously, while its
+	// rendered `content` is still `''`, so the preview's restore effect runs on
+	// that activation against a host holding no document: no block owns the
+	// anchor line, there is no scroll range for the percentage, and the pixel
+	// offset has nowhere to go. The document arrives afterwards, at the top.
+	//
+	// The effect cannot cover this by depending on the render. It also runs
+	// while the reader is typing — split view and edit-with-outline re-render on
+	// a debounce — and a per-render dependency would drag the preview back to
+	// the saved position on every pause in typing. So the arrival asks again
+	// itself, once `renderTabPreviewFromRaw` has awaited the patch.
+	//
+	// Ordering is the whole assertion, which is why it is a source assertion:
+	// what goes wrong is WHEN the restore is called, and the two moments are one
+	// `await` apart inside a Svelte component.
+	const accept = sliceBetween(viewer, 'acceptTransferredTab: async (snapshot)', 'onError: (message, error)');
+	const rendered = accept.indexOf('await renderTabPreviewFromRaw(transferred);');
+	const restored = accept.indexOf('restorePreviewReadingPosition(');
+	assert.ok(rendered !== -1, 'the arrival must render the document it was handed');
+	assert.ok(restored > rendered, 'the restore must run after the render, not before it');
+	// Only the active tab's host is displayed, and they all share one scrolling
+	// article: restoring for a tab the user has since switched away from would
+	// move whichever document is on screen instead.
+	assert.match(accept, /tabManager\.activeTabId === id/);
+});
+
 test('a second transfer of the same tab is refused while one is in flight', () => {
 	// The menu entry becomes clickable again long before the transfer
 	// resolves; two payloads for one tab means two windows each build it.

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -49,12 +49,11 @@ import {
 import { routeDroppedFile, type DropPane } from './utils/fileDrop.js';
 import { headingReference, preferredReferenceStyle } from './utils/headingReference.js';
 import {
-	findAnchorElement,
 	findSourceLineRange,
-	getAnchorScrollTop,
 	getSourceLineAtPreviewOffset,
 	measureAnchorBox,
 	mergeSourceLineRanges,
+	restorePreviewReadingPosition,
 	PREVIEW_ANCHOR_OFFSET,
 	anchorScrollTop,
 	type AnchorBox,
@@ -748,6 +747,30 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 					tabManager.closeTab(id);
 					return false;
 				}
+				// The reading position travels with the tab, and until here nothing
+				// put it back. `insertTransferredTab` activates the tab
+				// synchronously, while its `content` is still `''`; the restore
+				// effect below runs on that activation against a host with no
+				// document in it, finds no anchor and no scroll range, and the
+				// document the reader left arrives afterwards at the top. That effect
+				// cannot cover this by depending on the render — it also runs while
+				// the reader is typing in split view, where a per-render dependency
+				// would drag the preview back on every debounce — so the arrival
+				// asks again, now that `renderTabPreviewFromRaw` has awaited the
+				// patch and the host holds the document.
+				//
+				// Guarded on the tab still being the active one: only the active
+				// host is displayed, and `markdownBody` is the article all of them
+				// share, so scrolling it for a tab the user has since switched away
+				// from would move somebody else's document.
+				if (markdownBody && tabManager.activeTabId === id) {
+					restorePreviewReadingPosition(
+						markdownBody,
+						transferred,
+						getPreviewScrollMax(markdownBody),
+						measurePreviewBox,
+					);
+				}
 				return true;
 			} catch (error) {
 				tabManager.closeTab(id);
@@ -1403,44 +1426,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (id && body) {
 			untrack(() => {
 				const tab = tabManager.tabs.find((t) => t.id === id);
-				if (tab) {
-					let scrolled = false;
-
-					if (tab.anchorLine > 0) {
-						// Interpolated restore: find the rendered element that owns the
-						// saved source line and put that line back under the anchor
-						// offset. This has to descend — `processMarkdownHtml` re-parents
-						// every block after a heading into a `.foldable-content-wrapper`
-						// with no `data-sourcepos`, so a scan of `body.children` only
-						// ever matched an anchor sitting exactly on a top-level heading
-						// line (see scripts/previewAnchorRestore.test.ts for the rate).
-						const match = findAnchorElement(body, tab.anchorLine);
-						if (match) {
-							// Through the same measurement the sync path uses: an anchor
-							// inside a table or a code block resolves to an element whose
-							// `offsetTop` is measured from that table or that block's shell,
-							// and restoring to it would open the tab at the top instead.
-							const box = measurePreviewBox(match.element);
-							body.scrollTop = getAnchorScrollTop(
-								box.top,
-								box.height,
-								match,
-								tab.anchorLine,
-								PREVIEW_ANCHOR_OFFSET,
-							);
-							scrolled = true;
-						}
-					}
-
-					if (!scrolled) {
-						if (body.scrollHeight > body.clientHeight && tab.scrollPercentage > 0) {
-							const targetScroll = tab.scrollPercentage * (body.scrollHeight - body.clientHeight);
-							body.scrollTop = targetScroll;
-						} else {
-							body.scrollTop = tab.scrollTop;
-						}
-					}
-				}
+				// The cascade itself is `restorePreviewReadingPosition` in
+				// previewAnchor.ts, next to the three measurements it runs. It is a
+				// function and not this block because the arrival of a transferred
+				// tab has to run the SAME cascade after its document lands (see
+				// `acceptTransferredTab`), and two copies consulting the same three
+				// fields in different orders would be two answers for one tab.
+				if (tab) restorePreviewReadingPosition(body, tab, getPreviewScrollMax(body), measurePreviewBox);
 			});
 		}
 	});

--- a/src/lib/utils/previewAnchor.ts
+++ b/src/lib/utils/previewAnchor.ts
@@ -538,6 +538,90 @@ export function getAnchorScrollTop(
 	return Math.max(0, elementTop + elementHeight * ratio - offset);
 }
 
+/**
+ * The preview's scroll container: the element the restore writes to, and the
+ * root the anchor is resolved under.
+ *
+ * Nothing about its geometry is read off it. The layout arrives as `measure`
+ * and the scroll range as `scrollMax`, as everywhere else in this file — neither
+ * the DOM shim nor jsdom has a layout, so a test supplies its own, and
+ * `scrollHeight` is not a measurement `src/lib/utils` is allowed to take (see
+ * the fold-height rule in singleImplementationConvention.test.ts).
+ */
+export type PreviewScrollContainer = AnchorNode & {
+	scrollTop: number;
+};
+
+/**
+ * The three ways a tab records where its reader was — see `Tab` in
+ * `stores/tabs.svelte.ts` for why there are three.
+ */
+export type ReadingPosition = {
+	readonly anchorLine: number;
+	readonly scrollPercentage: number;
+	readonly scrollTop: number;
+};
+
+/**
+ * Put `container` back where the reader of this tab was, and return which entry
+ * of the cascade answered.
+ *
+ * One function rather than one per caller, because the cascade is an ORDER and
+ * a second copy that consulted the same three fields in a different one would
+ * be a different answer for the same tab. It stops at the first entry that
+ * resolves:
+ *
+ *   - `anchorLine`, an interpolated restore: find the rendered element that owns
+ *     the saved source line and put that line back under the anchor offset. This
+ *     descends, because `processMarkdownHtml` re-parents every block after a
+ *     heading into a `.foldable-content-wrapper` with no `data-sourcepos`, so a
+ *     scan of the container's children only ever matched an anchor sitting
+ *     exactly on a top-level heading line (see previewAnchorRestore.test.ts).
+ *     Measured through `measure` — `measureAnchorBox` in the app — and not raw
+ *     `offsetTop`: an anchor inside a table or a code block sits in that
+ *     table's or that shell's space, and restoring to it would open the tab at
+ *     the top instead.
+ *   - `scrollPercentage`, when there is anything to scroll;
+ *   - `scrollTop`, the raw pixel offset, which is also what puts a tab that has
+ *     never been scrolled at the top.
+ *
+ * `'nothing'` means the container held no document to anchor to and could not
+ * scroll — every caller that renders a tab's document AFTER activating it gets
+ * this on the activation and has to ask again once the document is in.
+ */
+export function restorePreviewReadingPosition(
+	container: PreviewScrollContainer,
+	position: ReadingPosition,
+	scrollMax: number,
+	measure: MeasureAnchorBox,
+): 'anchor' | 'percentage' | 'pixels' | 'nothing' {
+	if (position.anchorLine > 0) {
+		const match = findAnchorElement(container, position.anchorLine);
+		if (match) {
+			const box = measure(match.element);
+			container.scrollTop = getAnchorScrollTop(
+				box.top,
+				box.height,
+				match,
+				position.anchorLine,
+				PREVIEW_ANCHOR_OFFSET,
+			);
+			return 'anchor';
+		}
+	}
+
+	if (scrollMax > 0 && position.scrollPercentage > 0) {
+		container.scrollTop = position.scrollPercentage * scrollMax;
+		return 'percentage';
+	}
+
+	container.scrollTop = position.scrollTop;
+	// A container with nothing to scroll cannot hold a position: the assignment
+	// above clamps to 0, so a reader who was part-way down was not restored —
+	// the caller was asked too early and has to ask again with the document in.
+	return scrollMax > 0 || position.scrollTop === 0 ? 'pixels' : 'nothing';
+}
+
 /* ------------------------------------------------------------------ */
 /* the sample table                                                    */
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Based on #730 (`fix/tab-switch-keeps-its-dom`) and has to merge after it. #730 rewrites the preview DOM in this same file — one `.markdown-blocks` host per tab — and this change is written against that shape, not against master.

## What this is

Drag a tab from one window into another and the document opens at the top, however far down it the reader was. It now opens where they left it.

## Mechanism

The position does travel. `snapshotTab` puts `scrollTop`, `scrollPercentage` and `anchorLine` on the wire and the strict validator on the receiving side requires all three, so the arriving tab is built with the reader's position already on it. What was wrong is when the destination asked for it.

`TabManager.insertTransferredTab` pushes the tab and sets `this.activeTabId = tab.id` in the same synchronous call, while the tab's rendered `content` is still the `''` every construction site seeds. The preview's restore effect fires on that activation, and at that moment the tab's host is an empty `div`: `findAnchorElement` has no block to resolve the anchor line against, there is no scroll range for the percentage, and the last entry of the cascade assigns a pixel offset to a container that cannot scroll, which a browser clamps to 0. Only afterwards does `acceptTransferredTab` await `renderTabPreviewFromRaw`, and nothing re-triggers the effect when that document lands — it depends on the tab id, the article element and the path, deliberately not on the render.

So the arrival asks again, itself, after the await. The cascade it asks through is no longer inline in the effect: it moved into `restorePreviewReadingPosition` in `previewAnchor.ts`, beside the resolver and the measurement it runs, and both callers go through that one function. Two sites consulting the same three fields is fine; two sites consulting them in different orders is two answers for one tab, which is the shape this repo keeps finding.

The restore is guarded on the arriving tab still being the active one. All the per-tab hosts share one scrolling `article` and only the active host is displayed, so scrolling it for a tab the user switched away from during the render would move whichever document is now on screen.

## Scope

**The effect's dependencies are untouched.** The obvious fix — have the restore depend on `previewRevision` or `sanitizedHtml` — would have been wrong in a way that is worse than the bug. That effect also runs while the reader is typing: in split view and in edit-mode-with-outline the preview re-renders on a debounce, and a per-render dependency would drag the pane back to the saved position on every pause in typing. The fix is at the arrival, not in the effect.

**Nothing renders or measures a background tab.** The restore writes only to the shared article and only for the active tab, so the rule the `previewHosts` comment sets out in #730 — never patch or measure a host inside a `display: none` subtree, because every rect there is 0 and `foldLayout` writes what it measures into `--fold-content-height` — is not touched.

Two things noticed and left alone:

**The outgoing side captures a current position in reading mode, and a stale one in edit mode.** `handleScroll` in the preview writes all three fields on every scroll event with no debounce between the event and the store, so a tab transferred from reading mode (or from split view, where the preview is the pane that scrolls) carries where the reader actually was. A tab transferred while in edit-only mode does not: `Editor.svelte` writes `scrollPercentage` and `anchorLine` from its `onMount` teardown, and `transferPayload` builds the snapshot synchronously while the editor is still mounted — the source tab is closed only after the destination claims. Such a tab travels with whatever position it had the last time it left the editor, which for a tab opened straight into edit mode is 0. Fixing it means a "flush your position now" seam on `Editor` and a call before the snapshot, which is a change with its own failure mode and belongs on its own.

**Session restore has the same shape as the bug fixed here.** `applyRestoredContent` also fills a tab's `content` after it is already the active one, and nothing re-triggers the restore effect when it does. I did not exercise it and am not claiming it as a defect — it is the same reading of the same code, reported so the next person looking at this effect knows to check it.

## Tests

Two, and they answer different questions.

`scripts/tabReadingPosition.spec.ts` gains the two moments of an arrival, run against the real `TabManager`, the real `processMarkdownHtml` output of the document being transferred, and the real cascade. The first asserts that a tab which has just arrived is active with `content === ''` and that the restore run at that instant returns `'nothing'` — no block owns the anchor line, no scroll range, nowhere for the pixel offset to go. The second patches the document in and runs the same call, which returns `'anchor'` and lands at exactly `(line - 1) * 24 - 60`. The geometry is the fixture, as it is in `scrollSyncAcrossFolds.test.ts` and `anchorJumpUnderZoom.spec.ts`: jsdom reports 0 for every offset, so the layout is supplied — one where each source line is 24px tall, derived from the element's own `data-sourcepos`. The first assertion is on the returned cascade entry rather than on `host.scrollTop`, because jsdom stores whatever is assigned to `scrollTop` while a real container clamps it to a range that is empty here.

`scripts/tabTransferHandoff.test.ts` gains the wiring assertion, and it is a source assertion on purpose: what goes wrong is *when* the restore is called, and the two moments are one `await` apart inside a Svelte component that cannot be imported. The anchor is the ordering of `await renderTabPreviewFromRaw(transferred)` and `restorePreviewReadingPosition(` inside the `acceptTransferredTab` block, plus the `tabManager.activeTabId === id` guard. This is the test that goes red: **reverting the fix and keeping both tests leaves vitest at 408 passed and turns `node --test` to 998 passed / 1 failed — "the restore must run after the render, not before it".** The spec tests stay green under the revert, which is honest about what they are: they prove the mechanism and the cascade, not the call site.

`scripts/previewAnchorRestore.test.ts` had a source assertion pinning the inline cascade (`const match = findAnchorElement(body, tab.anchorLine)` … `body.scrollTop = getAnchorScrollTop(`). That premise is gone, so the test was rewritten rather than deleted: "it resolves through the measured helpers" is now a behaviour claim made by calling the function, and what is left as text is the claim only text can make — that the component imports the shared cascade and has not grown a second copy back (no `scrollTop = getAnchorScrollTop(`, no `tab.scrollPercentage`, no `Array.from(body.children)`).

## Verification

All five, from the branch root:

```
npm audit                 0 vulnerabilities
npm run check             821 files, 0 errors, 0 warnings
npm test                  999 tests, 999 pass, 0 fail
npm run test:vitest       46 files, 408 tests passed
cargo test                164 passed, 0 failed
```

Baselines before the change were 998 and 406; the three new tests account for the difference and nothing else moved.

What I did **not** verify: the drag itself. Exercising a cross-window transfer needs two real Markpad windows and the Rust broker between them, which is not reachable from the test environment. The evidence here is a jsdom reproduction of the arrival sequence plus reading the code — I have not watched a tab arrive in a second window and land part-way down its document. A reviewer with the app open should drag a tab scrolled well into a long file into another window and check where it opens. The edit-mode case described under Scope will still open near the top, and that is expected of this change.
