### PR TITLE
fix(tabs): a tab dragged out of an editor arrives where the reader left it

### DIFF
--- a/scripts/editorPositionFlush.test.ts
+++ b/scripts/editorPositionFlush.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { editorReadingPosition } from '../src/lib/utils/editorPosition.js';
+import { EDITOR_ANCHOR_LINE_OFFSET } from '../src/lib/utils/lineCoordinates.js';
+import { readSource, offsetOf, sliceFrom } from './sourceTree.js';
+
+const editor = readSource('src/lib/components/Editor.svelte');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
+
+// A tab records where its reader was, and two panes write those fields. The
+// preview writes them on every scroll event; the editor writes them when it
+// comes down. Everything below is about the second one being asked at the
+// moments something reads a tab's position while the editor is still up.
+
+test('the percentage is where the reading puts the reader back', () => {
+	const { scrollPercentage } = editorReadingPosition({
+		scrollTop: 300,
+		contentHeight: 1600,
+		viewportHeight: 1000,
+		topLine: null,
+		text: '',
+	});
+	assert.equal(scrollPercentage, 0.5);
+});
+
+test('a document that fits the viewport has no percentage rather than zero', () => {
+	// Zero is a position — the top of the document — and writing it would move
+	// a reader who had not scrolled anywhere.
+	const { scrollPercentage } = editorReadingPosition({
+		scrollTop: 0,
+		contentHeight: 400,
+		viewportHeight: 1000,
+		topLine: null,
+		text: 'short',
+	});
+	assert.equal(scrollPercentage, null);
+});
+
+test('the anchor crosses out of the editor numbering, front matter and all', () => {
+	// Monaco counts from the first line of the FILE; the tab's anchor counts
+	// from the first line of the BODY. Both shifts apply: the four lines of
+	// front matter, and the offset that anchors the reader on the line they
+	// were reading rather than the one the viewport cut in half.
+	const text = '---\ntitle: t\n---\n\nbody line one\nbody line two\nbody line three\n';
+	const { anchorLine } = editorReadingPosition({
+		scrollTop: 0,
+		contentHeight: 2000,
+		viewportHeight: 1000,
+		topLine: 5,
+		text,
+	});
+	assert.equal(anchorLine, 5 + EDITOR_ANCHOR_LINE_OFFSET - 4);
+});
+
+test('an editor with nothing laid out yet reports no anchor', () => {
+	const { anchorLine } = editorReadingPosition({
+		scrollTop: 0,
+		contentHeight: 2000,
+		viewportHeight: 1000,
+		topLine: null,
+		text: 'body',
+	});
+	assert.equal(anchorLine, null);
+});
+
+test('the editor derives the anchor in exactly one place', () => {
+	// The teardown used to build it inline. A flush that built its own would be
+	// a second crossing of the same two numberings, which is the defect shape
+	// `lineCoordinates.ts` exists to prevent.
+	assert.doesNotMatch(editor, /tabAnchorForEditorTopLine/);
+	assert.equal((editor.match(/editorReadingPosition\(/g) ?? []).length, 1);
+});
+
+test('the flush refuses a tab the editor is not holding', () => {
+	// One Editor per window, swapping models between tabs: an unguarded flush
+	// would copy the active tab's position onto the record the caller named.
+	const flush = sliceFrom(editor, 'export function flushPositionTo');
+	assert.match(flush, /if \(!editorReady \|\| !editor \|\| currentTabId !== tabId\) return;/);
+});
+
+test('the transfer payload flushes before it snapshots the tab', () => {
+	// `snapshotTab` is synchronous and runs with the editor still mounted, so
+	// without this the tab travels at the position of the last teardown.
+	const flushAt = offsetOf(viewer, 'editorPane?.flushPositionTo(tabId);');
+	const snapshotAt = offsetOf(viewer, 'JSON.stringify(snapshotTab(tab))');
+	assert.ok(flushAt < snapshotAt);
+});
+
+test('the window-state snapshot flushes too', () => {
+	// Same staleness at window close: `serializeState` persists the same three
+	// fields and the editor has not come down yet.
+	const serialize = sliceFrom(viewer, 'serializeState: () => {');
+	const flushAt = offsetOf(serialize, 'flushPositionTo(tabManager.activeTabId)');
+	const stateAt = offsetOf(serialize, 'return tabManager.serializeState();');
+	assert.ok(flushAt < stateAt);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -235,6 +235,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		revealHeader: (sourceLine: BufferLine | null, text: string) => void;
 		revealSourceRange: (startLine: number, endLine: number) => void;
 		triggerFind: () => void;
+		flushPositionTo: (tabId: string) => void;
 		// The three the editor's context menu runs, which are the three its
 		// keyboard shortcuts run (#207).
 		cutToClipboard: () => Promise<void>;
@@ -694,7 +695,14 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		windowStateKey: WINDOW_STATE_KEY,
 		legacyStateKey: LEGACY_STATE_KEY,
 		restoreInProgressKey: RESTORE_IN_PROGRESS_KEY,
-		serializeState: () => tabManager.serializeState(),
+		serializeState: () => {
+			// Same reason as `transferPayload` below, at a different moment: this
+			// runs on window close with the editor still mounted, so the tab being
+			// edited would be persisted at the position it held when the editor
+			// last came down. Only the active tab can be the one the editor holds.
+			if (tabManager.activeTabId) editorPane?.flushPositionTo(tabManager.activeTabId);
+			return tabManager.serializeState();
+		},
 		shouldRestoreState: () => settings.restoreStateOnReopen,
 		isDisposed: () => isDisposed,
 		restoreState: (json) => tabManager.restoreState(json),
@@ -730,6 +738,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		transferPayload: (tabId) => {
 			const tab = tabManager.tabs.find((item) => item.id === tabId);
 			if (!tab) throw new Error('Tab disappeared before transfer');
+			// The snapshot carries the reading position and is taken here,
+			// synchronously, with the editor still mounted — so a tab being
+			// edited would travel with the position from its last teardown, and a
+			// tab opened straight into edit mode with 0. The preview writes its
+			// own fields on every scroll and needs nothing; this is edit mode's
+			// equivalent, and it is a no-op for any tab the editor is not on.
+			editorPane?.flushPositionTo(tabId);
 			return JSON.stringify(snapshotTab(tab));
 		},
 		onTransferClaimed: (tabId) => tabManager.closeTab(tabId),

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -36,9 +36,9 @@
 		asBufferLine,
 		editorTopLineForTabAnchor,
 		lineCoordinates,
-		tabAnchorForEditorTopLine,
 		type BufferLine,
 	} from '../utils/lineCoordinates.js';
+	import { editorReadingPosition } from '../utils/editorPosition.js';
 	import {
 		documentParentDir,
 		imageEmbed,
@@ -860,37 +860,39 @@
 			// reading mode and back.
 			removedKeybindings.dispose();
 
-			if (editor && currentTabId) {
-				const state = editor.saveViewState();
-				tabManager.updateTabEditorState(currentTabId, state);
-
-				const scrollHeight = editor.getScrollHeight();
-				const clientHeight = editor.getLayoutInfo().height;
-				if (scrollHeight > clientHeight) {
-					const percentage =
-						editor.getScrollTop() / (scrollHeight - clientHeight);
-					tabManager.updateTabScrollPercentage(currentTabId, percentage);
-				}
-
-				const ranges = editor.getVisibleRanges();
-				const model = editor.getModel();
-				if (ranges.length > 0 && model) {
-					// Monaco counts from the first line of the FILE and the tab's
-					// anchor counts from the first line of the body, so this is a
-					// crossing; `EDITOR_ANCHOR_LINE_OFFSET` is the old `+ 2`,
-					// which is a separate decision and is documented as one.
-					tabManager.updateTabAnchorLine(
-						currentTabId,
-						tabAnchorForEditorTopLine(
-							lineCoordinates(model.getValue()),
-							asBufferLine(ranges[0].startLineNumber),
-						),
-					);
-				}
-			}
+			if (editor && currentTabId) writeEditorPosition(currentTabId);
 
 			editor.dispose();
 		};
+	}
+
+	/**
+	 * Record on `tabId` where the editor is: the Monaco view state, and the two
+	 * position fields `editorReadingPosition` derives from one reading.
+	 *
+	 * Three layout reads (`getScrollHeight`, `getLayoutInfo`,
+	 * `getVisibleRanges`), so this belongs at moments and never on the hot path
+	 * — the teardown above is one such moment, `flushPositionTo` below is the
+	 * other, and there are no others.
+	 *
+	 * The caller has already established that `editor` is up and that `tabId` is
+	 * the tab it is holding.
+	 */
+	function writeEditorPosition(tabId: string) {
+		tabManager.updateTabEditorState(tabId, editor.saveViewState());
+
+		const ranges = editor.getVisibleRanges();
+		const model = editor.getModel();
+		const { scrollPercentage, anchorLine } = editorReadingPosition({
+			scrollTop: editor.getScrollTop(),
+			contentHeight: editor.getScrollHeight(),
+			viewportHeight: editor.getLayoutInfo().height,
+			topLine: ranges.length > 0 && model ? ranges[0].startLineNumber : null,
+			text: model?.getValue() ?? '',
+		});
+
+		if (scrollPercentage !== null) tabManager.updateTabScrollPercentage(tabId, scrollPercentage);
+		if (anchorLine !== null) tabManager.updateTabAnchorLine(tabId, anchorLine);
 	}
 
 	// Editing primitives used by the context-menu actions. They live at
@@ -2488,6 +2490,28 @@
 	export const setValue = (val: string) => editor?.setValue(val);
 	export const focus = () => editor?.focus();
 	export const restoreViewState = (state: any) => editor?.restoreViewState(state);
+
+	/**
+	 * Bring `tabId`'s recorded reading position up to date with what the editor
+	 * is showing right now.
+	 *
+	 * Reading mode never needs this: `handleScroll` in MarkdownViewer writes the
+	 * same fields through on every scroll event, so a tab in the preview is
+	 * always current. Edit mode writes them once, when the editor comes down —
+	 * which is cheap, and which leaves anything that reads a tab's position
+	 * while the editor is still up reading the position from the LAST teardown,
+	 * or 0 for a tab that was opened straight into edit mode and never left it.
+	 * Those callers ask here first.
+	 *
+	 * A no-op unless this editor is up AND holding `tabId`. There is one Editor
+	 * per window and it swaps models between tabs (`utils/tabModels.ts`), so an
+	 * unguarded flush would copy the ACTIVE tab's position onto whichever record
+	 * the caller named — a wrong position on two tabs instead of one.
+	 */
+	export function flushPositionTo(tabId: string) {
+		if (!editorReady || !editor || currentTabId !== tabId) return;
+		writeEditorPosition(tabId);
+	}
 </script>
 
 <div class="editor-outer">

--- a/src/lib/utils/editorPosition.ts
+++ b/src/lib/utils/editorPosition.ts
@@ -1,0 +1,75 @@
+/**
+ * Where the editor is, in the terms a tab records it in.
+ *
+ * `Tab.scrollPercentage` and `Tab.anchorLine` have two writers, one per pane.
+ * The preview's is `handleScroll` in MarkdownViewer, which measures the DOM and
+ * writes straight through on every scroll event. The editor's is here, and it
+ * is asked rather than volunteered: the numbers below are Monaco LAYOUT reads,
+ * too expensive to take on every keystroke and every scroll, so `Editor.svelte`
+ * takes them at the moments a stale record would be seen — its own teardown,
+ * and the flush a caller asks for before reading a tab's position while the
+ * editor is still mounted.
+ *
+ * The whole derivation lives in this one function so those moments cannot
+ * disagree. The disagreement worth naming is the numbering: Monaco counts from
+ * the first line of the FILE and a tab's anchor counts from the first line of
+ * the BODY, so a second site deriving its own anchor is a second chance to make
+ * that crossing differently. There is one crossing, it is
+ * `tabAnchorForEditorTopLine`, and this is the only caller in the editor.
+ */
+
+import {
+	asBufferLine,
+	lineCoordinates,
+	tabAnchorForEditorTopLine,
+	type RendererLine,
+} from './lineCoordinates.js';
+
+/**
+ * One reading of the editor. Every field is a layout read; the caller pays for
+ * them once.
+ *
+ * The two heights are Monaco's `getScrollHeight()` and `getLayoutInfo().height`,
+ * named after what they mean rather than after the DOM properties that answer
+ * the same questions about an element. Nothing here touches an element, and
+ * borrowing the DOM's spelling in this directory trips the guardrail that keeps
+ * fold heights off the scrollable extent (singleImplementationConvention).
+ */
+export interface EditorViewport {
+	scrollTop: number;
+	/** The full scrollable extent of the document. */
+	contentHeight: number;
+	/** What fits on screen. */
+	viewportHeight: number;
+	/**
+	 * Monaco's first visible line, a BUFFER line — `null` when the editor has
+	 * no model or nothing laid out yet, which is not the same as line 1.
+	 */
+	topLine: number | null;
+	/** The buffer's text, and only for the front-matter shift the crossing applies. */
+	text: string;
+}
+
+/**
+ * `null` on either field means this reading says nothing about it, so whatever
+ * the tab already records stands: a document shorter than the viewport has no
+ * meaningful percentage, and an editor with no visible range has no top line.
+ * Writing 0 in either case would move the reader to the top of the document.
+ */
+export interface EditorReadingPosition {
+	scrollPercentage: number | null;
+	anchorLine: RendererLine | null;
+}
+
+export function editorReadingPosition(view: EditorViewport): EditorReadingPosition {
+	return {
+		scrollPercentage:
+			view.contentHeight > view.viewportHeight
+				? view.scrollTop / (view.contentHeight - view.viewportHeight)
+				: null,
+		anchorLine:
+			view.topLine === null
+				? null
+				: tabAnchorForEditorTopLine(lineCoordinates(view.text), asBufferLine(view.topLine)),
+	};
+}


### PR DESCRIPTION
## What this is

Open a file, edit it without ever switching to reading mode, scroll down, drag
the tab into another window: it arrives at the top of the document.

#734 fixed the *receiving* side of this feature — an arriving tab was restored
before its document had landed — and named this one in its Scope section as the
other half, unfixed. This is that half.

Based on #730, not on master. Sibling of #732, #733 and #734 rather than a
child of them; it can merge in any order relative to those three, after #730.

## Mechanism

`Tab.scrollPercentage` and `Tab.anchorLine` are in the transfer payload's
required-field set (`utils/tabTransfer.ts`), and the payload is built by
`transferPayload` in MarkdownViewer.svelte from the tab record as it stands.
That snapshot is synchronous: `stageTransfer` in `sessions/windowSession.svelte.ts`
calls it and hands the JSON straight to `stage_detached_tab`.

Who keeps those fields current depends on which pane the tab is in.

In reading mode and split view, `handleScroll` in MarkdownViewer writes all
three straight through on every scroll event, with nothing between the event
and the store. The snapshot is current.

In edit-only mode, `Editor.svelte` wrote `scrollPercentage` and `anchorLine`
from one place: the teardown returned by `createEditor`, at the end of
`onMount`. The editor is still mounted when `transferPayload` runs, so the
teardown has not happened, and the tab travelled with whatever it recorded the
last time the editor came down — which for a tab opened straight into edit mode
and never taken out of it is 0.

The same staleness reaches `TabManager.serializeState()`, which persists the
same fields on window close: `persistWindowState` is awaited inside the
close-requested handler, before `appWindow.destroy()`, so the editor is
likewise still up. A tab left in edit mode was restored at its last-teardown
position on the next launch. Same one call, so it is fixed here.

The fix is a flush seam, not a second writer. `Editor.svelte`'s teardown block
already made a non-obvious crossing — Monaco counts from the first line of the
FILE, a tab's anchor counts from the first line of the BODY, and
`tabAnchorForEditorTopLine` plus `EDITOR_ANCHOR_LINE_OFFSET` is where that
lives. Writing a second derivation for the flush would have been a second
chance to make that crossing differently, which is the defect shape this repo
keeps finding. So the derivation moved out whole into
`utils/editorPosition.ts` as `editorReadingPosition(view)`, a plain function
over the numbers, and `Editor.svelte` has one `writeEditorPosition(tabId)` that
reads Monaco and calls it. The teardown calls that; so does the new export
`flushPositionTo(tabId)`, which is what the viewer calls.

`flushPositionTo` is a no-op unless the editor is mounted **and** currently on
the tab named. There is one `Editor` per window and it swaps models between
tabs (`utils/tabModels.ts`), so an unguarded flush asked about a background tab
would copy the active tab's position onto that tab's record — a wrong position
on two tabs instead of one, which is worse than the bug.

Nothing new runs on a hot path. `getVisibleRanges`, `getScrollHeight` and
`getLayoutInfo` are layout reads, and the whole reason this state was written
at teardown is that it is cheap there and expensive per keystroke. The flush is
one call at the moment a payload is built, and one at window close.

## Scope

Two things noticed and deliberately left alone.

The editor's tab-activation effect saves `editorViewState` for the outgoing tab
on a switch, but not `scrollPercentage` or `anchorLine` — so a background tab
that was last read in edit mode carries the same stale numbers until the editor
comes down. `serializeState` persists every tab, and the flush above only
corrects the active one. That is a third site with its own question (should a
switch flush, or should the two fields move onto the view state?), and it is
not this PR.

`Tab.scrollTop` is untouched. It is preview pixels; the editor has never
written it and does not start here.

Naming: `EditorViewport`'s two heights are `contentHeight` and `viewportHeight`
rather than `scrollHeight`/`clientHeight`. They are Monaco's
`getScrollHeight()` and `getLayoutInfo().height`, nothing in that module
touches an element, and the DOM spelling in `src/lib/utils` trips the
singleImplementationConvention rule that keeps fold heights off the scrollable
extent.

## Tests

`scripts/editorPositionFlush.test.ts`, 8 tests, `node --test`. The seam is a
plain function over numbers, so six of them run the real code with no Monaco
and no DOM: the percentage a reading yields, a document shorter than the
viewport yielding `null` rather than 0 (0 is a position — the top — and writing
it would move a reader who had not scrolled), the anchor crossing with both
shifts applied (four lines of front matter and `EDITOR_ANCHOR_LINE_OFFSET`), an
editor with no visible range yielding no anchor, that `Editor.svelte` derives
the anchor in exactly one place, and the guard on `flushPositionTo`.

Two match source text, and both are ordering claims about a `.svelte`
component, which is the category AGENTS.md keeps as text: that
`transferPayload` flushes before `snapshotTab`, and that `serializeState`
flushes before it serializes. The anchors are `editorPane?.flushPositionTo(...)`
and the two lines they must precede, compared by offset through `offsetOf`, so
an anchor that stops existing fails rather than silently asserting nothing.
A rename of `flushPositionTo` would go red without anything being broken; that
is the cost of pinning an ordering the compiler cannot see.

Revert: with the two viewer call sites removed and the seam left in place, 2 of
the 8 go red — the two ordering tests. Removing the whole change instead takes
the file down at its import, all 8.

## Verification

Run from the worktree root, against real Node v24 (`npm`/`node` on this machine
are bun shims and give a red baseline that has nothing to do with the code):

```
npm audit                                      0 vulnerabilities
npx svelte-check --tsconfig ./tsconfig.json    823 files, 0 errors, 0 warnings
node --test --import tsx 'scripts/*.test.ts'   1006 pass, 0 fail
npx vitest run                                 46 files, 406 pass
cargo test --manifest-path src-tauri/Cargo.toml  164 pass
```

Baseline on `fix/tab-switch-keeps-its-dom` before the change: 0, 821/0, 998,
406, 164. The frontend counts move by the 2 new source files and the 8 new
tests.

Not verified: the drag itself. There is no way to run the app in this
environment, so no live drag between two real windows was performed, and the
window-close path was not exercised either. Both were read: `transferPayload`
through `stageTransfer` to `stage_detached_tab`, and `persistWindowState`
through `windowSession.persistState` to `save_window_state`, in each case with
`Editor.svelte`'s teardown confirmed not to have run yet. The extracted
derivation is byte-for-byte the arithmetic that was in the teardown, so the
teardown path itself is unchanged behaviour rather than re-verified behaviour.
