### PR TITLE
An imported theme colours the preview, not only the editor

### DIFF
--- a/scripts/markdownTokenColours.test.ts
+++ b/scripts/markdownTokenColours.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { monacoTokenRules } from '../src/lib/utils/theme.js';
+import { PREVIEW_KIND_VARS, markdownKindColors, monacoTokenRules } from '../src/lib/utils/theme.js';
+import { readSource } from './sourceTree.js';
 
 // #676: an imported VS Code theme colours TextMate scopes, Monaco's markdown
 // tokenizer emits names of its own, and until now nothing renamed one into the
@@ -89,3 +90,46 @@ test('an imported theme reaches the semantic names too, not only the grammar one
 	assert.equal(byToken.get('quote'), '5c6370');
 });
 
+// #682: the same scopes, read as colours rather than as Monaco rules, because
+// the preview renders the constructs as HTML and takes them through CSS.
+
+test('a theme\'s Markdown scopes are readable as a colour per construct', () => {
+	const colors = markdownKindColors([
+		{ scope: 'markup.bold.markdown', settings: { foreground: '#ff0000' } },
+		{ scope: ['markup.heading', 'markup.quote'], settings: { foreground: '#00ff00' } },
+		{ scope: 'markup.underline.link', settings: { foreground: '#0000ff', fontStyle: 'underline' } },
+		// Not Markdown, and not a colour: neither may reach the preview.
+		{ scope: 'keyword.control', settings: { foreground: '#123456' } },
+		{ scope: 'markup.italic', settings: { fontStyle: 'italic' } },
+	]);
+
+	assert.equal(colors.get('strong'), 'ff0000');
+	assert.equal(colors.get('heading'), '00ff00');
+	assert.equal(colors.get('quote'), '00ff00');
+	assert.equal(colors.get('link'), '0000ff');
+	assert.equal(colors.has('emph'), false);
+	assert.equal([...colors.keys()].length, 4);
+});
+
+test('a theme with no token colours at all leaves the preview alone', () => {
+	// The built-in themes, and a theme file that only paints the workbench. An
+	// empty map writes no variable, and every rule falls back to what the
+	// stylesheet already said.
+	for (const tokenColors of [undefined, null, [], 'markup.bold']) {
+		assert.equal(markdownKindColors(tokenColors).size, 0);
+	}
+});
+
+test('every construct colour the importer writes is read by the stylesheet', () => {
+	// The two halves are joined by a variable name and nothing else: the
+	// importer writes `--md-strong`, `styles.css` reads it, and no type or
+	// import holds them together. Renaming one silently drops the colour.
+	const styles = readSource('src/styles.css');
+
+	for (const [kind, cssVar] of PREVIEW_KIND_VARS) {
+		// The comma is the fallback. Without one, a construct the theme does not
+		// name renders with no colour at all rather than with the value the rule
+		// carried before the import.
+		assert.ok(styles.includes(`var(${cssVar},`), `${cssVar} is written for \`${kind}\` and read by no rule with a fallback`);
+	}
+});

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -73,6 +73,51 @@ export function sanitizeThemeColors(colors: unknown): Record<string, string> {
 export type MonacoTokenRule = { token: string; foreground?: string; fontStyle?: string };
 
 /**
+ * The constructs the preview takes from an imported theme, and the variable
+ * each is written to.
+ *
+ * The preview renders what the editor tokenizes, but as HTML with the markup
+ * gone: `**bold**` arrives as `<strong>`, `##` as an `<h2>`. So the colours
+ * reach it through CSS rather than through Monaco, and they reach the
+ * construct's *text*, which is all that is left of it (#682).
+ *
+ * A kind the theme does not name is simply absent here, and the stylesheet's
+ * own fallback stands — which is what keeps the built-in themes' preview, and
+ * every preview that was rendered before an import, exactly as it was.
+ */
+export const PREVIEW_KIND_VARS: ReadonlyArray<readonly [kind: string, cssVar: string]> = [
+	['heading', '--md-heading'],
+	['strong', '--md-strong'],
+	['emph', '--md-emph'],
+	['code', '--md-code'],
+	['link', '--md-link'],
+	['strike', '--md-strike'],
+	['quote', '--md-quote'],
+];
+
+/** The colour the theme gave each construct, by the kind the extractor emits. */
+function kindColorsOf(rules: readonly MonacoTokenRule[]): Map<string, string> {
+	const byKind = new Map<string, string>();
+	for (const rule of rules) {
+		// Read off the scope the theme wrote, which `monacoTokenRules` keeps
+		// beside every alias it derives, so a language-qualified spelling like
+		// `markup.bold.markdown` is matched by the same prefix rule.
+		const alias = markdownAliasFor(rule.token);
+		if (alias && rule.foreground) byKind.set(alias.kind, rule.foreground);
+	}
+	return byKind;
+}
+
+/**
+ * The colour an imported theme gives each Markdown construct, for a caller that
+ * needs the colours rather than Monaco's rules — the preview, which renders the
+ * same constructs as HTML.
+ */
+export function markdownKindColors(tokenColors: unknown): Map<string, string> {
+	return kindColorsOf(monacoTokenRules(tokenColors));
+}
+
+/**
  * Every rule an imported theme's editor gets, semantic layer included.
  *
  * The layer needs a rule for every kind it emits or it erases the theme. A
@@ -104,16 +149,7 @@ export type MonacoTokenRule = { token: string; foreground?: string; fontStyle?: 
  */
 export function importedThemeRules(tokenColors: unknown, isDark: boolean): MonacoTokenRule[] {
 	const themeRules = monacoTokenRules(tokenColors);
-
-	/** The colour the theme gave each construct, by the kind the extractor emits. */
-	const byKind = new Map<string, string>();
-	for (const rule of themeRules) {
-		// Read off the scope the theme wrote, which `monacoTokenRules` keeps
-		// beside every alias it derives, so a language-qualified spelling like
-		// `markup.bold.markdown` is matched by the same prefix rule.
-		const alias = markdownAliasFor(rule.token);
-		if (alias && rule.foreground) byKind.set(alias.kind, rule.foreground);
-	}
+	const byKind = kindColorsOf(themeRules);
 
 	const base = semanticTokenRules(isDark ? 'dark' : 'light').map((rule) => {
 		const foreground = byKind.get(rule.token.split('.')[0]);
@@ -279,6 +315,16 @@ export async function parseAndApplyVscodeTheme(themeJsonStr: string, name: strin
 	cssVars['--hljs-title'] = cssVars['--color-attention-fg'];
 	cssVars['--hljs-variable'] = cssVars['--color-fg-default'];
 	cssVars['--hljs-type'] = cssVars['--color-fg-default'];
+
+	// `tokenColors` reached the editor and nothing else, so an imported theme
+	// arrived on one half of the window and stopped (#682). The values are hex
+	// literals `monacoTokenRules` already validated, and are re-checked below
+	// with the rest.
+	const kindColors = markdownKindColors(theme.tokenColors);
+	for (const [kind, cssVar] of PREVIEW_KIND_VARS) {
+		const foreground = kindColors.get(kind);
+		if (foreground) cssVars[cssVar] = `#${foreground}`;
+	}
 
 	let styleTag = document.getElementById('vscode-theme-style');
 	if (!styleTag) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -500,7 +500,7 @@ body {
 
 .markdown-body a {
 	background-color: transparent;
-	color: var(--color-accent-fg);
+	color: var(--md-link, var(--color-accent-fg));
 	text-decoration: none;
 }
 
@@ -509,9 +509,26 @@ body {
 	text-decoration: underline dotted;
 }
 
+/*
+ * The colours an imported VS Code theme gives Markdown, applied to the rendered
+ * construct rather than to the markup that produced it (#682). Every fallback
+ * is the value the rule had before, so a built-in theme — which has no
+ * `tokenColors` to take — renders exactly as it did.
+ */
 .markdown-body b,
 .markdown-body strong {
 	font-weight: 600;
+	color: var(--md-strong, inherit);
+}
+
+.markdown-body em,
+.markdown-body i {
+	color: var(--md-emph, inherit);
+}
+
+.markdown-body del,
+.markdown-body s {
+	color: var(--md-strike, inherit);
 }
 
 .markdown-body dfn {
@@ -870,7 +887,11 @@ body {
 .markdown-body h6 {
 	font-weight: 600;
 	font-size: 0.85em;
-	color: var(--color-fg-muted);
+	color: var(--md-heading, var(--color-fg-muted));
+}
+
+.markdown-body :is(h1, h2, h3, h4, h5) {
+	color: var(--md-heading, inherit);
 }
 
 .markdown-body p {
@@ -883,7 +904,7 @@ body {
 .markdown-body blockquote {
 	margin: 0;
 	padding: 0 1em;
-	color: var(--color-fg-muted);
+	color: var(--md-quote, var(--color-fg-muted));
 	border-left: 0.25em solid var(--color-border-default);
 }
 
@@ -935,6 +956,10 @@ body {
 .markdown-body dl dd {
 	padding: 0 16px;
 	margin-bottom: 16px;
+}
+
+.markdown-body :not(pre) > code {
+	color: var(--md-code, inherit);
 }
 
 .markdown-body code {


### PR DESCRIPTION
## What this is

An imported VS Code theme now colours the preview's headings, bold, italic,
inline code, links, strikethrough and blockquotes, the way it already coloured
them in the editor.

Fallgrim, who reported #676, tested 2.7.6 and said in
https://github.com/sftwrdotdev/Markpad/issues/682#issuecomment-5496811232 that the
editor colouring arrived but "nothing has changed for the preview mode", and
that preview is where it matters more for them because they open existing files
there. This does not close #682 — that issue asks for arbitrary custom CSS,
which is a different and much larger question.

## Mechanism

A VS Code theme file has two halves and only one of them reached the preview.

`theme.colors` — `editor.background`, `editor.foreground`, `textLink.foreground`,
`terminal.ansi*` — is turned into `--color-*` and `--hljs-*` in
`parseAndApplyVscodeTheme`, so the preview's background, body text, links and
fenced-code highlighting have always followed an imported theme.

`theme.tokenColors` — which is where `markup.bold`, `markup.heading`,
`markup.inline.raw` and the rest live — went to `monacoTokenRules` and
`defineTheme` and nowhere else. #678, #684, #686 and #689 all worked on that
path. So an imported theme arrived on the editor and stopped at the splitter,
and every construct the reporter came for kept `--color-fg-default` in the
preview.

The preview renders the same constructs the editor tokenizes, but as HTML with
the markup gone: `**bold**` is a `<strong>`, `##` is an `<h2>`. So the colours
reach it as CSS variables rather than as token rules, and they land on the
construct's text, which is all that is left of it. `importedThemeRules` already
built a kind-to-colour map to rewrite its base rules; that map is now a named
function the importer also reads, and seven of its kinds are written into the
same `:root[data-theme="vscode"]` block the rest of the variables go into.

## Scope

Every rule keeps the value it already had as its `var()` fallback, so a theme
naming none of these kinds, and a built-in theme with no `tokenColors` at all,
render the preview exactly as before. No setting: importing a theme is the
opt-in, the same way #684 gave the built-in themes their editor colours without
one.

Deliberately left alone:

- The built-in light and dark themes. Colouring the preview by default is a
  different decision — VS Code's own markdown preview colours none of this, and
  Obsidian ships `--h1-color`, `--bold-color` and `--italic-color` defaulting to
  the body colour for the user to fill in. If it is ever wanted, the variables
  are now there and it is a value per theme block.
- `mark` and `ins`. `==highlight==` and `++insert++` have no `markup.*` scope,
  so there is nothing in a theme file to read for them.
- Fenced code, which stays with the `--hljs-*` rules. `--md-code` is scoped to
  `:not(pre) > code` so a code block is not repainted with the inline-code
  colour.
- Fonts. `markup.*` settings carry `fontStyle`, not a family, and `font-src` is
  `'self'`.

## Tests

Three in `scripts/markdownTokenColours.test.ts`, beside the #676 ones:

- `markdownKindColors` returns a colour per construct, and drops a non-Markdown
  scope and a rule with only a `fontStyle`.
- A theme with no `tokenColors` — `undefined`, `null`, `[]`, a non-array —
  yields an empty map, which is what leaves the built-in themes alone.
- Every variable the importer writes is read by `styles.css` **with a fallback**.
  The two halves are joined by a variable name and nothing else: no type or
  import holds `--md-strong` in `theme.ts` to `--md-strong` in the stylesheet,
  and renaming one silently drops the colour. The anchor is the variable name
  and the comma after it, both of which are the contract rather than today's
  spelling of a call site. Dropping either half of the change turns it red.

## Verification

```
npm audit        found 0 vulnerabilities
npm run check    822 files, 0 errors, 0 warnings
npm test         1003 pass, 0 fail
cargo test       164 pass, 0 fail
```

The colours themselves were read out of a browser rather than reasoned about:
a page built from `src/styles.css` with the `:root[data-theme="vscode"]` block
the importer would write, then `getComputedStyle().color` for each construct
with and without the attribute. Without it every element keeps today's value
(`#1f2328` body, `#656d76` for `h6` and blockquote, `#0969da` links); with it
each takes its own colour and the fenced block stays on the body colour.

Not verified: a real import in the running app on Windows or Linux, and the
`--md-*` block travelling into an exported HTML file. The export copies the
generated `<style>` tag with the rest of the stylesheet, so it should follow,
but I reasoned about that rather than exporting a document and opening it.
