### PR TITLE
fix(tabs): the four tab-switch follow-ups (#732, #733, #734, #735), retargeted to master

### DIFF
--- a/scripts/editorPositionFlush.test.ts
+++ b/scripts/editorPositionFlush.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { editorReadingPosition } from '../src/lib/utils/editorPosition.js';
+import { EDITOR_ANCHOR_LINE_OFFSET } from '../src/lib/utils/lineCoordinates.js';
+import { readSource, offsetOf, sliceFrom } from './sourceTree.js';
+
+const editor = readSource('src/lib/components/Editor.svelte');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
+
+// A tab records where its reader was, and two panes write those fields. The
+// preview writes them on every scroll event; the editor writes them when it
+// comes down. Everything below is about the second one being asked at the
+// moments something reads a tab's position while the editor is still up.
+
+test('the percentage is where the reading puts the reader back', () => {
+	const { scrollPercentage } = editorReadingPosition({
+		scrollTop: 300,
+		contentHeight: 1600,
+		viewportHeight: 1000,
+		topLine: null,
+		text: '',
+	});
+	assert.equal(scrollPercentage, 0.5);
+});
+
+test('a document that fits the viewport has no percentage rather than zero', () => {
+	// Zero is a position — the top of the document — and writing it would move
+	// a reader who had not scrolled anywhere.
+	const { scrollPercentage } = editorReadingPosition({
+		scrollTop: 0,
+		contentHeight: 400,
+		viewportHeight: 1000,
+		topLine: null,
+		text: 'short',
+	});
+	assert.equal(scrollPercentage, null);
+});
+
+test('the anchor crosses out of the editor numbering, front matter and all', () => {
+	// Monaco counts from the first line of the FILE; the tab's anchor counts
+	// from the first line of the BODY. Both shifts apply: the four lines of
+	// front matter, and the offset that anchors the reader on the line they
+	// were reading rather than the one the viewport cut in half.
+	const text = '---\ntitle: t\n---\n\nbody line one\nbody line two\nbody line three\n';
+	const { anchorLine } = editorReadingPosition({
+		scrollTop: 0,
+		contentHeight: 2000,
+		viewportHeight: 1000,
+		topLine: 5,
+		text,
+	});
+	assert.equal(anchorLine, 5 + EDITOR_ANCHOR_LINE_OFFSET - 4);
+});
+
+test('an editor with nothing laid out yet reports no anchor', () => {
+	const { anchorLine } = editorReadingPosition({
+		scrollTop: 0,
+		contentHeight: 2000,
+		viewportHeight: 1000,
+		topLine: null,
+		text: 'body',
+	});
+	assert.equal(anchorLine, null);
+});
+
+test('the editor derives the anchor in exactly one place', () => {
+	// The teardown used to build it inline. A flush that built its own would be
+	// a second crossing of the same two numberings, which is the defect shape
+	// `lineCoordinates.ts` exists to prevent.
+	assert.doesNotMatch(editor, /tabAnchorForEditorTopLine/);
+	assert.equal((editor.match(/editorReadingPosition\(/g) ?? []).length, 1);
+});
+
+test('the flush refuses a tab the editor is not holding', () => {
+	// One Editor per window, swapping models between tabs: an unguarded flush
+	// would copy the active tab's position onto the record the caller named.
+	const flush = sliceFrom(editor, 'export function flushPositionTo');
+	assert.match(flush, /if \(!editorReady \|\| !editor \|\| currentTabId !== tabId\) return;/);
+});
+
+test('the transfer payload flushes before it snapshots the tab', () => {
+	// `snapshotTab` is synchronous and runs with the editor still mounted, so
+	// without this the tab travels at the position of the last teardown.
+	const flushAt = offsetOf(viewer, 'editorPane?.flushPositionTo(tabId);');
+	const snapshotAt = offsetOf(viewer, 'JSON.stringify(snapshotTab(tab))');
+	assert.ok(flushAt < snapshotAt);
+});
+
+test('the window-state snapshot flushes too', () => {
+	// Same staleness at window close: `serializeState` persists the same three
+	// fields and the editor has not come down yet.
+	const serialize = sliceFrom(viewer, 'serializeState: () => {');
+	const flushAt = offsetOf(serialize, 'flushPositionTo(tabManager.activeTabId)');
+	const stateAt = offsetOf(serialize, 'return tabManager.serializeState();');
+	assert.ok(flushAt < stateAt);
+});

--- a/scripts/firstReadMeasuresItsOwnTab.spec.ts
+++ b/scripts/firstReadMeasuresItsOwnTab.spec.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+/**
+ * Opening a large file is two reads: a 5MB slice that puts something on screen,
+ * and a background read that completes it. The slice arrives after three awaits,
+ * and the reader can switch tabs inside any of them.
+ *
+ * Every write the first stage makes is addressed by tab id, so a switch costs
+ * nothing — with a preview host per tab, the HTML lands on the tab that asked
+ * for it and is shown when that tab is next displayed. The exception was the
+ * viewport measurement: there is one article on screen and one `isAtBottom`
+ * flag, so measuring after a switch answers "does this document fit the
+ * viewport" for the tab the reader moved to, and a short one sets the flag that
+ * raises the "loading full document" chip on the tab still loading — at the top
+ * of a slice nobody has scrolled.
+ *
+ * The switch here happens inside `renderMarkdown`, which is where the real one
+ * has the most room: rendering 5MB of markdown is the longest await on the path.
+ */
+
+let handleInvoke: (cmd: string, args: any) => unknown = (cmd) => {
+	throw new Error(`unexpected invoke: ${cmd}`);
+};
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string, args: any) => Promise.resolve(handleInvoke(cmd, args)),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+const BIG = '/notes/big.md';
+const SMALL = '/notes/small.md';
+
+/** The first stage returns a slice (`isFull` false); the completion never lands. */
+function readsATruncatedFile() {
+	handleInvoke = (cmd, args) => {
+		if (cmd === 'get_os_type') return 'macos';
+		if (cmd === 'canonicalize_path') return args.path;
+		if (cmd === 'open_markdown_preview') return [args.path, 'the first five megabytes', false, false, 'UTF-8'];
+		// The background completion, left in flight: this is about the tab the
+		// first stage lands on, not about what finishes afterwards.
+		if (cmd === 'read_file_content_checked') return new Promise(() => {});
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+}
+
+function openTwoTabs() {
+	tabManager.closeAll();
+	tabManager.addTab(BIG);
+	tabManager.addTab(SMALL);
+	const big = tabManager.tabs.find((tab) => tab.path === BIG)!.id;
+	const small = tabManager.tabs.find((tab) => tab.path === SMALL)!.id;
+	tabManager.setActive(big);
+	return { big, small };
+}
+
+function makeSession(overrides: Record<string, unknown> = {}) {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async () => 'rendered',
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: (message: string, error: unknown) => {
+			throw new Error(`${message}: ${String(error)}`);
+		},
+		onDiskChangedUnderSave: () => {},
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+		onPartialCopySaved: () => {},
+		...overrides,
+	});
+}
+
+test('a switch during the first read leaves the other document unmeasured', async () => {
+	readsATruncatedFile();
+	const { big, small } = openTwoTabs();
+
+	const measuredWhileActive: (string | null)[] = [];
+	let loading: string[] = [];
+	const session = makeSession({
+		renderMarkdown: async () => {
+			tabManager.setActive(small);
+			return 'rendered';
+		},
+		setLoadingTabs: (ids: string[]) => (loading = ids),
+		measureInitialViewport: () => measuredWhileActive.push(tabManager.activeTabId),
+	});
+
+	await session.loadMarkdown(BIG);
+
+	assert.deepEqual(measuredWhileActive, [], 'the article showing the other tab is not measured');
+	// The rest of the path was already right, and stays that way: the slice and
+	// its rendered HTML are addressed by id, and so is the loading set the chip
+	// asks about.
+	assert.equal(tabManager.tabs.find((tab) => tab.id === big)!.content, 'rendered');
+	assert.equal(tabManager.tabs.find((tab) => tab.id === big)!.isTruncated, true);
+	assert.equal(tabManager.tabs.find((tab) => tab.id === small)!.content, '');
+	assert.deepEqual(loading, [big], 'the loading tab is the one that is loading, not the one on screen');
+});
+
+test('with no switch, the tab that loaded is the tab measured', async () => {
+	readsATruncatedFile();
+	const { big } = openTwoTabs();
+
+	const measuredWhileActive: (string | null)[] = [];
+	const session = makeSession({
+		measureInitialViewport: () => measuredWhileActive.push(tabManager.activeTabId),
+	});
+
+	await session.loadMarkdown(BIG);
+
+	assert.deepEqual(measuredWhileActive, [big], 'the ordinary open still measures, exactly once');
+});

--- a/scripts/lossyDecodeSaveGuard.test.ts
+++ b/scripts/lossyDecodeSaveGuard.test.ts
@@ -216,6 +216,8 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		isScrollSynced: false,
 		hasReplacementChars: true,
 		encoding: 'UTF-8',
+		scrollHistory: [],
+		scrollFuture: [],
 		foldOverrides: new Set<string>(),
 		...overrides,
 	};

--- a/scripts/previewAnchorRestore.test.ts
+++ b/scripts/previewAnchorRestore.test.ts
@@ -429,30 +429,39 @@ test('source position ranges parse the way comrak writes them', () => {
 });
 
 /**
- * The two assertions below are source assertions, not behavior assertions: the
- * restore effect lives inside a Svelte component and cannot be imported. They
- * pin the wiring — that the component calls the measured resolver, and that the
- * top-level-only scan the rates above were measured against does not come back.
+ * The assertions below are source assertions, not behavior assertions: the
+ * restore is triggered from inside a Svelte component and that effect cannot be
+ * imported. They pin the wiring — that the component restores through the
+ * measured cascade, and that the top-level-only scan the rates above were
+ * measured against does not come back.
+ *
+ * The cascade itself moved out of the component and into
+ * `restorePreviewReadingPosition`, next to the resolvers it runs, when the
+ * arrival of a transferred tab needed to run the same one after its document
+ * lands (see tabTransferHandoff.test.ts). So "it resolves through the measured
+ * helpers" is now a behavior claim, made by calling the function — every test
+ * above this one, and the arrival tests in tabReadingPosition.spec.ts. What is
+ * left here is what a source assertion is for: that there is no second copy.
  */
 test('the viewer restores through the measured resolver', async () => {
 	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 	// Read out of the one import statement rather than matched across the whole
-	// file: `import \{[\s\S]*findAnchorElement[\s\S]*\} from '…previewAnchor.js'`
-	// starts at the first import in the file and runs past every brace in
-	// between, so forking the two resolvers into another module while leaving
-	// the rest of the import behind satisfied it.
+	// file: `import \{[\s\S]*restorePreviewReadingPosition[\s\S]*\} from
+	// '…previewAnchor.js'` starts at the first import in the file and runs past
+	// every brace in between, so forking the cascade into another module while
+	// leaving the rest of the import behind satisfied it.
 	const anchorImport = viewer.match(/import \{([^}]*)\} from '\.\/utils\/previewAnchor\.js'/);
 	assert.ok(anchorImport, 'the viewer must import from previewAnchor.js');
 	const imported = anchorImport[1].split(',').map((name) => name.trim()).filter(Boolean);
-	assert.deepEqual(
-		['findAnchorElement', 'getAnchorScrollTop'].filter((name) => !imported.includes(name)),
-		[],
-		'the restore must resolve through the measured helpers, not a fork of them',
+	assert.ok(
+		imported.includes('restorePreviewReadingPosition'),
+		'the restore must go through the shared cascade, not a fork of it',
 	);
-	assert.match(
-		viewer,
-		/const match = findAnchorElement\(body, tab\.anchorLine\);[\s\S]*body\.scrollTop = getAnchorScrollTop\(/,
-	);
+	// And the component must not grow one of its own back: the cascade is an
+	// ORDER, and a second site consulting the same three fields in a different
+	// one is a different answer for the same tab.
+	assert.doesNotMatch(viewer, /scrollTop = getAnchorScrollTop\(/);
+	assert.doesNotMatch(viewer, /tab\.scrollPercentage/);
 	assert.doesNotMatch(viewer, /Array\.from\(body\.children\)/);
 });

--- a/scripts/scrollHistoryPerTab.spec.ts
+++ b/scripts/scrollHistoryPerTab.spec.ts
@@ -1,0 +1,339 @@
+/**
+ * The preview's in-page back/forward stacks belong to the document they were
+ * measured in.
+ *
+ * They hold raw `markdownBody.scrollTop` pixels — where the reader was standing
+ * before each anchor jump — and the viewer held ONE pair for the whole window.
+ * Nothing emptied it on a tab switch, and a tab switch reloads nothing, so a
+ * jump in a long document left an offset behind that the next mouse-back in
+ * whatever tab the reader landed on would scroll to. A long document followed
+ * by a short one is the visible case: the short one has no such offset to be
+ * at, so it goes as far as it can and stops somewhere the reader has never
+ * been. The only reset was `resetScrollHistory`, an option of `loadMarkdown`,
+ * which fires for a document LOAD and not for a switch.
+ *
+ * These stacks are not `Tab.history`/`historyIndex`, which is the FILE the tab
+ * points at and is what the mouse falls through to when there is no jump left
+ * to undo. Both are exercised below, because the fall-through is the half a
+ * per-tab stack changes: a tab with a stale offset never reached it.
+ *
+ * Everything here runs the REAL `TabManager` — the same `pushScrollHistory`,
+ * `popScrollHistoryBack` and `popScrollHistoryForward` the viewer calls, the
+ * real `navigate`/`goBack`/`goForward`, the real serialization and the real
+ * cross-window snapshot. Nothing asserts on the text of an implementation file.
+ *
+ * WHAT IS NOT THE REAL THING, AND WHY. `handleMouseUp` lives in
+ * MarkdownViewer.svelte and is not exported; `mouseButton` below is its three
+ * lines, restated. What it stands in for is one `markdownBody.scrollTop` read —
+ * jsdom has no layout, so the offsets here are supplied rather than measured,
+ * which is also why this file asks "which offset comes back" and never "where
+ * does the preview end up".
+ */
+
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin. Only the Tauri backend is stubbed — importing the store boots
+// the settings singleton, which asks for the OS type.
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { snapshotTab, buildTransferredTab } = await import('../src/lib/utils/tabTransfer.js');
+
+// ------------------------------------------------------------------ the wiring
+
+type Direction = 'back' | 'forward';
+
+/**
+ * What the mouse's back and forward buttons do, as `handleMouseUp` wires them:
+ * pop the tab's in-page stack first, and move to another DOCUMENT only when
+ * that tab has no jump left to walk. `at` is where the reader is standing,
+ * which the viewer reads off the preview container.
+ */
+function mouseButton(direction: Direction, at: number): { scrolledTo: number } | { openedFile: string | null } {
+	const id = tabManager.activeTabId!;
+	const pos =
+		direction === 'back'
+			? tabManager.popScrollHistoryBack(id, at)
+			: tabManager.popScrollHistoryForward(id, at);
+	if (pos !== null) return { scrolledTo: pos };
+	return { openedFile: direction === 'back' ? tabManager.goBack(id) : tabManager.goForward(id) };
+}
+
+/** An anchor jump: the reader was at `at`, and is about to be somewhere else. */
+function jumpFrom(at: number) {
+	tabManager.pushScrollHistory(tabManager.activeTabId!, at);
+}
+
+function reset() {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+}
+
+const stackOf = (id: string) => tabManager.tabs.find((t) => t.id === id)!.scrollHistory;
+const futureOf = (id: string) => tabManager.tabs.find((t) => t.id === id)!.scrollFuture;
+
+/** A long document and a short one, a jump made in the long one, landing on the short. */
+function jumpInLongThenSwitchToShort() {
+	reset();
+	tabManager.addTab('/notes/long.md', '# Long\n');
+	const long = tabManager.activeTabId!;
+	tabManager.addTab('/notes/short.md', '# Short\n');
+	const short = tabManager.activeTabId!;
+
+	tabManager.setActive(long);
+	jumpFrom(8400);
+
+	tabManager.setActive(short);
+	return { long, short };
+}
+
+// ------------------------------------------------- the switch the bug was about
+
+test('a back click in one document does not scroll to an offset measured in another', () => {
+	const { short } = jumpInLongThenSwitchToShort();
+
+	const result = mouseButton('back', 0);
+
+	assert.deepEqual(stackOf(short), []);
+	assert.ok(!('scrolledTo' in result), 'the short document has no jump of its own to go back to');
+});
+
+test('with no jump of its own, back moves the tab to the previous FILE instead', () => {
+	reset();
+	tabManager.addTab('/notes/long.md', '# Long\n');
+	const long = tabManager.activeTabId!;
+	jumpFrom(8400);
+
+	tabManager.addTab('/notes/short.md', '# Short\n');
+	const short = tabManager.activeTabId!;
+	tabManager.navigate(short, '/notes/other.md');
+
+	assert.deepEqual(mouseButton('back', 0), { openedFile: '/notes/short.md' });
+	// ...and the tab that DID jump still has its own offset waiting.
+	assert.deepEqual(stackOf(long), [8400]);
+});
+
+test('the offset is still there when the reader comes back to the document they jumped in', () => {
+	const { long } = jumpInLongThenSwitchToShort();
+
+	tabManager.setActive(long);
+
+	assert.deepEqual(mouseButton('back', 200), { scrolledTo: 8400 });
+});
+
+test('forward is per tab too', () => {
+	const { long, short } = jumpInLongThenSwitchToShort();
+
+	tabManager.setActive(long);
+	mouseButton('back', 200);
+	assert.deepEqual(futureOf(long), [200]);
+
+	tabManager.setActive(short);
+	assert.deepEqual(futureOf(short), []);
+	assert.ok(!('scrolledTo' in mouseButton('forward', 0)));
+});
+
+test('two tabs jumped in keep their own offsets, in their own order', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(100);
+	jumpFrom(200);
+
+	tabManager.addTab('/notes/b.md', '# B\n');
+	const b = tabManager.activeTabId!;
+	jumpFrom(900);
+
+	tabManager.setActive(a);
+	assert.deepEqual(mouseButton('back', 250), { scrolledTo: 200 });
+	assert.deepEqual(mouseButton('back', 200), { scrolledTo: 100 });
+
+	tabManager.setActive(b);
+	assert.deepEqual(mouseButton('back', 950), { scrolledTo: 900 });
+});
+
+test('an untitled buffer has a stack of its own', () => {
+	reset();
+	tabManager.addNewTab();
+	const untitled = tabManager.activeTabId!;
+	jumpFrom(300);
+
+	tabManager.addTab('/notes/a.md', '# A\n');
+	assert.deepEqual(stackOf(tabManager.activeTabId!), []);
+
+	tabManager.setActive(untitled);
+	assert.deepEqual(mouseButton('back', 400), { scrolledTo: 300 });
+});
+
+test('closing a tab takes its offsets with it', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(500);
+	tabManager.addTab('/notes/b.md', '# B\n');
+
+	tabManager.closeTab(a);
+	tabManager.addTab('/notes/a.md', '# A\n');
+
+	assert.deepEqual(stackOf(tabManager.activeTabId!), []);
+});
+
+// ------------------------------------- repointing the tab at another document
+
+test('following a link drops the offsets of the document left behind', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+
+	tabManager.navigate(a, '/notes/b.md');
+
+	assert.deepEqual(stackOf(a), []);
+	assert.ok(!('scrolledTo' in mouseButton('back', 0)));
+});
+
+test('going back to the previous file drops them', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	tabManager.navigate(a, '/notes/b.md');
+	jumpFrom(4000);
+
+	assert.equal(tabManager.goBack(a), '/notes/a.md');
+	assert.deepEqual(stackOf(a), []);
+});
+
+test('going forward again drops them', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	tabManager.navigate(a, '/notes/b.md');
+	tabManager.goBack(a);
+	jumpFrom(4000);
+
+	assert.equal(tabManager.goForward(a), '/notes/b.md');
+	assert.deepEqual(stackOf(a), []);
+});
+
+test('the forward stack goes with them', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+	mouseButton('back', 4200);
+	assert.deepEqual(futureOf(a), [4200]);
+
+	tabManager.navigate(a, '/notes/b.md');
+
+	assert.deepEqual(futureOf(a), []);
+});
+
+test('Save As keeps them, because the document on screen has not changed', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+
+	tabManager.updateTabPath(a, '/notes/copy.md');
+
+	assert.deepEqual(mouseButton('back', 4200), { scrolledTo: 4000 });
+});
+
+test('renaming the file on disk keeps them', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+
+	tabManager.renameTab(a, '/notes/renamed.md');
+
+	assert.deepEqual(mouseButton('back', 4200), { scrolledTo: 4000 });
+});
+
+test('a reload in place drops them, because the text they were measured in is gone', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+
+	tabManager.clearScrollHistory(a);
+
+	assert.deepEqual(stackOf(a), []);
+	assert.deepEqual(futureOf(a), []);
+});
+
+// -------------------------------------------------------------- the stack itself
+
+test('a new jump abandons the forward stack, as every history does', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(100);
+	mouseButton('back', 500);
+	assert.deepEqual(futureOf(a), [500]);
+
+	jumpFrom(700);
+
+	assert.deepEqual(futureOf(a), []);
+});
+
+test('back and forward walk the same offsets in both directions', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	jumpFrom(100);
+	jumpFrom(400);
+
+	assert.deepEqual(mouseButton('back', 900), { scrolledTo: 400 });
+	assert.deepEqual(mouseButton('back', 400), { scrolledTo: 100 });
+	assert.deepEqual(mouseButton('forward', 100), { scrolledTo: 400 });
+	assert.deepEqual(mouseButton('forward', 400), { scrolledTo: 900 });
+});
+
+test('a tab remembers the last fifty jumps and drops the oldest', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	for (let i = 1; i <= 55; i += 1) jumpFrom(i);
+
+	assert.equal(stackOf(a).length, 50);
+	assert.equal(stackOf(a)[0], 6);
+	assert.equal(stackOf(a)[49], 55);
+});
+
+// ------------------------------------------------ what deliberately does not travel
+
+test('a restored window opens with no offsets to walk', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	jumpFrom(4000);
+	const saved = tabManager.serializeState();
+
+	reset();
+	tabManager.restoreState(saved);
+
+	const restored = tabManager.tabs.find((t) => t.path === '/notes/a.md')!;
+	assert.deepEqual(restored.scrollHistory, []);
+	assert.deepEqual(restored.scrollFuture, []);
+});
+
+test('a tab moved to another window arrives with none either', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', '# A\n');
+	const a = tabManager.activeTabId!;
+	jumpFrom(4000);
+
+	const arrived = buildTransferredTab(
+		snapshotTab(tabManager.tabs.find((t) => t.id === a)!),
+		[],
+		'Untitled',
+	);
+
+	assert.deepEqual(arrived.scrollHistory, []);
+	assert.deepEqual(arrived.scrollFuture, []);
+});

--- a/scripts/tabReadingPosition.spec.ts
+++ b/scripts/tabReadingPosition.spec.ts
@@ -66,7 +66,14 @@ import { test } from 'vitest';
 
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { processMarkdownHtml } = await import('../src/lib/utils/markdown.js');
-const { findAnchorElement } = await import('../src/lib/utils/previewAnchor.js');
+const {
+	findAnchorElement,
+	parseSourceposLineRange,
+	PREVIEW_ANCHOR_OFFSET,
+	restorePreviewReadingPosition,
+} = await import('../src/lib/utils/previewAnchor.js');
+type AnchorNode = Parameters<typeof findAnchorElement>[0];
+type AnchorBox = ReturnType<Parameters<typeof restorePreviewReadingPosition>[3]>;
 const { asRendererLine, lineCoordinates } = await import('../src/lib/utils/lineCoordinates.js');
 const { snapshotTab, validateTransferPayload } = await import('../src/lib/utils/tabTransfer.js');
 
@@ -378,4 +385,119 @@ test('branding both sides of a snapshot changes none of its bytes', () => {
 
 	tabManager.restoreState(tabManager.serializeState());
 	assert.equal(tabManager.tabs.find((item) => item.path === '/notes/a.md')?.anchorLine, 812);
+});
+
+/* ------------------------------------------------------------------ */
+/* the arrival of a tab from another window                            */
+/* ------------------------------------------------------------------ */
+//
+// The transfer payload carries all three fields (`tabTransfer.ts`), so the
+// destination has everything it needs — and used to open the document at the
+// top anyway, because of WHEN it asked.
+//
+// `insertTransferredTab` pushes the tab and activates it synchronously, while
+// its rendered `content` is still the `''` every construction site seeds. The
+// preview's restore effect runs on that activation, against a host holding no
+// document; `acceptTransferredTab` only awaits `renderTabPreviewFromRaw`
+// afterwards, and nothing re-triggers the effect when that document lands (it
+// depends on the tab id, the article and the path — deliberately not on the
+// render, which also fires on every debounced re-render while the reader is
+// typing in split view).
+//
+// The two tests below are the two moments, run against the REAL cascade over
+// the REAL `processMarkdownHtml` output of the document being transferred.
+// What they cannot be is a live drag: two windows and a Rust broker are not
+// reachable from here, so the sequence is replayed rather than performed, and
+// the wiring that performs it is asserted in `tabTransferHandoff.test.ts`.
+
+/**
+ * A layout in which every source line is `LINE_HEIGHT` tall.
+ *
+ * jsdom reports 0 for every offset, so the geometry is the fixture — as in
+ * `scrollSyncAcrossFolds.test.ts` and `anchorJumpUnderZoom.spec.ts`. Deriving
+ * it from the element's own `data-sourcepos` is what makes the expected
+ * scrollTop below a number this file can state rather than read back.
+ */
+const LINE_HEIGHT = 24;
+
+function measureBySourcepos(node: AnchorNode): AnchorBox {
+	const range = parseSourceposLineRange(node.getAttribute?.('data-sourcepos'));
+	if (!range) return { top: Number.NaN, height: Number.NaN };
+	return {
+		top: (range.startLine - 1) * LINE_HEIGHT,
+		height: (range.endLine - range.startLine + 1) * LINE_HEIGHT,
+	};
+}
+
+/**
+ * The article the preview scrolls. Its scroll range is passed to the restore
+ * rather than read off it, so it is stated here: nothing to scroll while the
+ * host is empty, a tall document once one has been patched in.
+ */
+function emptyPreview(): HTMLElement {
+	const host = document.createElement('div');
+	host.className = 'markdown-body';
+	return host;
+}
+
+function scrollMaxOf(host: HTMLElement): number {
+	return host.innerHTML === '' ? 0 : 40_000 - 900;
+}
+
+/** A tab that left another window with its reader parked on `anchorLine`. */
+function arriveFromAnotherWindow(anchorLine: number): Tab {
+	tabManager.addTab('/notes/b.md', DOC_B.html());
+	const source = tabManager.tabs.find((item) => item.path === '/notes/b.md')!;
+	source.scrollTop = 4820;
+	source.scrollPercentage = 0.73;
+	source.anchorLine = asRendererLine(anchorLine);
+
+	const payload = validateTransferPayload(JSON.stringify(snapshotTab(source)));
+	assert.ok(payload, 'a snapshot of a real tab must validate');
+
+	// The destination window, which has never seen this document.
+	tabManager.closeAll();
+	const id = tabManager.insertTransferredTab(payload);
+	return tabManager.tabs.find((item) => item.id === id)!;
+}
+
+/** A heading line, so the block spans one line and the interpolation is exact. */
+const ARRIVAL_LINE = DOC_B.lines[Math.floor(DOC_B.lines.length / 2)];
+
+test('a transferred tab is activated before its document exists, so the restore then has nothing to work with', () => {
+	reset();
+	const arrived = arriveFromAnotherWindow(ARRIVAL_LINE);
+
+	// The three fields survived the wire, and the tab is already the active one.
+	assert.equal(arrived.anchorLine, ARRIVAL_LINE);
+	assert.equal(arrived.scrollPercentage, 0.73);
+	assert.equal(arrived.scrollTop, 4820);
+	assert.equal(tabManager.activeTabId, arrived.id);
+	assert.equal(arrived.content, '', 'the rendered document has not been built yet');
+
+	const host = emptyPreview();
+
+	// Every entry of the cascade in turn: no block owns the line because there
+	// are no blocks, there is no scroll range for the percentage, and the pixel
+	// offset has nowhere to go. Asserted on the returned entry rather than on
+	// `host.scrollTop`, because jsdom stores whatever is assigned to `scrollTop`
+	// while a real container clamps it to a range that here is empty.
+	assert.equal(restorePreviewReadingPosition(host, arrived, scrollMaxOf(host), measureBySourcepos), 'nothing');
+	assert.equal(findAnchorElement(host, arrived.anchorLine), null);
+});
+
+test('the same cascade, run once the arriving document is in, puts the reader back', () => {
+	reset();
+	const arrived = arriveFromAnotherWindow(ARRIVAL_LINE);
+	const host = emptyPreview();
+
+	// What `renderTabPreviewFromRaw` leaves behind: the tab's own buffer through
+	// the real pipeline, patched into the host it just awaited a flush for.
+	host.innerHTML = processMarkdownHtml(DOC_B.html(), arrived.path, new Set<string>());
+
+	assert.equal(restorePreviewReadingPosition(host, arrived, scrollMaxOf(host), measureBySourcepos), 'anchor');
+	// The first entry of the cascade answered, so the answer is the anchor's:
+	// the line's own box, pinned `PREVIEW_ANCHOR_OFFSET` below the top.
+	assert.equal(host.scrollTop, (ARRIVAL_LINE - 1) * LINE_HEIGHT - PREVIEW_ANCHOR_OFFSET);
+	assert.notEqual(host.scrollTop, 0);
 });

--- a/scripts/tabTransfer.test.ts
+++ b/scripts/tabTransfer.test.ts
@@ -41,6 +41,8 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		isScrollSynced: true,
 		hasReplacementChars: false,
 		encoding: 'UTF-8',
+		scrollHistory: [],
+		scrollFuture: [],
 		foldOverrides: new Set<string>(),
 		...overrides,
 	};

--- a/scripts/tabTransferHandoff.test.ts
+++ b/scripts/tabTransferHandoff.test.ts
@@ -47,6 +47,34 @@ test('a failed render undoes the inserted tab', () => {
 	assert.match(accept, /if \(isDisposed\) \{\s*\n\s*tabManager\.closeTab\(id\);/);
 });
 
+test('the arriving tab is put back where its reader was, after its document lands', () => {
+	// The position travels in the payload (tabTransfer.ts) and nothing put it
+	// back. `insertTransferredTab` activates the tab synchronously, while its
+	// rendered `content` is still `''`, so the preview's restore effect runs on
+	// that activation against a host holding no document: no block owns the
+	// anchor line, there is no scroll range for the percentage, and the pixel
+	// offset has nowhere to go. The document arrives afterwards, at the top.
+	//
+	// The effect cannot cover this by depending on the render. It also runs
+	// while the reader is typing — split view and edit-with-outline re-render on
+	// a debounce — and a per-render dependency would drag the preview back to
+	// the saved position on every pause in typing. So the arrival asks again
+	// itself, once `renderTabPreviewFromRaw` has awaited the patch.
+	//
+	// Ordering is the whole assertion, which is why it is a source assertion:
+	// what goes wrong is WHEN the restore is called, and the two moments are one
+	// `await` apart inside a Svelte component.
+	const accept = sliceBetween(viewer, 'acceptTransferredTab: async (snapshot)', 'onError: (message, error)');
+	const rendered = accept.indexOf('await renderTabPreviewFromRaw(transferred);');
+	const restored = accept.indexOf('restorePreviewReadingPosition(');
+	assert.ok(rendered !== -1, 'the arrival must render the document it was handed');
+	assert.ok(restored > rendered, 'the restore must run after the render, not before it');
+	// Only the active tab's host is displayed, and they all share one scrolling
+	// article: restoring for a tab the user has since switched away from would
+	// move whichever document is on screen instead.
+	assert.match(accept, /tabManager\.activeTabId === id/);
+});
+
 test('a second transfer of the same tab is refused while one is in flight', () => {
 	// The menu entry becomes clickable again long before the transfer
 	// resolves; two payloads for one tab means two windows each build it.

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -49,12 +49,11 @@ import {
 import { routeDroppedFile, type DropPane } from './utils/fileDrop.js';
 import { headingReference, preferredReferenceStyle } from './utils/headingReference.js';
 import {
-	findAnchorElement,
 	findSourceLineRange,
-	getAnchorScrollTop,
 	getSourceLineAtPreviewOffset,
 	measureAnchorBox,
 	mergeSourceLineRanges,
+	restorePreviewReadingPosition,
 	PREVIEW_ANCHOR_OFFSET,
 	anchorScrollTop,
 	type AnchorBox,
@@ -745,6 +744,30 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 					tabManager.closeTab(id);
 					return false;
 				}
+				// The reading position travels with the tab, and until here nothing
+				// put it back. `insertTransferredTab` activates the tab
+				// synchronously, while its `content` is still `''`; the restore
+				// effect below runs on that activation against a host with no
+				// document in it, finds no anchor and no scroll range, and the
+				// document the reader left arrives afterwards at the top. That effect
+				// cannot cover this by depending on the render — it also runs while
+				// the reader is typing in split view, where a per-render dependency
+				// would drag the preview back on every debounce — so the arrival
+				// asks again, now that `renderTabPreviewFromRaw` has awaited the
+				// patch and the host holds the document.
+				//
+				// Guarded on the tab still being the active one: only the active
+				// host is displayed, and `markdownBody` is the article all of them
+				// share, so scrolling it for a tab the user has since switched away
+				// from would move somebody else's document.
+				if (markdownBody && tabManager.activeTabId === id) {
+					restorePreviewReadingPosition(
+						markdownBody,
+						transferred,
+						getPreviewScrollMax(markdownBody),
+						measurePreviewBox,
+					);
+				}
 				return true;
 			} catch (error) {
 				tabManager.closeTab(id);
@@ -1401,44 +1424,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (id && body) {
 			untrack(() => {
 				const tab = tabManager.tabs.find((t) => t.id === id);
-				if (tab) {
-					let scrolled = false;
-
-					if (tab.anchorLine > 0) {
-						// Interpolated restore: find the rendered element that owns the
-						// saved source line and put that line back under the anchor
-						// offset. This has to descend — `processMarkdownHtml` re-parents
-						// every block after a heading into a `.foldable-content-wrapper`
-						// with no `data-sourcepos`, so a scan of `body.children` only
-						// ever matched an anchor sitting exactly on a top-level heading
-						// line (see scripts/previewAnchorRestore.test.ts for the rate).
-						const match = findAnchorElement(body, tab.anchorLine);
-						if (match) {
-							// Through the same measurement the sync path uses: an anchor
-							// inside a table or a code block resolves to an element whose
-							// `offsetTop` is measured from that table or that block's shell,
-							// and restoring to it would open the tab at the top instead.
-							const box = measurePreviewBox(match.element);
-							body.scrollTop = getAnchorScrollTop(
-								box.top,
-								box.height,
-								match,
-								tab.anchorLine,
-								PREVIEW_ANCHOR_OFFSET,
-							);
-							scrolled = true;
-						}
-					}
-
-					if (!scrolled) {
-						if (body.scrollHeight > body.clientHeight && tab.scrollPercentage > 0) {
-							const targetScroll = tab.scrollPercentage * (body.scrollHeight - body.clientHeight);
-							body.scrollTop = targetScroll;
-						} else {
-							body.scrollTop = tab.scrollTop;
-						}
-					}
-				}
+				// The cascade itself is `restorePreviewReadingPosition` in
+				// previewAnchor.ts, next to the three measurements it runs. It is a
+				// function and not this block because the arrival of a transferred
+				// tab has to run the SAME cascade after its document lands (see
+				// `acceptTransferredTab`), and two copies consulting the same three
+				// fields in different orders would be two answers for one tab.
+				if (tab) restorePreviewReadingPosition(body, tab, getPreviewScrollMax(body), measurePreviewBox);
 			});
 		}
 	});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -344,9 +344,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 	}
 
-	// in-page scroll position history for mouse 4/5 nav
-	let scrollHistory: number[] = [];
-	let scrollFuture: number[] = [];
 	let zoomData = $state<{ src?: string; html?: string } | null>(null);
 
 	// What a document with no tab behind it has folded. Never written to — every
@@ -819,8 +816,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		setShowHome: (value) => (showHome = value),
 		currentFile: () => currentFile,
 		resetScrollHistory: () => {
-			scrollHistory = [];
-			scrollFuture = [];
+			if (tabManager.activeTabId) tabManager.clearScrollHistory(tabManager.activeTabId);
 		},
 		renderMarkdown: renderMarkdownPreview,
 		afterLoad: tick,
@@ -1718,7 +1714,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (!resolved) return;
 
 		tabManager.addTab(resolved);
-		await loadMarkdown(resolved, { skipTabManagement: true, resetScrollHistory: true });
+		await loadMarkdown(resolved, { skipTabManagement: true });
 		if (target.hash) {
 			await scrollToAnchorWhenReady(target.hash, { pushHistory: false }, resolved);
 		}
@@ -3176,42 +3172,46 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			: tabManager.goForward(activeTabId);
 
 		if (path) {
-			await loadMarkdown(path, { skipTabManagement: true, resetScrollHistory: true });
+			// No `resetScrollHistory` here, and none in `openMarkdownTargetInNewTab`
+			// either: goBack/goForward repoint the tab, so `clearReadingPosition`
+			// has already dropped its in-page stacks along with the rest of the
+			// position, and a tab opened by `addTab` never had any.
+			await loadMarkdown(path, { skipTabManagement: true });
 		}
 	}
 
+	// The in-page jump stacks belong to the tab the offsets were measured in —
+	// see `Tab.scrollHistory`. These three wrappers exist only to name that tab
+	// and to read the offset off the preview, which the store cannot see.
 	function pushScrollHistory() {
-		if (markdownBody) {
-			scrollHistory.push(markdownBody.scrollTop);
-			scrollFuture = [];
-			if (scrollHistory.length > 50) scrollHistory.shift();
+		if (markdownBody && tabManager.activeTabId) {
+			tabManager.pushScrollHistory(tabManager.activeTabId, markdownBody.scrollTop);
 		}
+	}
+
+	/**
+	 * Where an in-page back/forward would land, or null if this tab has no jump
+	 * to walk — the caller then falls through to the FILE history.
+	 */
+	function popScrollHistory(direction: 'back' | 'forward'): number | null {
+		if (!markdownBody || !tabManager.activeTabId) return null;
+		return direction === 'back'
+			? tabManager.popScrollHistoryBack(tabManager.activeTabId, markdownBody.scrollTop)
+			: tabManager.popScrollHistoryForward(tabManager.activeTabId, markdownBody.scrollTop);
 	}
 
 	async function handleMouseUp(e: MouseEvent) {
-		if (e.button === 3) {
-			// Back
-			e.preventDefault();
-			// try in-page scroll history first
-			if (scrollHistory.length > 0 && markdownBody) {
-				scrollFuture.push(markdownBody.scrollTop);
-				const pos = scrollHistory.pop()!;
-				isProgrammaticScroll = true;
-				markdownBody.scrollTo({ top: pos, behavior: jumpBehavior });
-			} else {
-				await navigateFileHistory('back');
-			}
-		} else if (e.button === 4) {
-			// Forward
-			e.preventDefault();
-			if (scrollFuture.length > 0 && markdownBody) {
-				scrollHistory.push(markdownBody.scrollTop);
-				const pos = scrollFuture.pop()!;
-				isProgrammaticScroll = true;
-				markdownBody.scrollTo({ top: pos, behavior: jumpBehavior });
-			} else {
-				await navigateFileHistory('forward');
-			}
+		if (e.button !== 3 && e.button !== 4) return;
+		const direction = e.button === 3 ? 'back' : 'forward';
+		e.preventDefault();
+		// In-page scroll history first; only a tab with no jump left to undo
+		// moves to another document.
+		const pos = popScrollHistory(direction);
+		if (pos !== null && markdownBody) {
+			isProgrammaticScroll = true;
+			markdownBody.scrollTo({ top: pos, behavior: jumpBehavior });
+		} else {
+			await navigateFileHistory(direction);
 		}
 	}
 

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1004,10 +1004,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	//
 	// `folds` is a parameter rather than a read of the active tab because this
 	// renders documents that are NOT on screen: a window restore renders every
-	// restored tab, a cross-window arrival renders itself, and the background
+	// restored tab, a cross-window arrival renders itself, the background
 	// completion of a large file lands long after the user may have switched
-	// away. Each of those must fold the document it is rendering, not whichever
-	// one happens to be active when the promise resolves.
+	// away, and the first-stage read in `documentSession` resolves after three
+	// awaits a switch can happen inside — the four `previewHosts` lists. Each of
+	// those must fold the document it is rendering, not whichever one happens to
+	// be active when the promise resolves.
 	async function renderMarkdownPreview(raw: string, filePath: string, folds: Set<string>) {
 		const body = getMarkdownBodyWithoutFrontMatter(raw);
 		const html = (await invoke('render_markdown', { content: body })) as string;

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -234,6 +234,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		revealHeader: (sourceLine: BufferLine | null, text: string) => void;
 		revealSourceRange: (startLine: number, endLine: number) => void;
 		triggerFind: () => void;
+		flushPositionTo: (tabId: string) => void;
 		// The three the editor's context menu runs, which are the three its
 		// keyboard shortcuts run (#207).
 		cutToClipboard: () => Promise<void>;
@@ -690,7 +691,14 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		windowStateKey: WINDOW_STATE_KEY,
 		legacyStateKey: LEGACY_STATE_KEY,
 		restoreInProgressKey: RESTORE_IN_PROGRESS_KEY,
-		serializeState: () => tabManager.serializeState(),
+		serializeState: () => {
+			// Same reason as `transferPayload` below, at a different moment: this
+			// runs on window close with the editor still mounted, so the tab being
+			// edited would be persisted at the position it held when the editor
+			// last came down. Only the active tab can be the one the editor holds.
+			if (tabManager.activeTabId) editorPane?.flushPositionTo(tabManager.activeTabId);
+			return tabManager.serializeState();
+		},
 		shouldRestoreState: () => settings.restoreStateOnReopen,
 		isDisposed: () => isDisposed,
 		restoreState: (json) => tabManager.restoreState(json),
@@ -726,6 +734,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		transferPayload: (tabId) => {
 			const tab = tabManager.tabs.find((item) => item.id === tabId);
 			if (!tab) throw new Error('Tab disappeared before transfer');
+			// The snapshot carries the reading position and is taken here,
+			// synchronously, with the editor still mounted — so a tab being
+			// edited would travel with the position from its last teardown, and a
+			// tab opened straight into edit mode with 0. The preview writes its
+			// own fields on every scroll and needs nothing; this is edit mode's
+			// equivalent, and it is a no-op for any tab the editor is not on.
+			editorPane?.flushPositionTo(tabId);
 			return JSON.stringify(snapshotTab(tab));
 		},
 		onTransferClaimed: (tabId) => tabManager.closeTab(tabId),

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -36,9 +36,9 @@
 		asBufferLine,
 		editorTopLineForTabAnchor,
 		lineCoordinates,
-		tabAnchorForEditorTopLine,
 		type BufferLine,
 	} from '../utils/lineCoordinates.js';
+	import { editorReadingPosition } from '../utils/editorPosition.js';
 	import {
 		documentParentDir,
 		imageEmbed,
@@ -860,37 +860,39 @@
 			// reading mode and back.
 			removedKeybindings.dispose();
 
-			if (editor && currentTabId) {
-				const state = editor.saveViewState();
-				tabManager.updateTabEditorState(currentTabId, state);
-
-				const scrollHeight = editor.getScrollHeight();
-				const clientHeight = editor.getLayoutInfo().height;
-				if (scrollHeight > clientHeight) {
-					const percentage =
-						editor.getScrollTop() / (scrollHeight - clientHeight);
-					tabManager.updateTabScrollPercentage(currentTabId, percentage);
-				}
-
-				const ranges = editor.getVisibleRanges();
-				const model = editor.getModel();
-				if (ranges.length > 0 && model) {
-					// Monaco counts from the first line of the FILE and the tab's
-					// anchor counts from the first line of the body, so this is a
-					// crossing; `EDITOR_ANCHOR_LINE_OFFSET` is the old `+ 2`,
-					// which is a separate decision and is documented as one.
-					tabManager.updateTabAnchorLine(
-						currentTabId,
-						tabAnchorForEditorTopLine(
-							lineCoordinates(model.getValue()),
-							asBufferLine(ranges[0].startLineNumber),
-						),
-					);
-				}
-			}
+			if (editor && currentTabId) writeEditorPosition(currentTabId);
 
 			editor.dispose();
 		};
+	}
+
+	/**
+	 * Record on `tabId` where the editor is: the Monaco view state, and the two
+	 * position fields `editorReadingPosition` derives from one reading.
+	 *
+	 * Three layout reads (`getScrollHeight`, `getLayoutInfo`,
+	 * `getVisibleRanges`), so this belongs at moments and never on the hot path
+	 * — the teardown above is one such moment, `flushPositionTo` below is the
+	 * other, and there are no others.
+	 *
+	 * The caller has already established that `editor` is up and that `tabId` is
+	 * the tab it is holding.
+	 */
+	function writeEditorPosition(tabId: string) {
+		tabManager.updateTabEditorState(tabId, editor.saveViewState());
+
+		const ranges = editor.getVisibleRanges();
+		const model = editor.getModel();
+		const { scrollPercentage, anchorLine } = editorReadingPosition({
+			scrollTop: editor.getScrollTop(),
+			contentHeight: editor.getScrollHeight(),
+			viewportHeight: editor.getLayoutInfo().height,
+			topLine: ranges.length > 0 && model ? ranges[0].startLineNumber : null,
+			text: model?.getValue() ?? '',
+		});
+
+		if (scrollPercentage !== null) tabManager.updateTabScrollPercentage(tabId, scrollPercentage);
+		if (anchorLine !== null) tabManager.updateTabAnchorLine(tabId, anchorLine);
 	}
 
 	// Editing primitives used by the context-menu actions. They live at
@@ -2488,6 +2490,28 @@
 	export const setValue = (val: string) => editor?.setValue(val);
 	export const focus = () => editor?.focus();
 	export const restoreViewState = (state: any) => editor?.restoreViewState(state);
+
+	/**
+	 * Bring `tabId`'s recorded reading position up to date with what the editor
+	 * is showing right now.
+	 *
+	 * Reading mode never needs this: `handleScroll` in MarkdownViewer writes the
+	 * same fields through on every scroll event, so a tab in the preview is
+	 * always current. Edit mode writes them once, when the editor comes down —
+	 * which is cheap, and which leaves anything that reads a tab's position
+	 * while the editor is still up reading the position from the LAST teardown,
+	 * or 0 for a tab that was opened straight into edit mode and never left it.
+	 * Those callers ask here first.
+	 *
+	 * A no-op unless this editor is up AND holding `tabId`. There is one Editor
+	 * per window and it swaps models between tabs (`utils/tabModels.ts`), so an
+	 * unguarded flush would copy the ACTIVE tab's position onto whichever record
+	 * the caller named — a wrong position on two tabs instead of one.
+	 */
+	export function flushPositionTo(tabId: string) {
+		if (!editorReady || !editor || currentTabId !== tabId) return;
+		writeEditorPosition(tabId);
+	}
 </script>
 
 <div class="editor-outer">

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -12,6 +12,16 @@ export type LoadMarkdownOptions = {
 	navigate?: boolean;
 	skipTabManagement?: boolean;
 	preserveEditState?: boolean;
+	/**
+	 * Drop the receiving tab's in-page jump stacks (`Tab.scrollHistory`).
+	 *
+	 * Only the two reloads ask for it: the tab keeps the document it already
+	 * had, so nothing repoints it and `clearReadingPosition` never runs, but
+	 * the text underneath is about to be replaced by whatever is on disk now
+	 * and the recorded offsets describe the version being thrown away. A caller
+	 * that changes which document a tab holds does not belong here — that route
+	 * clears the stacks with the rest of the reading position.
+	 */
 	resetScrollHistory?: boolean;
 	/**
 	 * Read the file even though the tab that will receive it holds unsaved
@@ -411,6 +421,12 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		let existing = null;
 		let pendingNavigateTabId: string | null = null;
 		try {
+			// The second arm predates the stacks being per tab and is kept as it
+			// was: this runs before tab management, so the tab it reaches is the
+			// one being LEFT, and opening another file has always cleared the
+			// in-page stacks of whatever was on screen. Narrowing that to "only
+			// the tab whose text actually changes" is a behaviour change on its
+			// own terms, not part of making the stacks per tab.
 			if (loadOptions.resetScrollHistory || filePath !== options.currentFile()) {
 				options.resetScrollHistory();
 			}

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -557,7 +557,18 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 						return targetTab?.path === filePath && loadRevisionByTab.get(activeId) === fullLoadRevision && !targetTab.isDirty && targetTab.isEditing === initialIsEditing && targetTab.isSplit === initialIsSplit;
 					};
 					updateLoading(activeId, true);
-					options.measureInitialViewport();
+					// Everything above addresses the tab by id, so a switch during
+					// the two reads costs nothing. This one cannot: it measures the
+					// single article on screen and writes the single `isAtBottom`
+					// flag, which gates the "loading full document" chip for
+					// whichever tab is active. Taken while another tab is showing,
+					// it answers for that document — a short one sets the flag, and
+					// switching back raises the chip at the top of a slice the
+					// reader has not scrolled. Same test as the full-load
+					// completion below, for the same reason: a measurement of the
+					// view only speaks for this load while this load's tab is the
+					// view.
+					if (tabManager.activeTabId === activeId) options.measureInitialViewport();
 					(invoke('read_file_content_checked', { path: filePath }) as Promise<[string, boolean, string]>)
 						.then(([fullContent, fullLossy, fullEncoding]) => {
 							const applyFull = () => {

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -168,6 +168,37 @@ export interface Tab {
 	 */
 	scrollPercentage: number;
 	anchorLine: RendererLine;
+	/**
+	 * Where the reader was standing before each in-page jump, and where they
+	 * came back from — the two stacks the mouse's back and forward buttons
+	 * walk. Raw preview pixels, in the same space as `scrollTop`: pushed by
+	 * every anchor jump (a heading in the outline, a link into the same
+	 * document), popped by `popScrollHistoryBack` / `popScrollHistoryForward`.
+	 *
+	 * Nothing to do with `history` / `historyIndex` above, which are the FILE
+	 * this tab points at. These two never leave the current document.
+	 *
+	 * Per tab for the reason the position fields above are per tab: an offset
+	 * only means anything in the document it was measured in. One window-wide
+	 * pair meant a back click in a short document scrolled it to an offset
+	 * recorded in a long one, because a tab switch reloads nothing and so reset
+	 * nothing.
+	 *
+	 * Cleared with the rest of the reading position when the tab is repointed
+	 * at another file — see `clearReadingPosition`. A reload of the SAME
+	 * document in place is a separate trigger and clears them separately; see
+	 * `resetScrollHistory` in documentSession.
+	 *
+	 * Neither persisted nor carried between windows: pixels measured in one
+	 * container are wrong in a container of another height, which is already
+	 * why `scrollTop` is the last resort of the restore cascade. A stack of
+	 * them is not worth a schema entry. See `serializeState` and tabTransfer.ts.
+	 *
+	 * Required, like `foldOverrides`: every consumer pushes and pops, so a
+	 * construction site that forgot one would hand them `undefined`.
+	 */
+	scrollHistory: number[];
+	scrollFuture: number[];
 	isSplit: boolean;
 	splitRatio: number;
 	isScrollSynced: boolean;
@@ -288,6 +319,9 @@ export interface Tab {
 	pathKey?: string;
 }
 
+/** How many in-page jumps back a tab remembers. See `Tab.scrollHistory`. */
+const SCROLL_HISTORY_LIMIT = 50;
+
 class TabManager {
 	tabs = $state<Tab[]>([]);
 	activeTabId = $state<string | null>(null);
@@ -346,6 +380,12 @@ class TabManager {
 	 * that the user never folded in the text now on screen — the failure this
 	 * per-tab state exists to remove. Scroll degrades (you scroll); a fold
 	 * hides text.
+	 *
+	 * Nor are `scrollHistory`/`scrollFuture`. Those are pixels too, but unlike
+	 * `scrollTop` they are not a position to approximate — they are a record of
+	 * jumps the reader made in a session that has ended, in a window that may
+	 * come back a different size. Restoring them would arm the back button with
+	 * offsets nobody in this session created.
 	 */
 	serializeState(): string {
 		const stateData = {
@@ -423,6 +463,9 @@ class TabManager {
 					// exactly why the read side has to re-declare what came back.
 					// `serializeState` wrote a renderer line; this says so again.
 					anchorLine: asRendererLine(typeof saved.anchorLine === 'number' ? saved.anchorLine : 0),
+					// Not persisted — see serializeState.
+					scrollHistory: [],
+					scrollFuture: [],
 					isSplit: saved.isSplit === true,
 					splitRatio: typeof saved.splitRatio === 'number' ? saved.splitRatio : 0.5,
 					isScrollSynced: saved.isScrollSynced === true,
@@ -564,6 +607,8 @@ class TabManager {
 			editorViewState: null,
 			scrollPercentage: 0,
 			anchorLine: asRendererLine(0),
+			scrollHistory: [],
+			scrollFuture: [],
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
@@ -605,6 +650,8 @@ class TabManager {
 			editorViewState: null,
 			scrollPercentage: 0,
 			anchorLine: asRendererLine(0),
+			scrollHistory: [],
+			scrollFuture: [],
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
@@ -642,6 +689,8 @@ class TabManager {
 			editorViewState: null,
 			scrollPercentage: 0,
 			anchorLine: asRendererLine(0),
+			scrollHistory: [],
+			scrollFuture: [],
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
@@ -864,6 +913,64 @@ class TabManager {
 	}
 
 	/**
+	 * The in-page back/forward stacks — see `Tab.scrollHistory`. Three methods
+	 * rather than a field the viewer reaches into, because the tab they belong
+	 * to is the thing that used to be got wrong: the viewer holds the offsets
+	 * of the document ON SCREEN, and the only way to be sure of that is to name
+	 * the tab on every push and every pop.
+	 *
+	 * `from` is where the reader is standing right now, which the caller has
+	 * and this file does not. Popping records it on the opposite stack, so back
+	 * and forward walk the same path in both directions.
+	 */
+	pushScrollHistory(id: string, from: number) {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (!tab) return;
+		tab.scrollHistory.push(from);
+		tab.scrollFuture = [];
+		// A reader who has jumped fifty times is not going back to the first
+		// one, and the stack is per tab now — a window full of documents would
+		// otherwise keep every offset any of them ever had.
+		if (tab.scrollHistory.length > SCROLL_HISTORY_LIMIT) tab.scrollHistory.shift();
+	}
+
+	/**
+	 * Where to scroll back to, or null if this tab has no in-page jump to undo
+	 * — which is the caller's cue to fall through to the FILE history
+	 * (`goBack`), a different thing entirely.
+	 */
+	popScrollHistoryBack(id: string, from: number): number | null {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (!tab || tab.scrollHistory.length === 0) return null;
+		tab.scrollFuture.push(from);
+		return tab.scrollHistory.pop()!;
+	}
+
+	/** The mirror of `popScrollHistoryBack`; falls through to `goForward`. */
+	popScrollHistoryForward(id: string, from: number): number | null {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (!tab || tab.scrollFuture.length === 0) return null;
+		tab.scrollHistory.push(from);
+		return tab.scrollFuture.pop()!;
+	}
+
+	/**
+	 * This tab still holds the same document, but its text has been replaced
+	 * from disk — a reload, or the "Reload" answer to an external change. The
+	 * offsets describe a document that is gone, so they go with it.
+	 *
+	 * Separate from `clearReadingPosition`, which answers a different question
+	 * (the tab now holds a DIFFERENT document) and is reached from the three
+	 * navigation routes rather than from a load.
+	 */
+	clearScrollHistory(id: string) {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (!tab) return;
+		tab.scrollHistory = [];
+		tab.scrollFuture = [];
+	}
+
+	/**
 	 * Replace this tab's fold overrides. Callers build a NEW set rather
 	 * than mutating the old one — see `Tab.foldOverrides`.
 	 */
@@ -1062,6 +1169,13 @@ class TabManager {
 	 * source line, and the line the reader left in one file names an unrelated
 	 * block in the next one.
 	 *
+	 * `scrollHistory`/`scrollFuture` are here for the same reason one step
+	 * removed: they are not where the reader IS but where they were standing
+	 * before each jump, and an offset recorded in the document the tab has just
+	 * left is no more meaningful than the position it left. Left behind, the
+	 * next back click in the incoming document scrolls it somewhere the reader
+	 * has never been.
+	 *
 	 * Nothing here scrolls anything; a restore runs on tab activation and on
 	 * editor mount, which is why the symptom of getting this wrong shows up on
 	 * a later tab switch rather than at the moment of the navigation.
@@ -1074,6 +1188,8 @@ class TabManager {
 		tab.anchorLine = asRendererLine(0);
 		tab.scrollPercentage = 0;
 		tab.scrollTop = 0;
+		tab.scrollHistory = [];
+		tab.scrollFuture = [];
 	}
 
 	/**

--- a/src/lib/utils/editorPosition.ts
+++ b/src/lib/utils/editorPosition.ts
@@ -1,0 +1,75 @@
+/**
+ * Where the editor is, in the terms a tab records it in.
+ *
+ * `Tab.scrollPercentage` and `Tab.anchorLine` have two writers, one per pane.
+ * The preview's is `handleScroll` in MarkdownViewer, which measures the DOM and
+ * writes straight through on every scroll event. The editor's is here, and it
+ * is asked rather than volunteered: the numbers below are Monaco LAYOUT reads,
+ * too expensive to take on every keystroke and every scroll, so `Editor.svelte`
+ * takes them at the moments a stale record would be seen — its own teardown,
+ * and the flush a caller asks for before reading a tab's position while the
+ * editor is still mounted.
+ *
+ * The whole derivation lives in this one function so those moments cannot
+ * disagree. The disagreement worth naming is the numbering: Monaco counts from
+ * the first line of the FILE and a tab's anchor counts from the first line of
+ * the BODY, so a second site deriving its own anchor is a second chance to make
+ * that crossing differently. There is one crossing, it is
+ * `tabAnchorForEditorTopLine`, and this is the only caller in the editor.
+ */
+
+import {
+	asBufferLine,
+	lineCoordinates,
+	tabAnchorForEditorTopLine,
+	type RendererLine,
+} from './lineCoordinates.js';
+
+/**
+ * One reading of the editor. Every field is a layout read; the caller pays for
+ * them once.
+ *
+ * The two heights are Monaco's `getScrollHeight()` and `getLayoutInfo().height`,
+ * named after what they mean rather than after the DOM properties that answer
+ * the same questions about an element. Nothing here touches an element, and
+ * borrowing the DOM's spelling in this directory trips the guardrail that keeps
+ * fold heights off the scrollable extent (singleImplementationConvention).
+ */
+export interface EditorViewport {
+	scrollTop: number;
+	/** The full scrollable extent of the document. */
+	contentHeight: number;
+	/** What fits on screen. */
+	viewportHeight: number;
+	/**
+	 * Monaco's first visible line, a BUFFER line — `null` when the editor has
+	 * no model or nothing laid out yet, which is not the same as line 1.
+	 */
+	topLine: number | null;
+	/** The buffer's text, and only for the front-matter shift the crossing applies. */
+	text: string;
+}
+
+/**
+ * `null` on either field means this reading says nothing about it, so whatever
+ * the tab already records stands: a document shorter than the viewport has no
+ * meaningful percentage, and an editor with no visible range has no top line.
+ * Writing 0 in either case would move the reader to the top of the document.
+ */
+export interface EditorReadingPosition {
+	scrollPercentage: number | null;
+	anchorLine: RendererLine | null;
+}
+
+export function editorReadingPosition(view: EditorViewport): EditorReadingPosition {
+	return {
+		scrollPercentage:
+			view.contentHeight > view.viewportHeight
+				? view.scrollTop / (view.contentHeight - view.viewportHeight)
+				: null,
+		anchorLine:
+			view.topLine === null
+				? null
+				: tabAnchorForEditorTopLine(lineCoordinates(view.text), asBufferLine(view.topLine)),
+	};
+}

--- a/src/lib/utils/previewAnchor.ts
+++ b/src/lib/utils/previewAnchor.ts
@@ -538,6 +538,90 @@ export function getAnchorScrollTop(
 	return Math.max(0, elementTop + elementHeight * ratio - offset);
 }
 
+/**
+ * The preview's scroll container: the element the restore writes to, and the
+ * root the anchor is resolved under.
+ *
+ * Nothing about its geometry is read off it. The layout arrives as `measure`
+ * and the scroll range as `scrollMax`, as everywhere else in this file — neither
+ * the DOM shim nor jsdom has a layout, so a test supplies its own, and
+ * `scrollHeight` is not a measurement `src/lib/utils` is allowed to take (see
+ * the fold-height rule in singleImplementationConvention.test.ts).
+ */
+export type PreviewScrollContainer = AnchorNode & {
+	scrollTop: number;
+};
+
+/**
+ * The three ways a tab records where its reader was — see `Tab` in
+ * `stores/tabs.svelte.ts` for why there are three.
+ */
+export type ReadingPosition = {
+	readonly anchorLine: number;
+	readonly scrollPercentage: number;
+	readonly scrollTop: number;
+};
+
+/**
+ * Put `container` back where the reader of this tab was, and return which entry
+ * of the cascade answered.
+ *
+ * One function rather than one per caller, because the cascade is an ORDER and
+ * a second copy that consulted the same three fields in a different one would
+ * be a different answer for the same tab. It stops at the first entry that
+ * resolves:
+ *
+ *   - `anchorLine`, an interpolated restore: find the rendered element that owns
+ *     the saved source line and put that line back under the anchor offset. This
+ *     descends, because `processMarkdownHtml` re-parents every block after a
+ *     heading into a `.foldable-content-wrapper` with no `data-sourcepos`, so a
+ *     scan of the container's children only ever matched an anchor sitting
+ *     exactly on a top-level heading line (see previewAnchorRestore.test.ts).
+ *     Measured through `measure` — `measureAnchorBox` in the app — and not raw
+ *     `offsetTop`: an anchor inside a table or a code block sits in that
+ *     table's or that shell's space, and restoring to it would open the tab at
+ *     the top instead.
+ *   - `scrollPercentage`, when there is anything to scroll;
+ *   - `scrollTop`, the raw pixel offset, which is also what puts a tab that has
+ *     never been scrolled at the top.
+ *
+ * `'nothing'` means the container held no document to anchor to and could not
+ * scroll — every caller that renders a tab's document AFTER activating it gets
+ * this on the activation and has to ask again once the document is in.
+ */
+export function restorePreviewReadingPosition(
+	container: PreviewScrollContainer,
+	position: ReadingPosition,
+	scrollMax: number,
+	measure: MeasureAnchorBox,
+): 'anchor' | 'percentage' | 'pixels' | 'nothing' {
+	if (position.anchorLine > 0) {
+		const match = findAnchorElement(container, position.anchorLine);
+		if (match) {
+			const box = measure(match.element);
+			container.scrollTop = getAnchorScrollTop(
+				box.top,
+				box.height,
+				match,
+				position.anchorLine,
+				PREVIEW_ANCHOR_OFFSET,
+			);
+			return 'anchor';
+		}
+	}
+
+	if (scrollMax > 0 && position.scrollPercentage > 0) {
+		container.scrollTop = position.scrollPercentage * scrollMax;
+		return 'percentage';
+	}
+
+	container.scrollTop = position.scrollTop;
+	// A container with nothing to scroll cannot hold a position: the assignment
+	// above clamps to 0, so a reader who was part-way down was not restored —
+	// the caller was asked too early and has to ask again with the document in.
+	return scrollMax > 0 || position.scrollTop === 0 ? 'pixels' : 'nothing';
+}
+
 /* ------------------------------------------------------------------ */
 /* the sample table                                                    */
 /* ------------------------------------------------------------------ */

--- a/src/lib/utils/tabTransfer.ts
+++ b/src/lib/utils/tabTransfer.ts
@@ -22,6 +22,13 @@ import { nextUntitledTitle } from './untitledTitle.js';
  *   open is the honest version of "this was rendered fresh here". Carrying it
  *   would mean a new required entry in the strict validator below, which is a
  *   change to make on its own terms.
+ * - `scrollHistory`/`scrollFuture`: raw preview pixels, and the destination
+ *   window is a different container of a different height — `scrollTop` only
+ *   travels because it is the LAST resort of a cascade that starts with
+ *   `anchorLine`, and a back stack has no such cascade to be wrong under.
+ *   Arriving empty means the back button walks the file history until the
+ *   reader jumps in the new window, which is what a freshly opened document
+ *   does anyway.
  */
 export interface TransferableTab {
 	path: string;
@@ -216,6 +223,9 @@ export function buildTransferredTab(
 		editorViewState: null,
 		scrollPercentage: snap.scrollPercentage,
 		anchorLine: snap.anchorLine,
+		// Not carried — see the header.
+		scrollHistory: [],
+		scrollFuture: [],
 		isSplit: snap.isSplit,
 		splitRatio: snap.splitRatio,
 		isScrollSynced: snap.isScrollSynced,


### PR DESCRIPTION
Administrative, not new work. These are #732, #733, #734 and #735 — all four
reviewed and merged already, but into `fix/tab-switch-keeps-its-dom` rather than
into `master`, because that branch was their base while #730 was open. #730 was
squash-merged to `master`, which closed the branch's own PR and left these four
sitting on a branch nothing points at. Cherry-picked onto `master` unchanged; the
four commits below are the same four, in the order they were merged.

No code was rewritten. Every cherry-pick applied cleanly, which is the expected
result: `master` already carries #730's content, byte for byte, under a different
SHA.

## What is in here

- **#732** — the first read of a large file measures its own tab. `loadMarkdown`
  addresses every write by tab id, but `measureInitialViewport()` reads the one
  article on screen and writes the one `isAtBottom` flag, so a switch during the
  read answered for the wrong document and raised the "loading full document"
  chip on a slice nobody had scrolled.
- **#733** — the preview's in-page back/forward stacks belong to the tab. They
  were two module-level arrays of raw pixel offsets, one pair per window, and
  nothing emptied them on a switch, so mouse-back in one document scrolled to an
  offset measured in another. Now on `Tab`, cleared with the rest of the reading
  position when a tab is repointed.
- **#734** — a tab dragged into another window opens where its reader left it.
  `insertTransferredTab` activates the tab while its content is still empty, the
  restore effect fires against an empty host, and nothing re-triggered it when the
  document landed. The cascade moved into `restorePreviewReadingPosition` so the
  arrival runs the same order rather than a second copy of it.
- **#735** — a tab dragged out of an editor arrives where the reader left it. The
  other half: `Editor.svelte` wrote `scrollPercentage` and `anchorLine` only from
  its teardown, and the transfer payload is snapshotted with the editor still
  mounted. One flush seam, called before the payload and before the window-state
  snapshot.

## Scope

Two findings named in #735's Scope are still open and not addressed here: a
background tab last read in edit mode keeps a stale coarse position until the
editor comes down (a fix is in progress), and rich-content libraries resolving
after a restore can drift the anchor on every path.

## Verification

Re-run after the cherry-picks, on this branch:

```
npm audit            0 vulnerabilities
npm run check        826 files, 0 errors, 0 warnings
npm test             1009 pass, 0 fail
npm run test:vitest  429 pass, 0 fail
cargo test           164 pass, 0 fail
```

Each PR's own verification and revert-the-fix results stand as written in #732,
#733, #734 and #735; nothing was re-tested by hand here beyond the suites above.
