### PR TITLE
A background tab in edit mode reopens where the reader left it

### DIFF
--- a/scripts/backgroundEditorPosition.test.ts
+++ b/scripts/backgroundEditorPosition.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { outgoingTabAnchorLine, type StoredTabPosition } from '../src/lib/utils/editorPosition.js';
+import { asRendererLine, EDITOR_ANCHOR_LINE_OFFSET } from '../src/lib/utils/lineCoordinates.js';
+import { readSource, offsetOf, sliceFrom } from './sourceTree.js';
+
+// A tab left in EDIT-ONLY mode in the background is the one population neither
+// writer of `Tab.anchorLine` covers: the preview writes only the active tab and
+// is not on screen for this one, and the single editor has moved on to another
+// model. What covers it in memory is `editorViewState`, which survives neither
+// the window-state snapshot nor the cross-window payload -- so the anchor is
+// recovered from it at those two gates. Everything below is about which tabs
+// that applies to, because the tabs it must NOT apply to already have a better
+// record than the view state.
+
+/** A view state as Monaco writes one, cut down to the field the derivation reads. */
+function viewStateAtLine(lineNumber: number) {
+	return { viewState: { firstPosition: { lineNumber, column: 1 }, firstPositionDeltaTop: 0 } };
+}
+
+function tab(over: Partial<StoredTabPosition> = {}): StoredTabPosition {
+	return {
+		id: 'background',
+		isEditing: true,
+		isSplit: false,
+		editorViewState: viewStateAtLine(40),
+		rawContent: 'body\n'.repeat(200),
+		anchorLine: asRendererLine(0),
+		...over,
+	};
+}
+
+test('a background edit-only tab is recorded where its view state says it was', () => {
+	// This is the defect: nothing wrote `anchorLine` for this tab, so `0` is
+	// what would be persisted -- the top of the document.
+	assert.equal(
+		outgoingTabAnchorLine(tab(), 'some-other-tab'),
+		40 + EDITOR_ANCHOR_LINE_OFFSET,
+	);
+});
+
+test('the recovered anchor crosses out of the editor numbering, front matter and all', () => {
+	// `firstPosition.lineNumber` is a BUFFER line and the tab's anchor is a
+	// RENDERER line. The crossing has one home and this reuses it rather than
+	// making its own -- the defect shape `lineCoordinates.ts` exists to prevent.
+	const rawContent = '---\ntitle: t\n---\n\n' + 'body\n'.repeat(200);
+	assert.equal(
+		outgoingTabAnchorLine(tab({ rawContent, editorViewState: viewStateAtLine(40) }), null),
+		40 + EDITOR_ANCHOR_LINE_OFFSET - 4,
+	);
+});
+
+test('a tab that left edit mode keeps the position its preview wrote', () => {
+	// THE regression this change could introduce. Nothing clears
+	// `editorViewState` when a tab leaves edit mode, so a tab the reader edited,
+	// switched to reading mode and then scrolled carries a stale view state
+	// under a fresh `anchorLine`. Deriving there would replace a correct record
+	// with an older one, on the commoner path.
+	const stale = tab({ isEditing: false, anchorLine: asRendererLine(120) });
+	assert.equal(outgoingTabAnchorLine(stale, 'some-other-tab'), 120);
+});
+
+test('a split tab keeps the position its preview wrote', () => {
+	// A split tab has its preview on screen writing `anchorLine` on every scroll
+	// event, and the editor beside it is scrolled independently unless
+	// `isScrollSynced`. Its record is a real reading position; the view state is
+	// a second opinion about a different pane.
+	const split = tab({ isSplit: true, anchorLine: asRendererLine(120) });
+	assert.equal(outgoingTabAnchorLine(split, 'some-other-tab'), 120);
+});
+
+test('the active tab keeps what the live editor just flushed onto it', () => {
+	// #735 flushes the active tab from the live editor immediately before both
+	// gates, and that reading is the better one AND a different one: Monaco's
+	// `saveViewState` records the first PARTIALLY visible line, while
+	// `getVisibleRanges()` -- what the flush reads -- starts at the first
+	// completely visible one. Deriving over the flush would move the active tab
+	// by a line at most scroll positions.
+	const active = tab({ id: 'live', anchorLine: asRendererLine(120) });
+	assert.equal(outgoingTabAnchorLine(active, 'live'), 120);
+});
+
+test('a tab with no saved view state is left exactly as it is', () => {
+	// Restored from disk, or transferred in: `editorViewState` starts null on
+	// both routes and there is nothing to recover from.
+	const fresh = tab({ editorViewState: null, anchorLine: asRendererLine(7) });
+	assert.equal(outgoingTabAnchorLine(fresh, null), 7);
+});
+
+test('a view state written by an older Monaco is left exactly as it is', () => {
+	// `firstPosition` is what `reduceRestoreState` falls back from when it is
+	// missing, so the shape is real and reachable rather than defensive.
+	const legacy = tab({ editorViewState: { scrollTop: 900 }, anchorLine: asRendererLine(7) });
+	assert.equal(outgoingTabAnchorLine(legacy, null), 7);
+});
+
+test('a percentage is not invented to go with the anchor', () => {
+	// The view state carries `scrollTop` but neither height, so no fraction of
+	// the scrollable range can be computed from it. `anchorLine` is the first
+	// entry of both restore cascades, so recovering it is what decides where the
+	// tab opens; writing a percentage nobody can justify is not.
+	const source = readSource('src/lib/utils/editorPosition.ts');
+	const derivation = sliceFrom(source, 'export function outgoingTabAnchorLine');
+	assert.doesNotMatch(derivation, /scrollPercentage/);
+});
+
+test('both gates that drop the view state ask for the anchor first', () => {
+	// The two moments a tab's position leaves memory. Neither carries
+	// `editorViewState`: `serializeState` omits it and `restoreState` seeds
+	// null, and `tabTransfer.ts` excludes it as a live Monaco object.
+	const store = readSource('src/lib/stores/tabs.svelte.ts');
+	const serialize = sliceFrom(store, 'serializeState(): string {');
+	assert.match(serialize, /anchorLine: outgoingTabAnchorLine\(t, this\.activeTabId\)/);
+
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
+	const payload = sliceFrom(viewer, 'transferPayload: (tabId) => {');
+	assert.match(payload, /anchorLine: outgoingTabAnchorLine\(tab, tabManager\.activeTabId\)/);
+	// After the spread, or the snapshot's own field would win.
+	assert.ok(offsetOf(payload, '...snapshotTab(tab)') < offsetOf(payload, 'outgoingTabAnchorLine'));
+});

--- a/scripts/editorPositionFlush.test.ts
+++ b/scripts/editorPositionFlush.test.ts
@@ -83,7 +83,7 @@ test('the transfer payload flushes before it snapshots the tab', () => {
 	// `snapshotTab` is synchronous and runs with the editor still mounted, so
 	// without this the tab travels at the position of the last teardown.
 	const flushAt = offsetOf(viewer, 'editorPane?.flushPositionTo(tabId);');
-	const snapshotAt = offsetOf(viewer, 'JSON.stringify(snapshotTab(tab))');
+	const snapshotAt = offsetOf(viewer, 'snapshotTab(tab)');
 	assert.ok(flushAt < snapshotAt);
 });
 

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -105,6 +105,7 @@ import {
 	import HomePage from './components/HomePage.svelte';
 import { tabManager, type Tab } from './stores/tabs.svelte.js';
 import { snapshotTab } from './utils/tabTransfer.js';
+import { outgoingTabAnchorLine } from './utils/editorPosition.js';
 import { adjustPreviewMaxWidth, getPreviewContentWidth } from './utils/previewWidth.js';
 import { isTocOverhanging } from './utils/tocOverlay.js';
 import { splitRatioAfterMove } from './utils/splitPanes.js';
@@ -745,7 +746,16 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			// own fields on every scroll and needs nothing; this is edit mode's
 			// equivalent, and it is a no-op for any tab the editor is not on.
 			editorPane?.flushPositionTo(tabId);
-			return JSON.stringify(snapshotTab(tab));
+			// The other half of the same problem: the flush can only speak for
+			// the tab the editor is holding, and any other tab can be sent from
+			// here too — the tab context menu names one, and `mergeSelfInto`
+			// walks all of them. `editorViewState` is what covers a background
+			// edit-mode tab in memory and it is excluded from the payload, so
+			// the anchor is recovered from it before it is dropped.
+			return JSON.stringify({
+				...snapshotTab(tab),
+				anchorLine: outgoingTabAnchorLine(tab, tabManager.activeTabId),
+			});
 		},
 		onTransferClaimed: (tabId) => tabManager.closeTab(tabId),
 		acceptTransferredTab: async (snapshot) => {

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -6,6 +6,7 @@ import { HOME_TAB_PATH, isHomePath } from '../utils/homeTab.js';
 import { buildTransferredTab, type TransferableTab } from '../utils/tabTransfer.js';
 import { canonicalizePath, isSameFilePath } from '../utils/pathIdentity.js';
 import { asRendererLine, type RendererLine } from '../utils/lineCoordinates.js';
+import { outgoingTabAnchorLine } from '../utils/editorPosition.js';
 import { retainTabModels } from '../utils/tabModels.js';
 import {
 	canGoBackInHistory,
@@ -364,7 +365,13 @@ class TabManager {
 					isScrollSynced: t.isScrollSynced,
 					scrollTop: t.scrollTop,
 					scrollPercentage: t.scrollPercentage,
-					anchorLine: t.anchorLine
+					// Not `t.anchorLine`: a tab left in edit-only mode in the
+					// background has had no writer since it stopped being active,
+					// and its Monaco view state — which knows where it was, and
+					// which is not in the object above — is about to be dropped.
+					// `outgoingTabAnchorLine` recovers the line from it for that
+					// population and hands back `t.anchorLine` for every other.
+					anchorLine: outgoingTabAnchorLine(t, this.activeTabId)
 				}))
 		};
 		return JSON.stringify(stateData);

--- a/src/lib/utils/editorPosition.ts
+++ b/src/lib/utils/editorPosition.ts
@@ -73,3 +73,95 @@ export function editorReadingPosition(view: EditorViewport): EditorReadingPositi
 				: tabAnchorForEditorTopLine(lineCoordinates(view.text), asBufferLine(view.topLine)),
 	};
 }
+
+/**
+ * The fields of a tab the derivation below reads. Structural rather than
+ * `Tab`, because the store imports this module and not the other way round —
+ * and because a plain object is what the tests can hand it.
+ */
+export interface StoredTabPosition {
+	id: string;
+	isEditing: boolean;
+	isSplit: boolean;
+	/** `monaco.editor.ICodeEditorViewState | null` — see `Tab.editorViewState`. */
+	editorViewState: any;
+	/** The buffer, for the front-matter shift the crossing applies. */
+	rawContent: string;
+	/** What the tab records today, and what is returned unless the rule applies. */
+	anchorLine: RendererLine;
+}
+
+/**
+ * The anchor line to write down for `tab` at the two moments its position
+ * leaves memory: `TabManager.serializeState` and the cross-window snapshot.
+ *
+ * For almost every tab the answer is the one already on the tab. The exception
+ * is a tab left in EDIT-ONLY mode in the background, which is the one
+ * population no writer of `Tab.anchorLine` covers. Both writers only ever
+ * touch the ACTIVE tab: `handleScroll` in MarkdownViewer writes
+ * `tabManager.activeTabId`, and `writeEditorPosition` in Editor writes the tab
+ * the single editor is holding, which is the active one. So a tab sitting in
+ * the background in edit-only mode has had neither pane speak for it since it
+ * stopped being active — its preview is not on screen (the viewer pane gets
+ * `flex: 0`, so it never scrolls), and the editor moved on to another model.
+ * `editorViewState` is what covers that gap in memory, because the
+ * tab-activation effect saves it on the way out of every switch; it is also
+ * the one field that survives neither gate — `serializeState` does not write
+ * it and `restoreState` seeds `null`, and `tabTransfer.ts` excludes it. Past
+ * either gate the tab is left with an `anchorLine` from the last time it was
+ * active in some other mode, or `0` for one opened straight into edit mode.
+ *
+ * So the top line is recovered from the view state instead, which needs no
+ * live editor and no layout read: `viewState.firstPosition` is Monaco's own
+ * record of the line at the top of the viewport. It is a BUFFER line, and the
+ * crossing into the tab's renderer numbering is `tabAnchorForEditorTopLine`,
+ * the same one and only one `editorReadingPosition` above uses.
+ *
+ * The rule is a population, and the two tabs it excludes are the ones that
+ * would be made WORSE by including them:
+ *
+ * - `!isEditing`, i.e. a tab that has left edit mode. Nothing clears
+ *   `editorViewState` when it does (only `clearReadingPosition`, on pointing
+ *   the tab at another document, ever does), so a tab the reader edited,
+ *   switched to reading mode and then scrolled carries a stale view state
+ *   under a FRESH `anchorLine` that the preview wrote. Deriving there replaces
+ *   a correct record with an older one.
+ * - `isSplit`, because a split tab has its preview on screen writing
+ *   `anchorLine` on every scroll event. Its record is a real reading position
+ *   from a pane the reader was using, and the editor is scrolled independently
+ *   of it unless `isScrollSynced`.
+ *
+ * The active tab is excluded for a different reason: it is the one tab a live
+ * editor can be asked about, and #735 already asks — `flushPositionTo` runs
+ * immediately before both gates. That reading is the better one, and it is
+ * not the same one. Monaco's `saveViewState` records
+ * `getLineNumberAtVerticalOffset(scrollTop)`, the first PARTIALLY visible
+ * line, while `getVisibleRanges()` — what the flush reads — starts at
+ * `completelyVisibleStartLineNumber`. The two differ by one whenever the top
+ * line is cut in half by the viewport, which is most scroll positions, so
+ * deriving over the flush would move the active tab by a line for no reason.
+ * A tab in this population is always the active one or not; the editor holds
+ * the active tab whenever that tab is `isEditing || isSplit`, which every tab
+ * here is.
+ *
+ * Only `anchorLine` is recoverable. `scrollPercentage` is a fraction of the
+ * scrollable range and the view state carries neither height, so there is no
+ * honest number to write and this leaves that field alone. It costs nothing:
+ * `anchorLine` is the first entry of both restore cascades (see
+ * `Tab.scrollPercentage`), so it is the field that decides where the tab
+ * opens.
+ */
+export function outgoingTabAnchorLine(
+	tab: StoredTabPosition,
+	activeTabId: string | null,
+): RendererLine {
+	if (!tab.isEditing || tab.isSplit || tab.id === activeTabId) return tab.anchorLine;
+
+	// `editorViewState` is `any` and can be a view state written by an older
+	// Monaco, which had no `firstPosition` — `reduceRestoreState` still carries
+	// a path for those, so this is not hypothetical.
+	const topLine = tab.editorViewState?.viewState?.firstPosition?.lineNumber;
+	if (typeof topLine !== 'number') return tab.anchorLine;
+
+	return tabAnchorForEditorTopLine(lineCoordinates(tab.rawContent), asBufferLine(topLine));
+}


### PR DESCRIPTION
## What this is

Quit and reopen a window with several tabs in edit mode, and the ones that were
not active at quit time come back at an old position — the top of the document
in the common case. Same for a background edit-mode tab dragged into another
window.

#735 fixed the ACTIVE tab at both of those gates by flushing the live editor.
This is about the others, which no live editor can be asked about.

Based on `fix/editor-position-before-transfer` (#735), which is based on
`fix/tab-switch-keeps-its-dom` (#730). Neither is merged; the order is #730,
then #735, then this.

## Mechanism

`Tab.anchorLine` has two writers and both of them only ever touch the ACTIVE
tab. `handleScroll` in MarkdownViewer writes `tabManager.activeTabId`, and
`writeEditorPosition` in Editor writes the tab the single editor is holding,
which is the active one. So a tab sitting in the background in edit-only mode
has had neither pane speak for it since it stopped being active: its preview is
not on screen (the viewer pane gets `flex: 0`, so it never scrolls), and the
editor swapped to another model.

That is normally invisible, because the editor also stores `editorViewState` —
Monaco's own, precise — and the tab-activation effect saves it on every switch.
The restore cascade consults it first, so coming back to the tab in the same
window lands exactly right.

`editorViewState` does not survive either gate. `serializeState` omits it and
`restoreState` seeds `null`; `tabTransfer.ts` excludes it as a live Monaco
object. Past either one the tab is left with the coarse pair, and for this
population that pair is stale, or zero for a tab opened straight into edit mode
and never taken out of it.

So the anchor is derived from the view state that is already being saved.
`ICodeEditorViewState.viewState.firstPosition` is a documented public field
carrying the editor's first visible line, which means the top line can be
recovered with no live editor, no layout read, and nothing private written to
disk. It is a BUFFER line and `Tab.anchorLine` is a renderer line, so the
crossing is `tabAnchorForEditorTopLine` — the one that already exists, reused
rather than re-derived.

## Scope

**Only `anchorLine`.** The view state carries `scrollTop` but neither the
content nor the viewport height, so no percentage can be computed from it and
`scrollPercentage` is left alone rather than filled with a number nobody can
justify. It costs little: `anchorLine` is the FIRST entry of both restore
cascades, so it is the field that decides where the tab opens.

**Which tabs.** `outgoingTabAnchorLine` returns the tab's existing
`anchorLine` unless the tab is `isEditing && !isSplit` and is not the active
tab. The three exclusions are the point of the change, because including any of
them would replace a correct record with an older one:

- **A tab that has left edit mode.** Nothing clears `editorViewState` when it
  does — only `clearReadingPosition`, on pointing the tab at another document,
  ever does. A tab the reader edited, switched to reading mode and then
  scrolled therefore carries a stale view state under a FRESH `anchorLine` the
  preview wrote. This is the commoner path and the regression this change could
  have introduced.
- **A split tab**, which has its preview on screen writing `anchorLine` on
  every scroll event. Its record is a real reading position from a pane the
  reader was using, and the editor beside it is scrolled independently unless
  `isScrollSynced`.
- **The active tab.** #735 flushes it from the live editor immediately before
  both gates, and that reading is both better and *different*: Monaco's
  `saveViewState` records `getLineNumberAtVerticalOffset(scrollTop)`, the first
  PARTIALLY visible line, while `getVisibleRanges()` — what the flush reads —
  starts at `completelyVisibleStartLineNumber`. Those differ by one whenever the
  viewport cuts the top line in half, which is most scroll positions. So this is
  harmless for the active tab by exclusion, not by agreement; deriving over the
  flush would have moved it a line for no reason. Worth stating because the
  obvious reading is that the two agree, and in `viewModelImpl.js` they do not.

**Both gates.** `TabManager.serializeState` for quit-and-reopen, and the
cross-window payload in `transferPayload`. The second one needed checking,
because `TabList.svelte`'s own drag only reorders within the window — but a
background tab does reach the payload two other ways: the tab context menu
sends `menu-tab-detach` / `menu-tab-move` naming any tab, and `mergeSelfInto`
walks every tab in the window.

**Not touched.** No flush on tab switch: that would be three Monaco layout
reads on a gesture #730 had just optimised for latency, and a third writer of
the same two fields. Nothing writes back onto the `Tab`; the derivation applies
to the outgoing payload only, so `Tab.anchorLine` still has exactly its two
writers.

`editorPositionFlush.test.ts` has one anchor respelled (`snapshotTab(tab)`
rather than `JSON.stringify(snapshotTab(tab))`) because the payload is now built
from a spread. The claim it makes — the flush runs before the snapshot — is
unchanged.

## Tests

`scripts/backgroundEditorPosition.test.ts`, 9 tests. The derivation is a pure
function over a plain object and the buffer text, so it needs no Monaco and no
jsdom and sits beside `editorPositionFlush.test.ts` under `node --test`.

Reverted the fix, kept the tests: **3 of the 9 go red**, and I would rather say
which than imply the file covers the change end to end.

Red on revert:

- a background edit-only tab is recorded where its view state says it was
- the recovered anchor crosses out of the editor numbering, front matter and all
- both gates that drop the view state ask for the anchor first

Green either way, and deliberately so — these are the population rule, and a
revert satisfies them by doing nothing at all:

- a tab that left edit mode keeps the position its preview wrote
- a split tab keeps the position its preview wrote
- the active tab keeps what the live editor just flushed onto it
- a tab with no saved view state is left exactly as it is
- a view state written by an older Monaco is left exactly as it is
- a percentage is not invented to go with the anchor

They are the assertions that fail if a later change widens the population, which
is the regression a reviewer should be looking for here. They cannot go red on
a revert, because "leave the tab alone" is exactly what a revert does.

Two of the nine match source text rather than running the code. "both gates ask
for the anchor first" pins the two call sites, which is a cross-file wiring
claim the compiler cannot make — a derivation with no caller compiles and the
defect comes straight back. "a percentage is not invented" pins the absence of a
second field being written, which running the function cannot observe.

## Verification

```
npm audit                 0 vulnerabilities
npm run check             824 files, 0 errors, 0 warnings
npm test                  1015 pass, 0 fail   (1006 before)
npm run test:vitest       406 pass, 0 fail    (unchanged)
cargo test                164 pass, 0 fail    (unchanged)
```

Run under real Node v24, from the worktree root. Baseline on the branch before
the change was reproduced first: 0 / 823 / 1006 / 406 / 164.

**Not verified.** There is no way to run the app here, so neither symptom was
observed and neither fix was watched: quit-and-reopen with several edit-mode
tabs, and dragging a background edit-mode tab into another window. What is
checked by running code is the derivation and the population rule; the two call
sites are checked by reading the source; and the claim that
`firstPosition.lineNumber` is the editor's top buffer line is read off
`editor.api.d.ts` and `viewModelImpl.js` in the pinned `monaco-editor`, not
observed on screen. The off-by-one against `getVisibleRanges()` is likewise read
out of `viewModelImpl.js` rather than measured — it is the reason the active tab
is excluded, so if it is wrong the exclusion is merely unnecessary, not harmful.
