### PR TITLE
fix(preview): a cold start restores the reading position against the layout it ends up with

### DIFF
--- a/scripts/previewAnchorRestore.test.ts
+++ b/scripts/previewAnchorRestore.test.ts
@@ -465,3 +465,58 @@ test('the viewer restores through the measured resolver', async () => {
 	assert.doesNotMatch(viewer, /tab\.scrollPercentage/);
 	assert.doesNotMatch(viewer, /Array\.from\(body\.children\)/);
 });
+
+/**
+ * The cold start: the rich-content libraries arrive after the document is
+ * already in the preview and after the position has been restored against it.
+ *
+ * Measured in Chromium — the numbers and the method are in the patch effect's
+ * comment in `MarkdownViewer.svelte` — the anchored text moves down by up to
+ * 812px when the enrichment lands, and re-running this cascade afterwards
+ * brings it back to within 0.8px. jsdom has no layout, so that magnitude cannot
+ * be asserted here and this is a source assertion like the one above: what it
+ * pins is that the second restore is wired up at all, and that nothing has
+ * quietly gone back to the arrangement that had no owner for this case.
+ */
+test('a cold start restores again once its enrichment has landed', async () => {
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
+
+	// The patch effect is the owner: when the libraries land, the diff finds
+	// nothing to do, so the roots are the host and the restore follows it.
+	assert.match(
+		viewer,
+		/const cold = patch\.inserted\.length === 0 && !enrichedHosts\.has\(host\)/,
+		'the patch effect must recognise a document that was patched in without the libraries',
+	);
+	assert.match(
+		viewer,
+		/renderRichContent\(cold \? \[host\] : patch\.inserted\)/,
+		'the cold pass must enrich the whole host — `patch.inserted` is empty on that run',
+	);
+	assert.match(
+		viewer,
+		/if \(cold\) restoreAfterColdEnrichment\(/,
+		'and only that run may re-restore, or every no-op patch would move the reader',
+	);
+
+	// The restore itself goes through the shared cascade, waits for the
+	// enrichment, and speaks only for the tab still on screen.
+	const helper = viewer.match(
+		/async function restoreAfterColdEnrichment\([\s\S]*?\n\t\}/,
+	)?.[0];
+	assert.ok(helper, 'restoreAfterColdEnrichment must exist');
+	assert.match(helper, /await enrichment;/);
+	assert.match(helper, /tabManager\.activeTabId !== tabId/);
+	assert.match(helper, /restorePreviewReadingPosition\(body, tab,/);
+
+	// And the accident that used to stand in for it must not come back. The
+	// theme effect's `renderRichContent()` reads `richLibraries` before its
+	// first await, so without `untrack` that effect re-runs when the libraries
+	// land — re-enriching every open tab's host, never firing in split view,
+	// and leaving the reading position where the old layout put it.
+	assert.match(
+		viewer,
+		/if \(markdownBody && !isEditing\) untrack\(\(\) => renderRichContent\(\)\);/,
+		'the theme effect must depend on the theme, not on the libraries arriving',
+	);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -538,10 +538,18 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// and that accident, not anything here, was what enriched a document
 		// patched in during a cold start. It was the wrong owner three ways over:
 		// it re-enriched every open tab's host rather than the one that needed it,
-		// it never fired in split view (the guard is `!isEditing`, so a restored
-		// split session showed raw LaTeX and `<pre>` diagram source), and it left
-		// the reading position restored against the layout the enrichment then
-		// changed. The patch effect owns that case now.
+		// it did not fire at all for a tab in edit mode (the guard is
+		// `!isEditing`), and it left the reading position restored against the
+		// layout the enrichment then changed. The patch effect owns that case now.
+		//
+		// The edit-mode gap is not only about a hidden preview. `isSplit` is
+		// independent of `isEditing` — `setSplitEnabled` never touches it — so a
+		// tab split from EDIT mode has both flags set, and its preview is on
+		// screen next to the editor while this guard excludes it. A restored
+		// session in that shape showed raw LaTeX and `<pre>` diagram source with
+		// nothing scheduled to fix it. Split from READING mode leaves `isEditing`
+		// false and did reach this line, which is why the gap was only ever half
+		// of split view and took a while to see.
 		if (markdownBody && !isEditing) untrack(() => renderRichContent());
 	});
 

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -529,9 +529,20 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			});
 		}
 
-		// Re-initialize mermaid or trigger update if needed
-		// Note: Mermaid 10+ usually doesn't support dynamic re-init easily but we can try re-rendering rich content
-		if (markdownBody && !isEditing) renderRichContent();
+		// Mermaid bakes its colours into the SVG it produces, so the diagrams have
+		// to be drawn again for the new theme; no `roots`, because the whole
+		// article is what changed appearance.
+		//
+		// `untrack` because `renderRichContent` reads `richLibraries` before its
+		// first `await`, which made this effect re-run when the libraries landed —
+		// and that accident, not anything here, was what enriched a document
+		// patched in during a cold start. It was the wrong owner three ways over:
+		// it re-enriched every open tab's host rather than the one that needed it,
+		// it never fired in split view (the guard is `!isEditing`, so a restored
+		// split session showed raw LaTeX and `<pre>` diagram source), and it left
+		// the reading position restored against the layout the enrichment then
+		// changed. The patch effect owns that case now.
+		if (markdownBody && !isEditing) untrack(() => renderRichContent());
 	});
 
 	// ui state
@@ -1347,6 +1358,39 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	 * itself. The patch has to happen before the enrichment and the enrichment
 	 * has to be told what the patch changed, so the two stop being independent
 	 * effects racing on the same dependency and become one statement.
+	 *
+	 * ## The cold start, where the libraries have not arrived yet
+	 *
+	 * `loadRichContentLibraries()` is started in `onMount` and not awaited, and
+	 * it loses: `mode = 'app'` is roughly twenty-five sequentially awaited Tauri
+	 * round trips away (one per `appWindow.listen`, plus the session restore),
+	 * while the three chunks are megabytes of JavaScript to fetch and evaluate.
+	 * So the first document is normally patched in with `hljs` still null, this
+	 * effect skips the enrichment, and the reading position is then restored
+	 * against source text.
+	 *
+	 * This effect does re-run when they land — `hljs` is read here and it is a
+	 * `$derived` of `richLibraries` — but by then the diff has nothing to do and
+	 * `patch.inserted` comes back empty, which is why the roots below are the
+	 * host rather than the patch on that one pass.
+	 *
+	 * And the enrichment moves the text. Measured in Chromium (Vite, a
+	 * 1000x800 preview box, one anchor at each of the 10/25/50/75/90th
+	 * percentile of the rendered source lines) by restoring the position against
+	 * the un-enriched document and then re-measuring the anchored element after
+	 * `renderRichContent` — the cold-start sequence exactly — the anchored text
+	 * moved down by:
+	 *
+	 *     samples/katex-stress.md      0, 2.5, 367.1, 498.1, 502.0 px
+	 *     samples/markdown-syntax.md   0, 0, 96.0, 128.0, 812.3 px
+	 *     samples/stress-test.md       16.0, 714.2, 714.2, 714.2, 714.2 px
+	 *
+	 * A display formula replaces a line of source with a stack of boxes and a
+	 * Mermaid `<pre>` becomes an SVG several hundred pixels tall; every one of
+	 * those above the anchor pushes it down, and the constant 714.2px on
+	 * stress-test.md is its three diagrams, all near the top. Running the same
+	 * cascade once more after the enrichment lands brings the same anchors back
+	 * to within 0.8px — which is what `restoreAfterColdEnrichment` does.
 	 */
 	$effect(() => {
 		const host = previewBlocks;
@@ -1364,9 +1408,50 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// host would put back exactly the per-keystroke re-measure of every fold
 		// that keeping the observation alive removed.
 		for (const block of patch.inserted) foldLayout?.observe(block);
-		if (hljs && renderMathInElement && mermaid) renderRichContent(patch.inserted);
+		if (hljs && renderMathInElement && mermaid) {
+			// Nothing inserted and nothing enriched yet is the cold start above,
+			// and only that: a tab being re-activated also patches to nothing, but
+			// its host is in the set from the render that filled it.
+			const cold = patch.inserted.length === 0 && !enrichedHosts.has(host);
+			enrichedHosts.add(host);
+			const enrichment = renderRichContent(cold ? [host] : patch.inserted);
+			if (cold) restoreAfterColdEnrichment(enrichment, tabManager.activeTabId);
+		}
 		previewRevision = ++previewPatches;
 	});
+
+	/**
+	 * The hosts whose document has been through `renderRichContent` at least
+	 * once. A `WeakMap`/`WeakSet` keyed on the container for the same reason
+	 * `renderedKeys` in `blockPatch.ts` is: a host that Svelte destroys with its
+	 * tab takes its entry with it, so this cannot drift from the set of live
+	 * tabs the way a hand-kept registry can.
+	 */
+	const enrichedHosts = new WeakSet<HTMLElement>();
+
+	/**
+	 * Put the reader back where they were, once, after a cold start's enrichment
+	 * has changed the layout underneath them.
+	 *
+	 * Through `restorePreviewReadingPosition` — the same cascade the restore
+	 * effect runs, in the same order — because two sites consulting a tab's
+	 * three position fields in different orders are two answers for one tab.
+	 * That effect cannot do this itself: giving it a dependency on the render
+	 * would drag the preview back to the anchor on every debounced re-render
+	 * while the reader is typing in split view.
+	 *
+	 * Only for the tab that is still on screen. The enrichment is awaited, a
+	 * switch can happen inside it, and restoring another tab's position into the
+	 * article would move the document the reader is actually looking at.
+	 */
+	async function restoreAfterColdEnrichment(enrichment: Promise<void>, tabId: string | null) {
+		await enrichment;
+		await tick();
+		const body = markdownBody;
+		if (!body || !tabId || tabManager.activeTabId !== tabId) return;
+		const tab = tabManager.tabs.find((t) => t.id === tabId);
+		if (tab) restorePreviewReadingPosition(body, tab, getPreviewScrollMax(body), measurePreviewBox);
+	}
 
 	$effect(() => {
 		const host = previewBlocks;


### PR DESCRIPTION
## What this is

At app start the preview restores the reader's position against a document that has not been syntax-highlighted, typeset or drawn yet, and the enrichment that arrives afterwards moves the text out from under them. Nothing restores it a second time.

Found by reading, then measured; nobody reported it.

## Mechanism

`loadRichContentLibraries()` is started in `onMount` (MarkdownViewer.svelte:3365) and not awaited. `mode = 'app'` (:3708) is about twenty-five sequentially awaited Tauri round trips away — one per `appWindow.listen`/`onCloseRequested`/`onDragDropEvent`, plus `windowSession.restore()` and `send_markdown_path` — while highlight.js, KaTeX and Mermaid are megabytes of chunk to fetch and evaluate. The libraries lose. The article does not exist until `mode = 'app'`, so on that flush the patch effect fills the host with `hljs` still null, skips the enrichment, and the restore effect right below it runs `restorePreviewReadingPosition` against source text.

Then the enrichment lands. Measured in Chromium over the real pipeline (comrak → `processMarkdownHtml` → `sanitizeMarkdownHtml` → `patchPreviewBlocks` → `renderRichContent`, in a 1000x800 preview box, with the real highlight.js, KaTeX and Mermaid), restoring against the un-enriched document and re-measuring the anchored element's viewport top at the same `scrollTop` after the enrichment, at anchors on the 10/25/50/75/90th percentile of each document's rendered source lines:

```
samples/katex-stress.md      0, 2.5, 367.1, 498.1, 502.0 px
samples/markdown-syntax.md   0, 0, 96.0, 128.0, 812.3 px
samples/stress-test.md       16.0, 714.2, 714.2, 714.2, 714.2 px
```

A display formula replaces a line of source with a stack of boxes, a Mermaid `<pre>` becomes an SVG several hundred pixels tall, and every one above the anchor pushes it down; the constant 714.2px on stress-test.md is its three diagrams, all near the top. Running the same cascade once more after the enrichment brings the same anchors back to within 0.8px.

Nothing owned the "libraries arrived late" case. The patch effect does re-run when they land — `hljs` is a `$derived` of `richLibraries` and it is read there — but by then the diff has nothing to do and `patch.inserted` comes back empty, so it enriched nothing. What actually enriched the document was an accident in the theme effect: `renderRichContent` reads `richLibraries` before its first `await`, so that effect tracked it too and its whole-article pass doubled as the recovery. Verified with a Svelte 5 probe (a plain function reading `$state` inside an `$effect` is tracked, and the short-circuit in `markdownBody && !isEditing` decides whether it is). It was the wrong owner three ways: it re-enriched every open tab's host rather than the one that needed it, it never fired in split view — the guard is `!isEditing`, so a restored split session showed raw LaTeX and `<pre>` diagram source until something else touched those blocks — and it ran after the restore.

The patch effect owns it now. On the run where the libraries arrive and `patch.inserted` is empty, the roots are the host, and `restoreAfterColdEnrichment` awaits that pass and re-runs `restorePreviewReadingPosition` — once per host, and only if the tab is still the one on screen. The theme effect's call is `untrack`ed, so it depends on the theme rather than on the libraries.

## Scope

The restore effect is untouched. It gains no dependency on `previewRevision`, `sanitizedHtml` or `htmlContent` — it runs while the reader is typing in split view, where a per-render dependency would drag the preview back on every debounce.

Awaiting the libraries before `mode = 'app'` is the obvious fix and was rejected. It puts the three chunks on the critical path of app start; `scripts/monacoStartupGraph.test.ts` exists because this repo already decided that question for a comparable payload.

Left alone:

- KaTeX's web fonts land after the enrichment and shift heights again. Same shape, second order, not measured here.
- The theme effect still re-renders the whole article across every open tab's host on a theme change. That is what it did before; the export path already works around it with explicit roots.
- The split-view hole is closed as a side effect (the patch effect has no `!isEditing` guard), not deliberately.

## Tests

`scripts/previewAnchorRestore.test.ts` gains `a cold start restores again once its enrichment has landed`. Reverting the change to `MarkdownViewer.svelte` and keeping the test: **red** (1 failed, 10 passed in that file).

It is a source assertion, and it pins internal call sites — `patch.inserted.length === 0 && !enrichedHosts.has(host)`, the `cold ? [host] : patch.inserted` roots, the `if (cold) restoreAfterColdEnrichment(` call, the three lines inside that helper, and the `untrack(...)` in the theme effect. A rename breaks it without breaking anything real. It is what is available: the subject is a Svelte effect that cannot be imported, and the thing it does — a position in pixels — is exactly what jsdom cannot answer, so the magnitude above lives in a comment rather than an assertion.

## Verification

```
npm audit                       0 vulnerabilities
npm run check                   826 files, 0 errors, 0 warnings
npm test                        1013 pass, 0 fail   (1012 on master)
npm run test:vitest             429 pass, 0 fail
cargo test                      164 pass, 0 fail
```

Not verified: the app was never run. The ordering claim — that `mode = 'app'` is reached before the libraries resolve — is reasoned from the count of awaited IPC round trips against the chunk sizes, not timed in a packaged build. The pixel figures come from a standalone harness that reproduces the pipeline in Chromium, not from Markpad itself, so what they establish is the size of the layout change, not that a given launch hits it. Worth one manual pass: open a session with `samples/stress-test.md` scrolled past its diagrams, quit, relaunch, and watch whether the text under the cursor stays put.
