### PR TITLE
fix(preview): a theme change re-draws the diagrams it has never re-drawn

### DIFF
--- a/scripts/diagramThemeRefresh.spec.ts
+++ b/scripts/diagramThemeRefresh.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Switching theme has to re-draw the diagrams, and until this file existed it
+ * did not — in any mode, for any theme.
+ *
+ * Mermaid bakes fills, strokes and label colours into the SVG as attributes, so
+ * a stylesheet cannot retarget them; `mermaidPrint.ts` says why at length, and
+ * re-rendering is the answer it already reaches for on the way to a PDF. The
+ * preview's own theme change was supposed to do the same thing through
+ * `renderRichContent`, and could not: that function finds diagrams by
+ * `pre code`, and a diagram that has been drawn once has no `<pre>` any more —
+ * it was replaced by the `.mermaid-diagram` container holding the SVG.
+ *
+ * That was invisible while the preview was `{@html sanitizedHtml}`, because
+ * every render put the whole document back as source. `blockPatch.ts` (#632)
+ * keeps enriched nodes across renders instead, and from then on a theme change
+ * reached no diagram at all. The `<pre>` is gone, `patch.inserted` is empty on
+ * a re-render of the same document, and typing does not help either: the
+ * diagram's markup is unchanged, so the patch keeps the node.
+ *
+ * The libraries are stood in for at the same boundary `exportRichContent` and
+ * `richContentIdempotence` use. What is under test is Markpad's bookkeeping:
+ * which containers it decides are stale, and what it does to them.
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import { patchPreviewBlocks } from '../src/lib/utils/blockPatch.js';
+import { readDiagramSource } from '../src/lib/utils/mermaidPrint.js';
+import { renderRichContent, type RichContentLibraries } from '../src/lib/utils/richContent.js';
+import { resetDiagramCache } from '../src/lib/utils/diagramCache.js';
+
+const SOURCE = 'graph TD;A-->B;';
+
+/** Records every draw so "did it re-render" is a count, not an inference. */
+function libraries(draws: string[]): RichContentLibraries {
+	let theme = 'unset';
+	return {
+		hljs: { getLanguage: () => undefined, highlight: () => ({ value: '' }) },
+		katex: { renderToString: (source: string) => source },
+		renderMathInElement: () => {},
+		mermaid: {
+			initialize: (config: { theme: string }) => {
+				theme = config.theme;
+			},
+			render: async (id: string, source: string) => {
+				draws.push(`${theme}:${source}`);
+				return { svg: `<svg id="${id}" data-drawn-for="${theme}"></svg>` };
+			},
+		},
+	} as any;
+}
+
+function article(html: string): HTMLElement {
+	const element = document.createElement('div');
+	element.innerHTML = html;
+	document.body.replaceChildren(element);
+	return element;
+}
+
+async function render(root: HTMLElement, mermaidTheme: string, draws: string[], seed = 0) {
+	await renderRichContent({
+		roots: [root],
+		libraries: libraries(draws),
+		mermaidTheme,
+		idFactory: (index) => `d${seed}-${index}`,
+	});
+}
+
+function drawnFor(root: ParentNode): string | null {
+	return root.querySelector('.mermaid-diagram svg')?.getAttribute('data-drawn-for') ?? null;
+}
+
+const PRE = `<pre data-sourcepos="1:1-3:3"><code class="language-mermaid">${SOURCE}</code></pre>`;
+
+describe('a theme change', () => {
+	test('re-draws a diagram that is already on screen', async () => {
+		resetDiagramCache();
+		const draws: string[] = [];
+		const root = article(PRE);
+
+		await render(root, 'dark', draws);
+		expect(drawnFor(root)).toBe('dark');
+
+		// The whole-article pass a theme change makes. There is no `<pre>` left.
+		expect(root.querySelectorAll('pre code').length).toBe(0);
+		await render(root, 'neutral', draws, 1);
+
+		expect(drawnFor(root)).toBe('neutral');
+		expect(draws).toEqual([`dark:${SOURCE}`, `neutral:${SOURCE}`]);
+	});
+
+	test('leaves the source on the container, so the PDF path still works', async () => {
+		resetDiagramCache();
+		const root = article(PRE);
+		await render(root, 'dark', []);
+		await render(root, 'neutral', [], 1);
+
+		expect(readDiagramSource(root.querySelector('.mermaid-diagram')!)).toBe(SOURCE);
+	});
+});
+
+describe('a pass that is not a theme change', () => {
+	test('does not re-draw a diagram already in the theme being asked for', async () => {
+		resetDiagramCache();
+		const draws: string[] = [];
+		const root = article(PRE);
+
+		await render(root, 'dark', draws);
+		// `syncPreviewForPrint` and a re-activated tab both re-run this over the
+		// whole host without the theme having moved.
+		await render(root, 'dark', draws, 1);
+		await render(root, 'dark', draws, 2);
+
+		expect(draws).toEqual([`dark:${SOURCE}`]);
+	});
+
+	test('does not reach a diagram outside the roots it was given', async () => {
+		resetDiagramCache();
+		const draws: string[] = [];
+		const host = article(`${PRE}<p data-sourcepos="5:1-5:5">text</p>`);
+		await render(host, 'dark', draws);
+
+		// The keystroke path: the patch replaces the paragraph and hands only
+		// that block to the enrichment. The diagram is not in it, and a theme it
+		// no longer matches must not drag it into the pass.
+		const patch = patchPreviewBlocks(document.createElement('div'), '<p>x</p>');
+		await renderRichContent({
+			roots: patch.inserted,
+			libraries: libraries(draws),
+			mermaidTheme: 'neutral',
+			idFactory: (index) => `k${index}`,
+		});
+
+		expect(draws).toEqual([`dark:${SOURCE}`]);
+		expect(drawnFor(host)).toBe('dark');
+	});
+});
+
+/**
+ * The wiring, which the tests above cannot reach: `renderRichContent` now knows
+ * how to re-draw a stale diagram, but the theme effect still has to call it, in
+ * every mode and once per theme change.
+ *
+ * A source assertion, because the caller is a Svelte effect that cannot be
+ * imported. It pins today's spelling of an internal call, so a rename breaks it
+ * without breaking anything real; what it is here for is the guard, which was
+ * `markdownBody && !isEditing`. That made the whole effect — the `dataset`
+ * writes, `monaco.editor.setTheme`, and for a `vscode:` theme an
+ * `invoke('read_vscode_theme')` and a re-parse — re-run on every mode toggle
+ * and on every tab switch that changed the mode, with nothing about the theme
+ * having moved. And it excluded from the re-colour every tab in edit mode,
+ * including a split tab entered from edit mode, whose preview is on screen.
+ */
+test('the theme effect re-colours in every mode, and does not re-run on a mode change', async () => {
+	const { readSource } = await import('./sourceTree.js');
+	const viewer: string = readSource('src/lib/MarkdownViewer.svelte');
+
+	const effect = viewer.match(
+		/\t\$effect\(\(\) => \{\n\t\t\/\/ Persistence and cross-window sync[\s\S]*?\n\t\}\);/,
+	)?.[0];
+	expect(effect, 'the theme effect must still be recognisable').toBeTruthy();
+
+	// The mode is not a reason to re-apply a theme, and this is the only read
+	// that ever made it one.
+	expect(effect).not.toMatch(/isEditing/);
+	expect(effect).toMatch(
+		/const recolourDiagrams = \(\) => untrack\(\(\) => \{ if \(markdownBody\) renderRichContent\(\); \}\);/,
+	);
+
+	// Once per branch: the `vscode:` branch does not know its own appearance
+	// until `parseAndApplyVscodeTheme` has published `dataset.themeType`, which
+	// is what `currentMermaidTheme` reads.
+	expect(effect!.match(/recolourDiagrams\(\);/g)).toHaveLength(2);
+	expect(effect).toMatch(/await parseAndApplyVscodeTheme[\s\S]*?recolourDiagrams\(\);/);
+});

--- a/scripts/mermaidPrintTheme.test.ts
+++ b/scripts/mermaidPrintTheme.test.ts
@@ -59,7 +59,7 @@ const asElement = (element: FakeElement) => element as unknown as Element;
 
 function diagram(source: string | null, html: string) {
 	const element = new FakeElement('mermaid-diagram');
-	if (source !== null) rememberDiagramSource(asElement(element), source);
+	if (source !== null) rememberDiagramSource(asElement(element), source, 'dark');
 	element.innerHTML = html;
 	return element;
 }
@@ -196,7 +196,12 @@ test('the PDF export wraps the print render and always restores', () => {
 	// calling the same function; the assertion follows it rather than being
 	// relaxed, because "some path renders diagrams without remembering the
 	// source" is exactly the drift that deleted the markdown.ts copy.
-	assert.match(richContent, /rememberDiagramSource\(\s*\w+\s*,\s*\w+\s*\)/);
+	//
+	// The theme it was drawn with is recorded alongside it now. That is not for
+	// this path — `renderDiagramsForPrint` swaps the print rendering in and the
+	// screen one back out, and never writes the attribute — it is what lets
+	// `renderRichContent` find the diagrams a theme change left behind.
+	assert.match(richContent, /rememberDiagramSource\(\s*\w+\s*,\s*\w+\s*,[^)]*\)/);
 
 	// One theme decision, shared by the screen render and the restore. Asserted
 	// as "both options are fed the same expression" rather than as the literal

--- a/scripts/previewAnchorRestore.test.ts
+++ b/scripts/previewAnchorRestore.test.ts
@@ -512,11 +512,16 @@ test('a cold start restores again once its enrichment has landed', async () => {
 	// And the accident that used to stand in for it must not come back. The
 	// theme effect's `renderRichContent()` reads `richLibraries` before its
 	// first await, so without `untrack` that effect re-runs when the libraries
-	// land — re-enriching every open tab's host, never firing in split view,
-	// and leaving the reading position where the old layout put it.
+	// land — re-enriching every open tab's host on top of the pass below, and
+	// leaving the reading position where the old layout put it.
+	//
+	// Matched on the `untrack`, not on the guard beside it: the guard was
+	// `markdownBody && !isEditing` when this was written and is `markdownBody`
+	// alone now (scripts/diagramThemeRefresh.spec.ts owns that question). What
+	// this test is for is the tracking.
 	assert.match(
 		viewer,
-		/if \(markdownBody && !isEditing\) untrack\(\(\) => renderRichContent\(\)\);/,
+		/untrack\(\(\) => \{? ?if \(markdownBody\) renderRichContent\(\);/,
 		'the theme effect must depend on the theme, not on the libraries arriving',
 	);
 });

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -500,6 +500,24 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// effect is only the part that cannot: applying the theme to the document.
 		const theme = settings.theme;
 
+		// Mermaid bakes its colours into the SVG it produces, so the diagrams have
+		// to be drawn again; `renderRichContent` finds the ones drawn for another
+		// theme. No `roots`, because the whole article is what changed appearance
+		// — including the hosts of tabs that are not on screen, which the reader
+		// switches back to without anything else re-rendering them.
+		//
+		// Called from each branch rather than once at the end, because the
+		// `vscode:` branch does not know its own appearance until
+		// `parseAndApplyVscodeTheme` has published `dataset.themeType`, and that
+		// is what `currentMermaidTheme` reads. Calling here would have re-drawn
+		// every diagram in the theme being replaced.
+		//
+		// `untrack` for the reason #740 established: `renderRichContent` reads
+		// `richLibraries` before its first `await`, so a tracked call makes this
+		// effect re-run when the libraries land — duplicating the cold-start
+		// enrichment the patch effect owns, over every open tab's host.
+		const recolourDiagrams = () => untrack(() => { if (markdownBody) renderRichContent(); });
+
 		if (theme === 'system' || theme === 'light' || theme === 'dark') {
 			if (theme === 'system') {
 				delete document.documentElement.dataset.theme;
@@ -510,6 +528,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			}
 			clearVscodeTheme();
 			saveStartupAppearance(theme);
+			recolourDiagrams();
 			const monaco = (window as any).monaco;
 			if (monaco && monaco.editor) {
 				const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -523,34 +542,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				// `parseAndApplyVscodeTheme` decides dark vs. light from the theme's
 				// own `type` field and publishes it here.
 				saveStartupAppearance(document.documentElement.dataset.themeType === 'dark' ? 'dark' : 'light');
+				recolourDiagrams();
 			}).catch(e => {
 				console.error("Failed to load vscode theme", e);
 				settings.theme = 'system';
 			});
 		}
-
-		// Mermaid bakes its colours into the SVG it produces, so the diagrams have
-		// to be drawn again for the new theme; no `roots`, because the whole
-		// article is what changed appearance.
-		//
-		// `untrack` because `renderRichContent` reads `richLibraries` before its
-		// first `await`, which made this effect re-run when the libraries landed —
-		// and that accident, not anything here, was what enriched a document
-		// patched in during a cold start. It was the wrong owner three ways over:
-		// it re-enriched every open tab's host rather than the one that needed it,
-		// it did not fire at all for a tab in edit mode (the guard is
-		// `!isEditing`), and it left the reading position restored against the
-		// layout the enrichment then changed. The patch effect owns that case now.
-		//
-		// The edit-mode gap is not only about a hidden preview. `isSplit` is
-		// independent of `isEditing` — `setSplitEnabled` never touches it — so a
-		// tab split from EDIT mode has both flags set, and its preview is on
-		// screen next to the editor while this guard excludes it. A restored
-		// session in that shape showed raw LaTeX and `<pre>` diagram source with
-		// nothing scheduled to fix it. Split from READING mode leaves `isEditing`
-		// false and did reach this line, which is why the gap was only ever half
-		// of split view and took a while to see.
-		if (markdownBody && !isEditing) untrack(() => renderRichContent());
 	});
 
 	// ui state

--- a/src/lib/utils/mermaidPrint.ts
+++ b/src/lib/utils/mermaidPrint.ts
@@ -20,6 +20,21 @@
 
 const SOURCE_ATTR = 'data-mermaid-source';
 
+/**
+ * The Mermaid theme the SVG on the container was drawn with.
+ *
+ * Kept next to the source because the colours are IN that SVG, so "is this
+ * diagram current" is a question about the drawing and not about the document.
+ * `renderRichContent` re-draws the containers whose answer no longer matches
+ * the theme it was asked for; without it a theme change reached no diagram at
+ * all, because a drawn diagram no longer has the `<pre>` that pass looks for.
+ *
+ * `renderDiagramsForPrint` deliberately does not write it: it swaps the print
+ * rendering in and the screen rendering back out again, and the attribute goes
+ * on describing what the container ends up holding.
+ */
+const THEME_ATTR = 'data-mermaid-theme';
+
 const MERMAID_PRINT_THEME = 'neutral';
 
 export interface MermaidConfig {
@@ -70,13 +85,18 @@ export function resolveMermaidTheme(input: {
 	return isDark ? 'dark' : 'neutral';
 }
 
-/** Keeps the source next to the rendered diagram so it can be rebuilt later. */
-export function rememberDiagramSource(container: Element, source: string) {
+/** Keeps the source and the theme next to the rendered diagram so it can be rebuilt later. */
+export function rememberDiagramSource(container: Element, source: string, theme: string) {
 	container.setAttribute(SOURCE_ATTR, source);
+	container.setAttribute(THEME_ATTR, theme);
 }
 
 export function readDiagramSource(container: Element): string | null {
 	return container.getAttribute(SOURCE_ATTR);
+}
+
+export function readDiagramTheme(container: Element): string | null {
+	return container.getAttribute(THEME_ATTR);
 }
 
 export function findRestorableDiagrams(root: ParentNode): Element[] {

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -5,7 +5,12 @@ import {
 	storeDiagramTemplate,
 	templateDiagramSvg,
 } from './diagramCache.js';
-import { mermaidConfig, rememberDiagramSource } from './mermaidPrint.js';
+import {
+	mermaidConfig,
+	readDiagramSource,
+	readDiagramTheme,
+	rememberDiagramSource,
+} from './mermaidPrint.js';
 import { highlightedCode, renderedMath } from './richContentCache.js';
 
 /**
@@ -227,6 +232,52 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 
 	const codeBlocks = roots.flatMap((root) => selfAndDescendants(root, 'pre code'));
 
+	/**
+	 * Diagrams already on screen that were drawn for a different theme.
+	 *
+	 * Mermaid bakes its colours into the SVG, so a theme change has to draw them
+	 * again — and until this existed, nothing did. The loop below finds diagrams
+	 * by `pre code`, and a diagram that has been drawn once has no `<pre>` left:
+	 * this function replaced it with the `.mermaid-diagram` container. While the
+	 * preview was `{@html sanitizedHtml}` that was invisible, because every
+	 * render put the whole document back as source; `blockPatch.ts` keeps the
+	 * enriched nodes instead, so from #632 on a theme change reached no diagram
+	 * at all, in any mode. The source is on the container already —
+	 * `mermaidPrint.ts` keeps it there so the PDF path can rebuild the diagram
+	 * with a light theme — and the theme it was drawn for is kept beside it.
+	 *
+	 * Collected BEFORE the loop, so the containers the loop is about to build
+	 * are not scanned as if they were stale. On the keystroke path the roots are
+	 * the blocks the patch just inserted, which are freshly parsed markup with
+	 * no rendered diagram in them, so this is one selector that matches nothing.
+	 *
+	 * What a theme change costs, measured in Chromium over the real pipeline
+	 * (comrak -> `processMarkdownHtml` -> `sanitizeMarkdownHtml` -> `blockPatch`
+	 * -> here) in a 1000x800 preview box, as one whole-article
+	 * `renderRichContent` with highlight.js and the display-maths memo already
+	 * warm, two runs:
+	 *
+	 *                                 diagrams   theme moved   theme unchanged
+	 *     samples/katex-stress.md            0    8.6-10.6ms       11.9-12.2ms
+	 *     samples/markdown-syntax.md         4   61.2-76.1ms         2.6-3.0ms
+	 *     samples/stress-test.md             3  107.5-121.2ms      12.5-12.8ms
+	 *
+	 * So the diagrams are the whole of it: katex-stress has none and its two
+	 * columns are the same number, which is `renderMathInElement` scanning a
+	 * document with no memo behind it. Toggling back to a theme the diagram
+	 * cache has already seen costs 9.8-30.1ms rather than the figures above.
+	 * The right-hand column is what a mode toggle used to pay for nothing —
+	 * the theme effect re-ran on every one of them, drawing no diagram because
+	 * it could not find any.
+	 */
+	const staleDiagrams = roots
+		.flatMap((root) => selfAndDescendants(root, '.mermaid-diagram'))
+		.filter(
+			(container) =>
+				readDiagramSource(container) !== null &&
+				readDiagramTheme(container) !== options.mermaidTheme,
+		);
+
 	// The config itself lives in `mermaidPrint.ts` — `initialize` replaces the
 	// site config rather than merging into it, so the two callers that write to
 	// this singleton have to send the same keys or the last one wins. See
@@ -241,11 +292,46 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 	// diagram on paper and configures it back, so a remembered theme here would
 	// be a claim about a global another module also writes to.
 	const hasDiagram = codeBlocks.some((block) => block.classList.contains('language-mermaid'));
-	if (hasDiagram) {
+	if (hasDiagram || staleDiagrams.length > 0) {
 		mermaid.initialize(mermaidConfig(options.mermaidTheme));
 	}
 
 	let diagramIndex = 0;
+
+	/**
+	 * The drawing itself, shared by the two callers below so a re-coloured
+	 * diagram is memoised, sanitized and identified exactly like a fresh one.
+	 *
+	 * The cache holds a *template* rather than the SVG: the id is stamped into
+	 * it, so a reused diagram is as uniquely identified as a fresh one. See
+	 * `diagramCache.ts` for why that is the whole difficulty.
+	 */
+	const drawDiagram = async (source: string, svgId: string): Promise<string> => {
+		const cached = lookupDiagramTemplate(source, options.mermaidTheme);
+		if (cached !== null) return fillDiagramTemplate(cached, svgId);
+		const { svg } = await mermaid.render(svgId, source);
+		// A source that contains the render id would have its own text rewritten
+		// by the substitution, so that one is left uncached.
+		if (!source.includes(svgId)) {
+			const template = templateDiagramSvg(svg, svgId);
+			if (template !== null) storeDiagramTemplate(source, options.mermaidTheme, template);
+		}
+		return svg;
+	};
+
+	for (const container of staleDiagrams) {
+		const source = readDiagramSource(container) as string;
+		try {
+			container.innerHTML = sanitizeDiagramSvg(await drawDiagram(source, idFactory(diagramIndex++)));
+			rememberDiagramSource(container, source, options.mermaidTheme);
+		} catch (error) {
+			// A diagram that fails to draw keeps the rendering it has. A diagram
+			// in the previous theme's colours still beats an empty box, which is
+			// the same call `renderDiagramsForPrint` makes.
+			options.onError?.(error);
+			console.error('Failed to re-render Mermaid diagram for the new theme:', error);
+		}
+	}
 	for (const block of codeBlocks) {
 		const codeEl = block as HTMLElement;
 		const preEl = codeEl.parentElement as HTMLPreElement;
@@ -253,33 +339,14 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 		if (codeEl.classList.contains('language-mermaid')) {
 			const mermaidCode = codeEl.textContent || '';
 			try {
-				// The preview re-renders the whole article roughly once per keystroke
-				// and `{@html}` puts every diagram's source back, so drawing is the
-				// one step worth remembering between passes. The cache holds a
-				// *template* rather than the SVG: the id below is stamped into it, so
-				// a reused diagram is as uniquely identified as a fresh one. See
-				// `diagramCache.ts` for why that is the whole difficulty.
-				const svgId = idFactory(diagramIndex++);
-				const cached = lookupDiagramTemplate(mermaidCode, options.mermaidTheme);
-				let svg: string;
-				if (cached !== null) {
-					svg = fillDiagramTemplate(cached, svgId);
-				} else {
-					svg = (await mermaid.render(svgId, mermaidCode)).svg;
-					// A source that contains the render id would have its own text
-					// rewritten by the substitution, so that one is left uncached.
-					if (!mermaidCode.includes(svgId)) {
-						const template = templateDiagramSvg(svg, svgId);
-						if (template !== null) storeDiagramTemplate(mermaidCode, options.mermaidTheme, template);
-					}
-				}
+				const svg = await drawDiagram(mermaidCode, idFactory(diagramIndex++));
 
 				const container = doc.createElement('div');
 				container.className = 'mermaid-diagram';
 				carrySourcepos(preEl, container);
 				// Kept so the PDF path can rebuild the diagram with a light theme
 				// instead of recolouring Mermaid's output.
-				rememberDiagramSource(container, mermaidCode);
+				rememberDiagramSource(container, mermaidCode, options.mermaidTheme);
 				container.innerHTML = sanitizeDiagramSvg(svg);
 				preEl.replaceWith(container);
 			} catch (error) {


### PR DESCRIPTION
Based on #740 and merges after it. The diff against that branch is six files; base is `perf/rich-content-anchor-drift`.

## What this is

Switching theme does not re-colour Mermaid diagrams. A dark diagram stays dark on a light theme, in every mode, for every theme — not only the edit-mode case the review that prompted this was about.

## Mechanism

Two defects, one on top of the other.

**The call has never worked.** `MarkdownViewer.svelte`'s theme effect calls `renderRichContent()` because Mermaid bakes fills, strokes and label colours into the SVG as attributes — `mermaidPrint.ts` explains at length why a stylesheet cannot retarget them, and re-rendering is the answer it already reaches for on the way to a PDF. But `renderRichContent` finds diagrams with `roots.flatMap(root => selfAndDescendants(root, 'pre code'))`, and a diagram that has been drawn once has no `<pre>` any more: that same function replaced it with `<div class="mermaid-diagram">`. While the preview was `{@html sanitizedHtml}` this was invisible, because every render put the whole document back as source. `blockPatch.ts` (#632) keeps enriched nodes across renders instead, and from that commit on the theme change reached nothing.

Nothing else covers it. A re-activated tab patches to nothing, so `patch.inserted` is empty and the enrichment returns immediately; typing does not help either, because the diagram's markup is unchanged and the patch keeps the node. Confirmed by running it: a diagram drawn for `dark` survives a `neutral` pass byte for byte.

**The guard made the effect a mode listener.** `if (markdownBody && !isEditing)` reads `isEditing`, a `$derived` of the active tab, so the whole effect re-ran on every ⌘E and on every tab switch that changed the mode — the `dataset` writes, `clearVscodeTheme`, `saveStartupAppearance`, `monaco.editor.setTheme`, and for a `vscode:` theme an `invoke('read_vscode_theme')` round trip plus a full re-parse and re-apply, on a keystroke-adjacent gesture, with nothing about the theme having moved.

Nothing in the body wants a mode dependency. `Editor.svelte` sets its own theme at creation and keeps it current from its `theme` prop, so the viewer's `monaco.editor.setTheme` is not what themes the editor. `git log -S` puts the guard at 06380bc, where the sibling render effect read `if (htmlContent && markdownBody && !isEditing && hljs && ...)` — enrichment was a whole-document pass on every render and the preview was hidden in edit mode, so it was protecting something real. That sibling lost its `!isEditing` when the patch effect was built (the patch effect's own comment says why: "so split view could not use it"). This copy was never revisited. And it excluded from the re-colour every tab in edit mode, including a split tab entered from edit mode — `setSplitEnabled` never touches `isEditing` — whose preview is on screen beside the editor.

## What changed

`mermaidPrint.ts` keeps the theme a diagram was drawn with next to the source it already keeps. `renderRichContent` collects the containers whose theme no longer matches the one it was asked for, before the `pre code` loop so the containers that loop is about to build are not scanned as stale, and re-draws them through the same cache, sanitizer and id factory as a fresh diagram — a `drawDiagram` the two paths now share, which is a net deletion in the main loop.

The theme effect's guard is `markdownBody` alone, and the call is made per branch rather than once at the end: the `vscode:` branch does not know its own appearance until `parseAndApplyVscodeTheme` has published `dataset.themeType`, which is what `currentMermaidTheme` reads, so the old placement would have re-drawn every diagram in the theme being replaced.

`untrack` stays, for the reason #740 established.

## Numbers

One whole-article `renderRichContent` in Chromium over the real pipeline (comrak → `processMarkdownHtml` → `sanitizeMarkdownHtml` → `blockPatch` → here), 1000x800 preview box, highlight.js and the display-maths memo already warm, two runs:

```
                             diagrams   theme moved   theme unchanged
samples/katex-stress.md            0    8.6-10.6ms       11.9-12.2ms
samples/markdown-syntax.md         4   61.2-76.1ms         2.6-3.0ms
samples/stress-test.md             3  107.5-121.2ms      12.5-12.8ms
```

The diagrams are the whole of it — katex-stress has none and its two columns are the same number, which is `renderMathInElement` scanning a document with no memo behind it. Toggling back to a theme the diagram cache has already seen is 9.8–30.1ms. The right-hand column is what a mode toggle used to pay to draw nothing; it now pays nothing at all.

No double work at a cold start: the theme effect's call is untracked, so it does not re-run when the libraries land, and the patch effect stays the owner of that case.

## Scope

Two things noticed and deliberately left:

- `monaco.editor.setTheme(effectiveTheme === 'dark' ? 'vs-dark' : 'vs')` in the viewer sets Monaco's global theme to a builtin, while `Editor.svelte` sets it to the `app-theme-dark`/`app-theme-light` it defines. Two writers, last one wins. Unrelated to the diagrams and not touched here.
- `renderRichContent()` with no roots enriches every open tab's host, which is right for a theme change and wasteful for the export refresh, which already passes explicit roots.

## Tests

`scripts/diagramThemeRefresh.spec.ts`, five tests. Reverting the three source files and keeping them: **2 red**.

- `re-draws a diagram that is already on screen` — **red**. A real behaviour test: it drives `renderRichContent` twice over the same root with a recording Mermaid stand-in and asserts the second theme actually reaches the SVG.
- `the theme effect re-colours in every mode, and does not re-run on a mode change` — **red**. A source assertion; the caller is a Svelte effect that cannot be imported, so it matches the effect's text for the absence of `isEditing` and for the two branch calls.
- The other three (a same-theme pass draws nothing; a keystroke-shaped pass does not reach a diagram outside its roots; the print path's source survives a re-colour) pass either way. They pin premises, not the fix — say so rather than counting them as coverage.

Two assertions added in #740 went red on this change and were updated rather than relaxed: `mermaidPrintTheme.test.ts` pinned `rememberDiagramSource`'s two-argument spelling, and `previewAnchorRestore.test.ts` pinned the whole `if (markdownBody && !isEditing) untrack(...)` line when what it is for is the `untrack`. That is the "pins today's spelling" weakness #740's own body called out, arriving one PR later.

## Verification

```
npm audit                       0 vulnerabilities
npm run check                   827 files, 0 errors, 0 warnings
npm test                        1013 pass, 0 fail
npm run test:vitest             434 pass, 0 fail   (429 before)
cargo test                      164 pass, 0 fail
```

Not verified: the app was never run. The measurements come from a standalone Chromium harness reproducing the pipeline, not from Markpad, and the Mermaid stand-in in the tests is a recorder rather than Mermaid. Worth one manual pass: open a document with a diagram, switch dark↔light, and check the diagram follows — then do it again with the tab in edit mode and split, which is the case that was excluded twice over.
