### PR TITLE
One writer decides which Monaco theme the editor wears

### DIFF
--- a/scripts/editorTheme.test.ts
+++ b/scripts/editorTheme.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { markdownTokenRules, semanticTokenRules } from '../src/lib/utils/editorTheme.js';
-import { readSource } from './sourceTree.js';
+import { markdownTokenRules, monacoThemeName, semanticTokenRules } from '../src/lib/utils/editorTheme.js';
+import { filesMatching, readSource, readSourceFiles } from './sourceTree.js';
 
 // The editor's Markdown colours. Two things can make a rule here do nothing at
 // all, and neither is visible to the compiler: a token name no grammar emits
@@ -141,5 +141,58 @@ test('a formula reads as markup around content, not as one flat run', () => {
 		assert.notEqual(marker?.foreground, body?.foreground, 'delimiters must not vanish into the body');
 		assert.equal(body?.foreground, byToken.get('code')?.foreground, 'a formula is code-coloured');
 		assert.equal(body?.fontStyle, 'italic');
+	}
+});
+
+// ------------------------------------------- who tells Monaco which theme it is
+
+// `monaco.editor.setTheme` is global to the page, not scoped to an editor, so
+// the last caller in a flush decides what every editor is wearing. Two callers
+// disagreed: `Editor.svelte` asked for `app-theme-*` (the rules above) and
+// `MarkdownViewer.svelte` asked for Monaco's stock `vs`/`vs-dark` from a second
+// effect over the same `settings.theme`. Svelte 5 runs a child's effects before
+// its parent's and `Editor` is the viewer's child, so the stock name won every
+// theme change and the whole palette above stopped existing until the pane was
+// re-created.
+
+test('a settings value maps to one theme name', () => {
+	assert.equal(monacoThemeName('dark', false), 'app-theme-dark');
+	assert.equal(monacoThemeName('light', true), 'app-theme-light');
+	assert.equal(monacoThemeName('system', true), 'app-theme-dark');
+	assert.equal(monacoThemeName('system', false), 'app-theme-light');
+	// The OS preference is only consulted for `system`.
+	assert.equal(monacoThemeName('dark', true), 'app-theme-dark');
+	assert.equal(monacoThemeName('light', false), 'app-theme-light');
+	// An imported theme is one Monaco theme whatever its file is called, and
+	// carries its own appearance rather than the desktop's.
+	assert.equal(monacoThemeName('vscode:Dracula', false), 'vscode-custom');
+	assert.equal(monacoThemeName('vscode:Solarized Light', true), 'vscode-custom');
+});
+
+test('the editor pane and the theme importer are the only writers', () => {
+	assert.deepEqual(filesMatching(readSourceFiles('src'), /\.editor\.setTheme\(/), [
+		// The widget's owner: it defines `app-theme-*` and it is the only thing
+		// on screen a Monaco theme can be seen on.
+		'src/lib/components/Editor.svelte',
+		// `vscode-custom` does not exist as a theme until this file has read the
+		// JSON and called `defineTheme`, so the set has to happen where the
+		// define does — `Editor.svelte`'s change effect abstains for `vscode:`.
+		'src/lib/utils/theme.ts',
+	]);
+});
+
+test('every name the seam returns is a theme somebody defines', () => {
+	const defined = [
+		readSource('src/lib/components/Editor.svelte'),
+		readSource('src/lib/utils/theme.ts'),
+	]
+		.flatMap((text) => [...text.matchAll(/\.editor\.defineTheme\(\s*["']([\w-]+)["']/g)])
+		.map((match) => match[1]);
+	const asked = ['system', 'light', 'dark', 'vscode:whatever'].map((theme) => [
+		monacoThemeName(theme, false),
+		monacoThemeName(theme, true),
+	]);
+	for (const name of new Set(asked.flat())) {
+		assert.ok(defined.includes(name), `nothing defines ${name}; Monaco would fall back to vs`);
 	}
 });

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -530,12 +530,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			clearVscodeTheme();
 			saveStartupAppearance(theme);
 			recolourDiagrams();
-			const monaco = (window as any).monaco;
-			if (monaco && monaco.editor) {
-				const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-				const effectiveTheme = theme === 'system' ? (isSystemDark ? 'dark' : 'light') : theme;
-				monaco.editor.setTheme(effectiveTheme === 'dark' ? 'vs-dark' : 'vs');
-			}
+			// No Monaco write here. It used to set `vs`/`vs-dark` through the
+			// `monaco` global, and because a child's effects run before its
+			// parent's it landed AFTER `Editor`'s own — stripping the editor of
+			// `app-theme-*` on every theme change. `editorTheme.ts`'s
+			// `monacoThemeName` is the one answer now, and `Editor` is the only
+			// pane that asks it; with no editor mounted there is nothing to
+			// paint, and a later mount reads the theme from the same seam.
 		} else {
 			const name = theme.replace('vscode:', '');
 			invoke('read_vscode_theme', { name }).then(async (json: any) => {

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -15,7 +15,7 @@
 	import { blockEnter, parseListItem, shiftListItem, type ListEdit } from '../utils/listEditing.js';
 	import { tableOperation, tableStep, type TableEdit, type TableOperation } from '../utils/tableEditing.js';
 	import { editorOptionsFromSettings } from '../utils/editorOptions.js';
-	import { markdownTokenRules, semanticTokenRules } from '../utils/editorTheme.js';
+	import { markdownTokenRules, monacoThemeName, semanticTokenRules } from '../utils/editorTheme.js';
 	import { createMarkdownSemanticTokensProvider } from '../utils/semanticTokens.js';
 	import { getTabModel, lineEndingLabel, tabModelUri } from '../utils/tabModels.js';
 	import { installVimScrollCommands } from '../utils/vimScrollCommands.js';
@@ -335,15 +335,11 @@
 		// active when this component was created.
 		currentTabId = tabManager.activeTabId;
 
-		const getTheme = () => {
-			if (theme && theme.startsWith("vscode:")) return "vscode-custom";
-			if (theme === "system") {
-				return window.matchMedia("(prefers-color-scheme: dark)").matches
-					? "app-theme-dark"
-					: "app-theme-light";
-			}
-			return theme === "dark" ? "app-theme-dark" : "app-theme-light";
-		};
+		const getTheme = () =>
+			monacoThemeName(
+				theme,
+				window.matchMedia("(prefers-color-scheme: dark)").matches,
+			);
 
 		// The editor is a VIEW; the document it shows is the active tab's model.
 		// Passing `model` rather than `value`/`language` also settles ownership:
@@ -2226,18 +2222,23 @@
 	});
 
 
+	// The only place a theme CHANGE reaches Monaco. `setTheme` is global to the
+	// page rather than per-editor, so a second effect writing it from anywhere
+	// else is not a redundancy, it is a coin toss — see `monacoThemeName`.
+	//
+	// `vscode:` is the one theme this pane cannot ask for on a change: its rules
+	// are read off disk, so it does not exist as a Monaco theme until
+	// `parseAndApplyVscodeTheme` has defined it, and asking for an undefined
+	// name gets `vs`. That function sets it itself the moment it can.
 	$effect(() => {
 		if (editorReady && editor && theme) {
 			if (theme.startsWith("vscode:")) return;
-			const targetTheme =
-				theme === "system"
-					? window.matchMedia("(prefers-color-scheme: dark)").matches
-						? "app-theme-dark"
-						: "app-theme-light"
-					: theme === "dark"
-						? "app-theme-dark"
-						: "app-theme-light";
-			monaco.editor.setTheme(targetTheme);
+			monaco.editor.setTheme(
+				monacoThemeName(
+					theme,
+					window.matchMedia("(prefers-color-scheme: dark)").matches,
+				),
+			);
 		}
 	});
 

--- a/src/lib/utils/editorTheme.ts
+++ b/src/lib/utils/editorTheme.ts
@@ -179,3 +179,36 @@ export function semanticTokenRules(appearance: 'light' | 'dark'): EditorTokenRul
 		fontStyle ? { token, foreground: palette[role], fontStyle } : { token, foreground: palette[role] },
 	);
 }
+
+/**
+ * The name of the Monaco theme a settings value asks for.
+ *
+ * `monaco.editor.setTheme` is a MODULE-GLOBAL switch — there is one current
+ * theme for the whole page, not one per editor — so "which theme is the editor
+ * wearing" has exactly one answer, and the app used to hold two. `Editor.svelte`
+ * set `app-theme-dark`/`app-theme-light` (this file's rules, plus the semantic
+ * layer's) while `MarkdownViewer.svelte` set Monaco's stock `vs-dark`/`vs` from
+ * a second effect over the same `settings.theme`. In Svelte 5 a child's effects
+ * run before its parent's, and `Editor` is the viewer's child, so the stock
+ * name landed last and won: after any theme change the editor was painted by
+ * `vs`/`vs-dark`, which is precisely the state the top of this file exists to
+ * describe as the defect — every heading, list marker and table pipe back to
+ * one blue `keyword`, links and rules back to no colour, and the semantic layer
+ * matching nothing at all.
+ *
+ * So the decision lives here, once, and the viewer no longer makes it. Callers
+ * pass the system preference rather than reading `matchMedia` here because this
+ * has to stay a pure function the tests can drive both ways.
+ *
+ * `vscode:` is named but not owned: that theme's rules come out of a file on
+ * disk, so `utils/theme.ts` is the only place that can `defineTheme` it, and
+ * `setTheme` on a name Monaco has never been given silently falls back to `vs`.
+ * The editor therefore asks for `vscode-custom` only where the definition is
+ * already guaranteed — at creation, and on a `prefers-color-scheme` change —
+ * and leaves the theme-change write to whoever did the defining.
+ */
+export function monacoThemeName(theme: string, systemPrefersDark: boolean): string {
+	if (theme.startsWith('vscode:')) return 'vscode-custom';
+	const dark = theme === 'system' ? systemPrefersDark : theme === 'dark';
+	return dark ? 'app-theme-dark' : 'app-theme-light';
+}


### PR DESCRIPTION
Base: `fix/theme-recolours-every-tab` (#741), which is based on `perf/rich-content-anchor-drift` (#740), which is based on `master`. None are merged. Merge order: #740, then #741, then this one — merging this into `master` directly would land nothing.

## What this is

The editor lost its Markdown colours on every theme change, and got them back only when the pane was re-created.

## Mechanism

`monaco.editor.setTheme` sets a MODULE-GLOBAL theme. There is one current theme for the whole page, not one per editor, so the last caller in a flush decides what every editor is wearing. Two callers disagreed:

- `Editor.svelte` asked for `app-theme-dark` / `app-theme-light` — the themes it defines itself, carrying `markdownTokenRules` and `semanticTokenRules` from `utils/editorTheme.ts`.
- `MarkdownViewer.svelte`'s theme effect asked for Monaco's stock `vs-dark` / `vs` through the `monaco` global (`globalThis.monaco`, which `monaco-editor/esm/vs/editor/internal/initialize.js` assigns as soon as the module loads).

Both effects read the same `settings.theme`, so both ran in the same flush. In Svelte 5 a child component's effects run before its parent's, and `Editor` is mounted inside `MarkdownViewer` — so the viewer's stock name landed last and won.

I did not take that ordering on faith. A throwaway Svelte parent/child pair with one `$effect` each over a shared `$state`, mounted under vitest and deleted afterwards, logged:

```
MOUNT ORDER:    ["child:light","parent:light"]
UPDATE ORDER:   ["child:dark","parent:dark"]
NO-CHILD ORDER: ["parent:light"]
REMOUNT ORDER:  ["child:light"]
```

Child before parent, on mount and on update alike.

What the user saw: right at editor creation, because `createEditor` passes `theme: getTheme()` into `monaco.editor.create` and that call is the last word; wrong from the first theme change onward. Under `vs`/`vs-dark` the whole palette at the top of `editorTheme.ts` stops existing — `#`, setext underlines, list bullets, `>`, `---`, the `---|---` divider and all four table-pipe tokens go from the app's accent (`#0969da` light / `#4390fc` dark) back to Monaco's one blue `keyword`; `string.md` / `variable.md` lose the code green (`#1a7f37` / `#3fb950`); `string.link.md` loses the link purple (`#8250df` / `#a371f7`); `strong.md` and `emphasis.md` lose the emphasis amber (`#9a6700` / `#d29922`); inline HTML goes back to being the loudest thing on the line. The semantic layer (`heading.marker`, `list.marker`, `fence`, `math`, `wikilink`, …) matches nothing in a stock theme at all, so it contributes no colour — and `math`'s italics and `strike`'s strikethrough go with it. The `colors` block goes too: `editor.background` `#181818` → Monaco's `#1E1E1E` in dark and `#FDFDFD` → `#FFFFFF` in light, and the context menu and find widget lose their app colours.

The `vscode:` branch was NOT racing. `Editor.svelte`'s change effect returns early for `vscode:` and the viewer's `vscode:` branch never touched Monaco either — it goes through `parseAndApplyVscodeTheme`, and `theme.ts:378` is the only `setTheme` on that path. The clobber went the other way: switching FROM an imported theme TO light/dark/system took the viewer's stock branch, so that transition was broken like any other.

## Scope

`Editor.svelte` owns it. It defines `app-theme-*`, it owns the widget, and with no editor mounted (`{#if isEditing || isSplit}`) there is nothing for a Monaco theme to be seen on. I checked whether the viewer's write was load-bearing for a window the editor's own effect misses, and it isn't: `createEditor` sets the theme in the create options, the `prefers-color-scheme` listener registered there covers an OS appearance change (the viewer's effect reads only `settings.theme`, so it never re-ran for one), and a pane that mounts later reads the same seam. Deleting the viewer's write costs nothing.

`theme.ts` stays a writer for `vscode-custom`, deliberately and not as a second opinion. That theme's rules are read off disk, so it does not exist as a Monaco theme until `defineTheme` has run there, and `setTheme` on a name Monaco has never been given falls back to `vs` — the editor cannot ask for it on a theme change without knowing when the file landed. The two writers are disjoint by theme family, and both spell the name through `monacoThemeName`.

Left alone: `theme.ts`'s `defineTheme` can still throw on a non-hex colour (the comment at `:365`), in which case the `catch` logs and nothing is set. Pre-existing, unchanged by this, and a separate question from ownership. Also left alone: a `vscode:` load that is still in flight when the user switches back to light/dark resolves afterwards and sets `vscode-custom` over the editor's `app-theme-*`. That is an async race in the importer, not a duplicated decision, and fixing it means cancellation bookkeeping this change does not need.

No fifth writer added. The `settings.theme` → Monaco-name decision moved into `monacoThemeName` in `utils/editorTheme.ts`, where the rules already live, and both places in `Editor.svelte` that made it (`getTheme` at creation, the change effect) now call it.

## Tests

`scripts/editorTheme.test.ts` gains three:

1. `a settings value maps to one theme name` — runs `monacoThemeName` over every settings value against both system preferences. Behaviour, not source text.
2. `the editor pane and the theme importer are the only writers` — `filesMatching(readSourceFiles('src'), /\.editor\.setTheme\(/)` must be exactly `Editor.svelte` and `utils/theme.ts`. Source text, and it pins a contract the compiler cannot see: "how many opinions exist about a global" is not a type. The anchor is the `setTheme` call itself, not a call site's spelling, so a rename inside either owner leaves it green and a third opinion anywhere in `src/` turns it red.
3. `every name the seam returns is a theme somebody defines` — cross-checks every name `monacoThemeName` can return against the `defineTheme` calls in those two files, because asking for an undefined name is silent (`vs`).

Revert result: restoring only the viewer's `monaco.editor.setTheme` block, with the seam and the tests kept, turns **1 of the 3** red — test 2, reporting `src/lib/MarkdownViewer.svelte` back in the list. Tests 1 and 3 stay green, and I am not claiming otherwise: they cover the decision, not the clobber, and the clobber is an effect-ordering fact between two Svelte components that no unit test can observe. Reverting the whole change instead takes the file down at import (`monacoThemeName` no longer exported), which is a red but a blunt one.

## Verification

Real Node v24 (`/usr/local/bin`); the `npm`/`node` on this machine's PATH are bun shims and give a false red on this suite.

```
npm audit                                     0 vulnerabilities
svelte-kit sync && svelte-check               827 files, 0 errors, 0 warnings
node --test --import tsx 'scripts/*.test.ts'  1016 pass, 0 fail   (1013 before, +3)
vitest run                                    434 pass, 0 fail
cargo test (src-tauri/)                       164 pass, 0 fail
```

Not verified: the app itself. It cannot be built or run in this environment, so nothing here was seen on screen — the colour claims above are read off `editorTheme.ts`'s palette and Monaco's stock themes, and the effect-ordering claim comes from the probe rather than from the running app. Worth someone toggling light/dark with the editor open, on any platform, before this lands.
