### PR TITLE
fix(preview): a theme change re-draws the diagrams it has never re-drawn (#741), retargeted to master

### DIFF
--- a/scripts/diagramThemeRefresh.spec.ts
+++ b/scripts/diagramThemeRefresh.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Switching theme has to re-draw the diagrams, and until this file existed it
+ * did not — in any mode, for any theme.
+ *
+ * Mermaid bakes fills, strokes and label colours into the SVG as attributes, so
+ * a stylesheet cannot retarget them; `mermaidPrint.ts` says why at length, and
+ * re-rendering is the answer it already reaches for on the way to a PDF. The
+ * preview's own theme change was supposed to do the same thing through
+ * `renderRichContent`, and could not: that function finds diagrams by
+ * `pre code`, and a diagram that has been drawn once has no `<pre>` any more —
+ * it was replaced by the `.mermaid-diagram` container holding the SVG.
+ *
+ * That was invisible while the preview was `{@html sanitizedHtml}`, because
+ * every render put the whole document back as source. `blockPatch.ts` (#632)
+ * keeps enriched nodes across renders instead, and from then on a theme change
+ * reached no diagram at all. The `<pre>` is gone, `patch.inserted` is empty on
+ * a re-render of the same document, and typing does not help either: the
+ * diagram's markup is unchanged, so the patch keeps the node.
+ *
+ * The libraries are stood in for at the same boundary `exportRichContent` and
+ * `richContentIdempotence` use. What is under test is Markpad's bookkeeping:
+ * which containers it decides are stale, and what it does to them.
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import { patchPreviewBlocks } from '../src/lib/utils/blockPatch.js';
+import { readDiagramSource } from '../src/lib/utils/mermaidPrint.js';
+import { renderRichContent, type RichContentLibraries } from '../src/lib/utils/richContent.js';
+import { resetDiagramCache } from '../src/lib/utils/diagramCache.js';
+
+const SOURCE = 'graph TD;A-->B;';
+
+/** Records every draw so "did it re-render" is a count, not an inference. */
+function libraries(draws: string[]): RichContentLibraries {
+	let theme = 'unset';
+	return {
+		hljs: { getLanguage: () => undefined, highlight: () => ({ value: '' }) },
+		katex: { renderToString: (source: string) => source },
+		renderMathInElement: () => {},
+		mermaid: {
+			initialize: (config: { theme: string }) => {
+				theme = config.theme;
+			},
+			render: async (id: string, source: string) => {
+				draws.push(`${theme}:${source}`);
+				return { svg: `<svg id="${id}" data-drawn-for="${theme}"></svg>` };
+			},
+		},
+	} as any;
+}
+
+function article(html: string): HTMLElement {
+	const element = document.createElement('div');
+	element.innerHTML = html;
+	document.body.replaceChildren(element);
+	return element;
+}
+
+async function render(root: HTMLElement, mermaidTheme: string, draws: string[], seed = 0) {
+	await renderRichContent({
+		roots: [root],
+		libraries: libraries(draws),
+		mermaidTheme,
+		idFactory: (index) => `d${seed}-${index}`,
+	});
+}
+
+function drawnFor(root: ParentNode): string | null {
+	return root.querySelector('.mermaid-diagram svg')?.getAttribute('data-drawn-for') ?? null;
+}
+
+const PRE = `<pre data-sourcepos="1:1-3:3"><code class="language-mermaid">${SOURCE}</code></pre>`;
+
+describe('a theme change', () => {
+	test('re-draws a diagram that is already on screen', async () => {
+		resetDiagramCache();
+		const draws: string[] = [];
+		const root = article(PRE);
+
+		await render(root, 'dark', draws);
+		expect(drawnFor(root)).toBe('dark');
+
+		// The whole-article pass a theme change makes. There is no `<pre>` left.
+		expect(root.querySelectorAll('pre code').length).toBe(0);
+		await render(root, 'neutral', draws, 1);
+
+		expect(drawnFor(root)).toBe('neutral');
+		expect(draws).toEqual([`dark:${SOURCE}`, `neutral:${SOURCE}`]);
+	});
+
+	test('leaves the source on the container, so the PDF path still works', async () => {
+		resetDiagramCache();
+		const root = article(PRE);
+		await render(root, 'dark', []);
+		await render(root, 'neutral', [], 1);
+
+		expect(readDiagramSource(root.querySelector('.mermaid-diagram')!)).toBe(SOURCE);
+	});
+});
+
+describe('a pass that is not a theme change', () => {
+	test('does not re-draw a diagram already in the theme being asked for', async () => {
+		resetDiagramCache();
+		const draws: string[] = [];
+		const root = article(PRE);
+
+		await render(root, 'dark', draws);
+		// `syncPreviewForPrint` and a re-activated tab both re-run this over the
+		// whole host without the theme having moved.
+		await render(root, 'dark', draws, 1);
+		await render(root, 'dark', draws, 2);
+
+		expect(draws).toEqual([`dark:${SOURCE}`]);
+	});
+
+	test('does not reach a diagram outside the roots it was given', async () => {
+		resetDiagramCache();
+		const draws: string[] = [];
+		const host = article(`${PRE}<p data-sourcepos="5:1-5:5">text</p>`);
+		await render(host, 'dark', draws);
+
+		// The keystroke path: the patch replaces the paragraph and hands only
+		// that block to the enrichment. The diagram is not in it, and a theme it
+		// no longer matches must not drag it into the pass.
+		const patch = patchPreviewBlocks(document.createElement('div'), '<p>x</p>');
+		await renderRichContent({
+			roots: patch.inserted,
+			libraries: libraries(draws),
+			mermaidTheme: 'neutral',
+			idFactory: (index) => `k${index}`,
+		});
+
+		expect(draws).toEqual([`dark:${SOURCE}`]);
+		expect(drawnFor(host)).toBe('dark');
+	});
+});
+
+/**
+ * The wiring, which the tests above cannot reach: `renderRichContent` now knows
+ * how to re-draw a stale diagram, but the theme effect still has to call it, in
+ * every mode and once per theme change.
+ *
+ * A source assertion, because the caller is a Svelte effect that cannot be
+ * imported. It pins today's spelling of an internal call, so a rename breaks it
+ * without breaking anything real; what it is here for is the guard, which was
+ * `markdownBody && !isEditing`. That made the whole effect — the `dataset`
+ * writes, `monaco.editor.setTheme`, and for a `vscode:` theme an
+ * `invoke('read_vscode_theme')` and a re-parse — re-run on every mode toggle
+ * and on every tab switch that changed the mode, with nothing about the theme
+ * having moved. And it excluded from the re-colour every tab in edit mode,
+ * including a split tab entered from edit mode, whose preview is on screen.
+ */
+test('the theme effect re-colours in every mode, and does not re-run on a mode change', async () => {
+	const { readSource } = await import('./sourceTree.js');
+	const viewer: string = readSource('src/lib/MarkdownViewer.svelte');
+
+	const effect = viewer.match(
+		/\t\$effect\(\(\) => \{\n\t\t\/\/ Persistence and cross-window sync[\s\S]*?\n\t\}\);/,
+	)?.[0];
+	expect(effect, 'the theme effect must still be recognisable').toBeTruthy();
+
+	// The mode is not a reason to re-apply a theme, and this is the only read
+	// that ever made it one.
+	expect(effect).not.toMatch(/isEditing/);
+	expect(effect).toMatch(
+		/const recolourDiagrams = \(\) => untrack\(\(\) => \{ if \(markdownBody\) renderRichContent\(\); \}\);/,
+	);
+
+	// Once per branch: the `vscode:` branch does not know its own appearance
+	// until `parseAndApplyVscodeTheme` has published `dataset.themeType`, which
+	// is what `currentMermaidTheme` reads.
+	expect(effect!.match(/recolourDiagrams\(\);/g)).toHaveLength(2);
+	expect(effect).toMatch(/await parseAndApplyVscodeTheme[\s\S]*?recolourDiagrams\(\);/);
+});

--- a/scripts/editorTheme.test.ts
+++ b/scripts/editorTheme.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { markdownTokenRules, semanticTokenRules } from '../src/lib/utils/editorTheme.js';
-import { readSource } from './sourceTree.js';
+import { markdownTokenRules, monacoThemeName, semanticTokenRules } from '../src/lib/utils/editorTheme.js';
+import { filesMatching, readSource, readSourceFiles } from './sourceTree.js';
 
 // The editor's Markdown colours. Two things can make a rule here do nothing at
 // all, and neither is visible to the compiler: a token name no grammar emits
@@ -141,5 +141,58 @@ test('a formula reads as markup around content, not as one flat run', () => {
 		assert.notEqual(marker?.foreground, body?.foreground, 'delimiters must not vanish into the body');
 		assert.equal(body?.foreground, byToken.get('code')?.foreground, 'a formula is code-coloured');
 		assert.equal(body?.fontStyle, 'italic');
+	}
+});
+
+// ------------------------------------------- who tells Monaco which theme it is
+
+// `monaco.editor.setTheme` is global to the page, not scoped to an editor, so
+// the last caller in a flush decides what every editor is wearing. Two callers
+// disagreed: `Editor.svelte` asked for `app-theme-*` (the rules above) and
+// `MarkdownViewer.svelte` asked for Monaco's stock `vs`/`vs-dark` from a second
+// effect over the same `settings.theme`. Svelte 5 runs a child's effects before
+// its parent's and `Editor` is the viewer's child, so the stock name won every
+// theme change and the whole palette above stopped existing until the pane was
+// re-created.
+
+test('a settings value maps to one theme name', () => {
+	assert.equal(monacoThemeName('dark', false), 'app-theme-dark');
+	assert.equal(monacoThemeName('light', true), 'app-theme-light');
+	assert.equal(monacoThemeName('system', true), 'app-theme-dark');
+	assert.equal(monacoThemeName('system', false), 'app-theme-light');
+	// The OS preference is only consulted for `system`.
+	assert.equal(monacoThemeName('dark', true), 'app-theme-dark');
+	assert.equal(monacoThemeName('light', false), 'app-theme-light');
+	// An imported theme is one Monaco theme whatever its file is called, and
+	// carries its own appearance rather than the desktop's.
+	assert.equal(monacoThemeName('vscode:Dracula', false), 'vscode-custom');
+	assert.equal(monacoThemeName('vscode:Solarized Light', true), 'vscode-custom');
+});
+
+test('the editor pane and the theme importer are the only writers', () => {
+	assert.deepEqual(filesMatching(readSourceFiles('src'), /\.editor\.setTheme\(/), [
+		// The widget's owner: it defines `app-theme-*` and it is the only thing
+		// on screen a Monaco theme can be seen on.
+		'src/lib/components/Editor.svelte',
+		// `vscode-custom` does not exist as a theme until this file has read the
+		// JSON and called `defineTheme`, so the set has to happen where the
+		// define does — `Editor.svelte`'s change effect abstains for `vscode:`.
+		'src/lib/utils/theme.ts',
+	]);
+});
+
+test('every name the seam returns is a theme somebody defines', () => {
+	const defined = [
+		readSource('src/lib/components/Editor.svelte'),
+		readSource('src/lib/utils/theme.ts'),
+	]
+		.flatMap((text) => [...text.matchAll(/\.editor\.defineTheme\(\s*["']([\w-]+)["']/g)])
+		.map((match) => match[1]);
+	const asked = ['system', 'light', 'dark', 'vscode:whatever'].map((theme) => [
+		monacoThemeName(theme, false),
+		monacoThemeName(theme, true),
+	]);
+	for (const name of new Set(asked.flat())) {
+		assert.ok(defined.includes(name), `nothing defines ${name}; Monaco would fall back to vs`);
 	}
 });

--- a/scripts/mermaidPrintTheme.test.ts
+++ b/scripts/mermaidPrintTheme.test.ts
@@ -59,7 +59,7 @@ const asElement = (element: FakeElement) => element as unknown as Element;
 
 function diagram(source: string | null, html: string) {
 	const element = new FakeElement('mermaid-diagram');
-	if (source !== null) rememberDiagramSource(asElement(element), source);
+	if (source !== null) rememberDiagramSource(asElement(element), source, 'dark');
 	element.innerHTML = html;
 	return element;
 }
@@ -196,7 +196,12 @@ test('the PDF export wraps the print render and always restores', () => {
 	// calling the same function; the assertion follows it rather than being
 	// relaxed, because "some path renders diagrams without remembering the
 	// source" is exactly the drift that deleted the markdown.ts copy.
-	assert.match(richContent, /rememberDiagramSource\(\s*\w+\s*,\s*\w+\s*\)/);
+	//
+	// The theme it was drawn with is recorded alongside it now. That is not for
+	// this path — `renderDiagramsForPrint` swaps the print rendering in and the
+	// screen one back out, and never writes the attribute — it is what lets
+	// `renderRichContent` find the diagrams a theme change left behind.
+	assert.match(richContent, /rememberDiagramSource\(\s*\w+\s*,\s*\w+\s*,[^)]*\)/);
 
 	// One theme decision, shared by the screen render and the restore. Asserted
 	// as "both options are fed the same expression" rather than as the literal

--- a/scripts/previewAnchorRestore.test.ts
+++ b/scripts/previewAnchorRestore.test.ts
@@ -512,11 +512,16 @@ test('a cold start restores again once its enrichment has landed', async () => {
 	// And the accident that used to stand in for it must not come back. The
 	// theme effect's `renderRichContent()` reads `richLibraries` before its
 	// first await, so without `untrack` that effect re-runs when the libraries
-	// land — re-enriching every open tab's host, never firing in split view,
-	// and leaving the reading position where the old layout put it.
+	// land — re-enriching every open tab's host on top of the pass below, and
+	// leaving the reading position where the old layout put it.
+	//
+	// Matched on the `untrack`, not on the guard beside it: the guard was
+	// `markdownBody && !isEditing` when this was written and is `markdownBody`
+	// alone now (scripts/diagramThemeRefresh.spec.ts owns that question). What
+	// this test is for is the tracking.
 	assert.match(
 		viewer,
-		/if \(markdownBody && !isEditing\) untrack\(\(\) => renderRichContent\(\)\);/,
+		/untrack\(\(\) => \{? ?if \(markdownBody\) renderRichContent\(\);/,
 		'the theme effect must depend on the theme, not on the libraries arriving',
 	);
 });

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -530,12 +530,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			clearVscodeTheme();
 			saveStartupAppearance(theme);
 			recolourDiagrams();
-			const monaco = (window as any).monaco;
-			if (monaco && monaco.editor) {
-				const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-				const effectiveTheme = theme === 'system' ? (isSystemDark ? 'dark' : 'light') : theme;
-				monaco.editor.setTheme(effectiveTheme === 'dark' ? 'vs-dark' : 'vs');
-			}
+			// No Monaco write here. It used to set `vs`/`vs-dark` through the
+			// `monaco` global, and because a child's effects run before its
+			// parent's it landed AFTER `Editor`'s own — stripping the editor of
+			// `app-theme-*` on every theme change. `editorTheme.ts`'s
+			// `monacoThemeName` is the one answer now, and `Editor` is the only
+			// pane that asks it; with no editor mounted there is nothing to
+			// paint, and a later mount reads the theme from the same seam.
 		} else {
 			const name = theme.replace('vscode:', '');
 			invoke('read_vscode_theme', { name }).then(async (json: any) => {

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -501,6 +501,24 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// effect is only the part that cannot: applying the theme to the document.
 		const theme = settings.theme;
 
+		// Mermaid bakes its colours into the SVG it produces, so the diagrams have
+		// to be drawn again; `renderRichContent` finds the ones drawn for another
+		// theme. No `roots`, because the whole article is what changed appearance
+		// — including the hosts of tabs that are not on screen, which the reader
+		// switches back to without anything else re-rendering them.
+		//
+		// Called from each branch rather than once at the end, because the
+		// `vscode:` branch does not know its own appearance until
+		// `parseAndApplyVscodeTheme` has published `dataset.themeType`, and that
+		// is what `currentMermaidTheme` reads. Calling here would have re-drawn
+		// every diagram in the theme being replaced.
+		//
+		// `untrack` for the reason #740 established: `renderRichContent` reads
+		// `richLibraries` before its first `await`, so a tracked call makes this
+		// effect re-run when the libraries land — duplicating the cold-start
+		// enrichment the patch effect owns, over every open tab's host.
+		const recolourDiagrams = () => untrack(() => { if (markdownBody) renderRichContent(); });
+
 		if (theme === 'system' || theme === 'light' || theme === 'dark') {
 			if (theme === 'system') {
 				delete document.documentElement.dataset.theme;
@@ -511,6 +529,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			}
 			clearVscodeTheme();
 			saveStartupAppearance(theme);
+			recolourDiagrams();
 			const monaco = (window as any).monaco;
 			if (monaco && monaco.editor) {
 				const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -524,34 +543,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				// `parseAndApplyVscodeTheme` decides dark vs. light from the theme's
 				// own `type` field and publishes it here.
 				saveStartupAppearance(document.documentElement.dataset.themeType === 'dark' ? 'dark' : 'light');
+				recolourDiagrams();
 			}).catch(e => {
 				console.error("Failed to load vscode theme", e);
 				settings.theme = 'system';
 			});
 		}
-
-		// Mermaid bakes its colours into the SVG it produces, so the diagrams have
-		// to be drawn again for the new theme; no `roots`, because the whole
-		// article is what changed appearance.
-		//
-		// `untrack` because `renderRichContent` reads `richLibraries` before its
-		// first `await`, which made this effect re-run when the libraries landed —
-		// and that accident, not anything here, was what enriched a document
-		// patched in during a cold start. It was the wrong owner three ways over:
-		// it re-enriched every open tab's host rather than the one that needed it,
-		// it did not fire at all for a tab in edit mode (the guard is
-		// `!isEditing`), and it left the reading position restored against the
-		// layout the enrichment then changed. The patch effect owns that case now.
-		//
-		// The edit-mode gap is not only about a hidden preview. `isSplit` is
-		// independent of `isEditing` — `setSplitEnabled` never touches it — so a
-		// tab split from EDIT mode has both flags set, and its preview is on
-		// screen next to the editor while this guard excludes it. A restored
-		// session in that shape showed raw LaTeX and `<pre>` diagram source with
-		// nothing scheduled to fix it. Split from READING mode leaves `isEditing`
-		// false and did reach this line, which is why the gap was only ever half
-		// of split view and took a while to see.
-		if (markdownBody && !isEditing) untrack(() => renderRichContent());
 	});
 
 	// ui state

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -15,7 +15,7 @@
 	import { blockEnter, parseListItem, shiftListItem, type ListEdit } from '../utils/listEditing.js';
 	import { tableOperation, tableStep, type TableEdit, type TableOperation } from '../utils/tableEditing.js';
 	import { editorOptionsFromSettings } from '../utils/editorOptions.js';
-	import { markdownTokenRules, semanticTokenRules } from '../utils/editorTheme.js';
+	import { markdownTokenRules, monacoThemeName, semanticTokenRules } from '../utils/editorTheme.js';
 	import { createMarkdownSemanticTokensProvider } from '../utils/semanticTokens.js';
 	import { getTabModel, lineEndingLabel, tabModelUri } from '../utils/tabModels.js';
 	import { installVimScrollCommands } from '../utils/vimScrollCommands.js';
@@ -335,15 +335,11 @@
 		// active when this component was created.
 		currentTabId = tabManager.activeTabId;
 
-		const getTheme = () => {
-			if (theme && theme.startsWith("vscode:")) return "vscode-custom";
-			if (theme === "system") {
-				return window.matchMedia("(prefers-color-scheme: dark)").matches
-					? "app-theme-dark"
-					: "app-theme-light";
-			}
-			return theme === "dark" ? "app-theme-dark" : "app-theme-light";
-		};
+		const getTheme = () =>
+			monacoThemeName(
+				theme,
+				window.matchMedia("(prefers-color-scheme: dark)").matches,
+			);
 
 		// The editor is a VIEW; the document it shows is the active tab's model.
 		// Passing `model` rather than `value`/`language` also settles ownership:
@@ -2226,18 +2222,23 @@
 	});
 
 
+	// The only place a theme CHANGE reaches Monaco. `setTheme` is global to the
+	// page rather than per-editor, so a second effect writing it from anywhere
+	// else is not a redundancy, it is a coin toss — see `monacoThemeName`.
+	//
+	// `vscode:` is the one theme this pane cannot ask for on a change: its rules
+	// are read off disk, so it does not exist as a Monaco theme until
+	// `parseAndApplyVscodeTheme` has defined it, and asking for an undefined
+	// name gets `vs`. That function sets it itself the moment it can.
 	$effect(() => {
 		if (editorReady && editor && theme) {
 			if (theme.startsWith("vscode:")) return;
-			const targetTheme =
-				theme === "system"
-					? window.matchMedia("(prefers-color-scheme: dark)").matches
-						? "app-theme-dark"
-						: "app-theme-light"
-					: theme === "dark"
-						? "app-theme-dark"
-						: "app-theme-light";
-			monaco.editor.setTheme(targetTheme);
+			monaco.editor.setTheme(
+				monacoThemeName(
+					theme,
+					window.matchMedia("(prefers-color-scheme: dark)").matches,
+				),
+			);
 		}
 	});
 

--- a/src/lib/utils/editorTheme.ts
+++ b/src/lib/utils/editorTheme.ts
@@ -179,3 +179,36 @@ export function semanticTokenRules(appearance: 'light' | 'dark'): EditorTokenRul
 		fontStyle ? { token, foreground: palette[role], fontStyle } : { token, foreground: palette[role] },
 	);
 }
+
+/**
+ * The name of the Monaco theme a settings value asks for.
+ *
+ * `monaco.editor.setTheme` is a MODULE-GLOBAL switch — there is one current
+ * theme for the whole page, not one per editor — so "which theme is the editor
+ * wearing" has exactly one answer, and the app used to hold two. `Editor.svelte`
+ * set `app-theme-dark`/`app-theme-light` (this file's rules, plus the semantic
+ * layer's) while `MarkdownViewer.svelte` set Monaco's stock `vs-dark`/`vs` from
+ * a second effect over the same `settings.theme`. In Svelte 5 a child's effects
+ * run before its parent's, and `Editor` is the viewer's child, so the stock
+ * name landed last and won: after any theme change the editor was painted by
+ * `vs`/`vs-dark`, which is precisely the state the top of this file exists to
+ * describe as the defect — every heading, list marker and table pipe back to
+ * one blue `keyword`, links and rules back to no colour, and the semantic layer
+ * matching nothing at all.
+ *
+ * So the decision lives here, once, and the viewer no longer makes it. Callers
+ * pass the system preference rather than reading `matchMedia` here because this
+ * has to stay a pure function the tests can drive both ways.
+ *
+ * `vscode:` is named but not owned: that theme's rules come out of a file on
+ * disk, so `utils/theme.ts` is the only place that can `defineTheme` it, and
+ * `setTheme` on a name Monaco has never been given silently falls back to `vs`.
+ * The editor therefore asks for `vscode-custom` only where the definition is
+ * already guaranteed — at creation, and on a `prefers-color-scheme` change —
+ * and leaves the theme-change write to whoever did the defining.
+ */
+export function monacoThemeName(theme: string, systemPrefersDark: boolean): string {
+	if (theme.startsWith('vscode:')) return 'vscode-custom';
+	const dark = theme === 'system' ? systemPrefersDark : theme === 'dark';
+	return dark ? 'app-theme-dark' : 'app-theme-light';
+}

--- a/src/lib/utils/mermaidPrint.ts
+++ b/src/lib/utils/mermaidPrint.ts
@@ -20,6 +20,21 @@
 
 const SOURCE_ATTR = 'data-mermaid-source';
 
+/**
+ * The Mermaid theme the SVG on the container was drawn with.
+ *
+ * Kept next to the source because the colours are IN that SVG, so "is this
+ * diagram current" is a question about the drawing and not about the document.
+ * `renderRichContent` re-draws the containers whose answer no longer matches
+ * the theme it was asked for; without it a theme change reached no diagram at
+ * all, because a drawn diagram no longer has the `<pre>` that pass looks for.
+ *
+ * `renderDiagramsForPrint` deliberately does not write it: it swaps the print
+ * rendering in and the screen rendering back out again, and the attribute goes
+ * on describing what the container ends up holding.
+ */
+const THEME_ATTR = 'data-mermaid-theme';
+
 const MERMAID_PRINT_THEME = 'neutral';
 
 export interface MermaidConfig {
@@ -70,13 +85,18 @@ export function resolveMermaidTheme(input: {
 	return isDark ? 'dark' : 'neutral';
 }
 
-/** Keeps the source next to the rendered diagram so it can be rebuilt later. */
-export function rememberDiagramSource(container: Element, source: string) {
+/** Keeps the source and the theme next to the rendered diagram so it can be rebuilt later. */
+export function rememberDiagramSource(container: Element, source: string, theme: string) {
 	container.setAttribute(SOURCE_ATTR, source);
+	container.setAttribute(THEME_ATTR, theme);
 }
 
 export function readDiagramSource(container: Element): string | null {
 	return container.getAttribute(SOURCE_ATTR);
+}
+
+export function readDiagramTheme(container: Element): string | null {
+	return container.getAttribute(THEME_ATTR);
 }
 
 export function findRestorableDiagrams(root: ParentNode): Element[] {

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -5,7 +5,12 @@ import {
 	storeDiagramTemplate,
 	templateDiagramSvg,
 } from './diagramCache.js';
-import { mermaidConfig, rememberDiagramSource } from './mermaidPrint.js';
+import {
+	mermaidConfig,
+	readDiagramSource,
+	readDiagramTheme,
+	rememberDiagramSource,
+} from './mermaidPrint.js';
 import { highlightedCode, renderedMath } from './richContentCache.js';
 
 /**
@@ -227,6 +232,52 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 
 	const codeBlocks = roots.flatMap((root) => selfAndDescendants(root, 'pre code'));
 
+	/**
+	 * Diagrams already on screen that were drawn for a different theme.
+	 *
+	 * Mermaid bakes its colours into the SVG, so a theme change has to draw them
+	 * again — and until this existed, nothing did. The loop below finds diagrams
+	 * by `pre code`, and a diagram that has been drawn once has no `<pre>` left:
+	 * this function replaced it with the `.mermaid-diagram` container. While the
+	 * preview was `{@html sanitizedHtml}` that was invisible, because every
+	 * render put the whole document back as source; `blockPatch.ts` keeps the
+	 * enriched nodes instead, so from #632 on a theme change reached no diagram
+	 * at all, in any mode. The source is on the container already —
+	 * `mermaidPrint.ts` keeps it there so the PDF path can rebuild the diagram
+	 * with a light theme — and the theme it was drawn for is kept beside it.
+	 *
+	 * Collected BEFORE the loop, so the containers the loop is about to build
+	 * are not scanned as if they were stale. On the keystroke path the roots are
+	 * the blocks the patch just inserted, which are freshly parsed markup with
+	 * no rendered diagram in them, so this is one selector that matches nothing.
+	 *
+	 * What a theme change costs, measured in Chromium over the real pipeline
+	 * (comrak -> `processMarkdownHtml` -> `sanitizeMarkdownHtml` -> `blockPatch`
+	 * -> here) in a 1000x800 preview box, as one whole-article
+	 * `renderRichContent` with highlight.js and the display-maths memo already
+	 * warm, two runs:
+	 *
+	 *                                 diagrams   theme moved   theme unchanged
+	 *     samples/katex-stress.md            0    8.6-10.6ms       11.9-12.2ms
+	 *     samples/markdown-syntax.md         4   61.2-76.1ms         2.6-3.0ms
+	 *     samples/stress-test.md             3  107.5-121.2ms      12.5-12.8ms
+	 *
+	 * So the diagrams are the whole of it: katex-stress has none and its two
+	 * columns are the same number, which is `renderMathInElement` scanning a
+	 * document with no memo behind it. Toggling back to a theme the diagram
+	 * cache has already seen costs 9.8-30.1ms rather than the figures above.
+	 * The right-hand column is what a mode toggle used to pay for nothing —
+	 * the theme effect re-ran on every one of them, drawing no diagram because
+	 * it could not find any.
+	 */
+	const staleDiagrams = roots
+		.flatMap((root) => selfAndDescendants(root, '.mermaid-diagram'))
+		.filter(
+			(container) =>
+				readDiagramSource(container) !== null &&
+				readDiagramTheme(container) !== options.mermaidTheme,
+		);
+
 	// The config itself lives in `mermaidPrint.ts` — `initialize` replaces the
 	// site config rather than merging into it, so the two callers that write to
 	// this singleton have to send the same keys or the last one wins. See
@@ -241,11 +292,46 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 	// diagram on paper and configures it back, so a remembered theme here would
 	// be a claim about a global another module also writes to.
 	const hasDiagram = codeBlocks.some((block) => block.classList.contains('language-mermaid'));
-	if (hasDiagram) {
+	if (hasDiagram || staleDiagrams.length > 0) {
 		mermaid.initialize(mermaidConfig(options.mermaidTheme));
 	}
 
 	let diagramIndex = 0;
+
+	/**
+	 * The drawing itself, shared by the two callers below so a re-coloured
+	 * diagram is memoised, sanitized and identified exactly like a fresh one.
+	 *
+	 * The cache holds a *template* rather than the SVG: the id is stamped into
+	 * it, so a reused diagram is as uniquely identified as a fresh one. See
+	 * `diagramCache.ts` for why that is the whole difficulty.
+	 */
+	const drawDiagram = async (source: string, svgId: string): Promise<string> => {
+		const cached = lookupDiagramTemplate(source, options.mermaidTheme);
+		if (cached !== null) return fillDiagramTemplate(cached, svgId);
+		const { svg } = await mermaid.render(svgId, source);
+		// A source that contains the render id would have its own text rewritten
+		// by the substitution, so that one is left uncached.
+		if (!source.includes(svgId)) {
+			const template = templateDiagramSvg(svg, svgId);
+			if (template !== null) storeDiagramTemplate(source, options.mermaidTheme, template);
+		}
+		return svg;
+	};
+
+	for (const container of staleDiagrams) {
+		const source = readDiagramSource(container) as string;
+		try {
+			container.innerHTML = sanitizeDiagramSvg(await drawDiagram(source, idFactory(diagramIndex++)));
+			rememberDiagramSource(container, source, options.mermaidTheme);
+		} catch (error) {
+			// A diagram that fails to draw keeps the rendering it has. A diagram
+			// in the previous theme's colours still beats an empty box, which is
+			// the same call `renderDiagramsForPrint` makes.
+			options.onError?.(error);
+			console.error('Failed to re-render Mermaid diagram for the new theme:', error);
+		}
+	}
 	for (const block of codeBlocks) {
 		const codeEl = block as HTMLElement;
 		const preEl = codeEl.parentElement as HTMLPreElement;
@@ -253,33 +339,14 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 		if (codeEl.classList.contains('language-mermaid')) {
 			const mermaidCode = codeEl.textContent || '';
 			try {
-				// The preview re-renders the whole article roughly once per keystroke
-				// and `{@html}` puts every diagram's source back, so drawing is the
-				// one step worth remembering between passes. The cache holds a
-				// *template* rather than the SVG: the id below is stamped into it, so
-				// a reused diagram is as uniquely identified as a fresh one. See
-				// `diagramCache.ts` for why that is the whole difficulty.
-				const svgId = idFactory(diagramIndex++);
-				const cached = lookupDiagramTemplate(mermaidCode, options.mermaidTheme);
-				let svg: string;
-				if (cached !== null) {
-					svg = fillDiagramTemplate(cached, svgId);
-				} else {
-					svg = (await mermaid.render(svgId, mermaidCode)).svg;
-					// A source that contains the render id would have its own text
-					// rewritten by the substitution, so that one is left uncached.
-					if (!mermaidCode.includes(svgId)) {
-						const template = templateDiagramSvg(svg, svgId);
-						if (template !== null) storeDiagramTemplate(mermaidCode, options.mermaidTheme, template);
-					}
-				}
+				const svg = await drawDiagram(mermaidCode, idFactory(diagramIndex++));
 
 				const container = doc.createElement('div');
 				container.className = 'mermaid-diagram';
 				carrySourcepos(preEl, container);
 				// Kept so the PDF path can rebuild the diagram with a light theme
 				// instead of recolouring Mermaid's output.
-				rememberDiagramSource(container, mermaidCode);
+				rememberDiagramSource(container, mermaidCode, options.mermaidTheme);
 				container.innerHTML = sanitizeDiagramSvg(svg);
 				preEl.replaceWith(container);
 			} catch (error) {


### PR DESCRIPTION
**Base is `master`.** Administrative: this is #741, already reviewed and merged,
but into `perf/rich-content-anchor-drift` rather than into `master`, because that
branch was its base while #740 was open. #740 was squash-merged to `master`,
which closed the branch's own PR and left this sitting where nothing points at
it. Cherry-picked onto `master`; the commit below is the same one. Same thing
happened to #732-#735 earlier in this series (#737).

Rebasing the branch instead does not work: #740's own commit conflicts against
its squash on `master`, which is the same content under a different SHA.

## What is in here

A theme change never re-drew a Mermaid diagram, in any mode, for any theme, and
had not since #632.

`renderRichContent` finds diagrams with `selfAndDescendants(root, 'pre code')`,
and a diagram that has been drawn once has no `<pre>` left — that same function
replaced it with `<div class="mermaid-diagram">`. While the preview was
`{@html sanitizedHtml}` this was invisible, because every render put the whole
document back as source and the diagram was rebuilt from scratch. `blockPatch.ts`
keeps the enriched nodes instead, so from #632 on the theme change reached
nothing. Mermaid bakes its colours into the SVG, so a dark diagram stayed dark on
a light page indefinitely.

The source was already on the container — `mermaidPrint.ts` keeps it there so the
PDF path can rebuild the diagram light — so the theme it was drawn for is kept
beside it, and `renderRichContent` now collects the containers whose theme no
longer matches and re-draws them through a `drawDiagram` both paths share. The
collection runs before the `pre code` loop so the containers that loop is about
to build are not scanned as stale.

The viewer's theme effect also stopped depending on `isEditing`. It was a tracked
read, so every ⌘E and every mode-changing tab switch re-ran the whole theme block
— `dataset` writes, `clearVscodeTheme`, `saveStartupAppearance`,
`monaco.editor.setTheme`, and for a `vscode:` theme an `invoke('read_vscode_theme')`
round trip plus a re-parse — to draw no diagram at all. `git log -S` puts that
guard at 06380bc, where enrichment was a whole-document pass on every render and
the preview was hidden in edit mode: it was protecting something real then. Its
sibling lost the guard when the patch effect was built; this copy was never
revisited.

Measured in Chromium over the real pipeline, one whole-article pass with the
other memos warm, two runs:

```
                             diagrams   theme moved   theme unchanged
samples/katex-stress.md            0    8.6-10.6ms       11.9-12.2ms
samples/markdown-syntax.md         4   61.2-76.1ms         2.6-3.0ms
samples/stress-test.md             3  107.5-121.2ms      12.5-12.8ms
```

The diagrams are the whole cost; katex-stress has none and its two columns agree.
The right-hand column is what a mode toggle used to pay to draw nothing.

## Tests

`scripts/diagramThemeRefresh.spec.ts` drives `renderRichContent` twice against a
recording Mermaid stand-in — a behaviour test, not a source assertion. Reverting
the re-draw with the tests kept turns 4 of its 5 red.

Two assertions from #740 went red on this change and were updated rather than
relaxed: `mermaidPrintTheme.test.ts` pinned `rememberDiagramSource`'s arity and
`previewAnchorRestore.test.ts` pinned a whole guard line when what it is for is
the `untrack`. That is the "pins today's spelling" weakness #740's own body
called out, arriving one PR later.

## Verification

```
npm audit            0 vulnerabilities
npm run check        828 files, 0 errors, 0 warnings
npm test             1022 pass, 0 fail
npm run test:vitest  434 pass, 0 fail
cargo test           164 pass, 0 fail
```

Re-run after the cherry-pick. The app cannot be run here: worth toggling
light/dark with a document containing a Mermaid diagram open before this lands.
