### PR TITLE
mhchem registers on the KaTeX the preview renders with

### DIFF
--- a/scripts/katexContribFlavour.test.ts
+++ b/scripts/katexContribFlavour.test.ts
@@ -1,0 +1,19 @@
+/**
+ * KaTeX publishes every contrib file twice: `contrib/*.mjs` behind the
+ * `import` condition, `contrib/*.js` (CommonJS, `require("katex")`) behind
+ * `require`. Only the `.mjs` shares the preview's KaTeX instance; the `.js`
+ * gets the bundler's CommonJS copy, and a macro mhchem registers there never
+ * reaches `renderToString` (#745). vitest and node both dedupe the two, so the
+ * only runtime that shows the split is a production build — which is why this
+ * is asserted on the source: the loader may not name the CommonJS flavour.
+ */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.ts';
+
+test('the rich-content loader imports KaTeX contribs through the exports map', () => {
+	const source = readSource('src/lib/utils/richContent.ts');
+	assert.doesNotMatch(source, /import\('katex\/dist\/contrib\//);
+	assert.match(source, /import\('katex\/contrib\/mhchem'\)/);
+});

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,3 +1,3 @@
-declare module 'katex/dist/contrib/auto-render.js';
-declare module 'katex/dist/contrib/mhchem.js';
+declare module 'katex/contrib/auto-render';
+declare module 'katex/contrib/mhchem';
 declare module 'highlightjs-svelte';

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -90,8 +90,6 @@ export function loadRichContentLibraries(): Promise<RichContentLibraries> {
 		}
 
 		const katex = (katexMainModule as any).default;
-		// mhchem is a KaTeX extension that binds to the global.
-		(window as any).katex = katex;
 
 		// `copy-tex` used to be loaded here too. It installs its own document
 		// `copy` listener, which fires only when the selection contains math and
@@ -100,9 +98,17 @@ export function loadRichContentLibraries(): Promise<RichContentLibraries> {
 		// Its two worthwhile behaviours, whole-formula expansion and TeX as the
 		// plain text, are implemented in `utils/previewCopy.ts` instead, where
 		// they apply to one copy path rather than a second one.
+		// The bare `katex/contrib/…` subpaths, not `katex/dist/contrib/….js`:
+		// KaTeX publishes every file twice, `.mjs` behind the `import` condition
+		// and `.js` (CommonJS, `require("katex")`) behind `require`. Ask for the
+		// `.js` and the bundler hands it the CommonJS copy of KaTeX — a second
+		// parser with its own macro table — so mhchem registered `\ce` on a
+		// KaTeX the preview never calls, and `$$\ce{…}$$` came out as a parse
+		// error (#745). The subpath resolves to the `.mjs`, which imports
+		// `../katex.mjs`: the same module `import('katex')` above returned.
 		const [autoRenderModule] = await Promise.all([
-			import('katex/dist/contrib/auto-render.js'),
-			import('katex/dist/contrib/mhchem.js'),
+			import('katex/contrib/auto-render'),
+			import('katex/contrib/mhchem'),
 		]);
 
 		return {


### PR DESCRIPTION
## What this is

Closes #745. `$$\ce{2H2 + O2 -> 2H2O}$$` rendered as a red parse error, "Undefined control sequence: \ce", although mhchem has been loaded since #411. The screenshot in the issue is that error, not raw text. A second commit fixes what showed up once `\ce` worked: the label on `->[燃烧]` had its top clipped.

## Mechanism

**Two copies of KaTeX.** KaTeX publishes every file twice: `dist/katex.mjs` behind the `import` condition and `dist/katex.js` (CommonJS) behind `require`, and the contrib files come in both flavours. The loader asked for `katex/dist/contrib/mhchem.js` — the CommonJS one, which does `require("katex")` — so the production bundle carried two copies of KaTeX 0.18.4. `import('katex')` gave the preview the ESM copy; mhchem registered `\ce` on the CommonJS copy. Display math goes through `katex.renderToString` on the preview's copy and never saw the macro. Inline `\(\ce{…}\)` happened to work because auto-render, loaded the same way, ran on the copy mhchem had patched.

Counted in `build/_app/immutable/chunks` before and after:

| | before | after |
|---|---|---|
| chunks containing KaTeX 0.18.4 | 2 | 1 |
| KaTeX the mhchem chunk imports | the CommonJS copy | the chunk the preview imports |

The fix is the bare `katex/contrib/mhchem` and `katex/contrib/auto-render` subpaths: the exports map resolves them to the `.mjs`, which imports `../katex.mjs`. `window.katex` is dropped with it — it existed only for the CommonJS build's global fallback and nothing else read it. One copy of KaTeX 0.16.47 remains: mermaid's own nested dependency, untouched.

**The clipped label.** `.katex-display` sets `overflow-y: hidden` so a wide formula's horizontal scrollbar does not bring a vertical one, and hidden overflow clips at the padding edge. KaTeX sizes the block from its own font metrics and has none for CJK, so the label in `->[燃烧]` — set in the fallback font — drew taller than the box and lost its top. The block now carries `0.4em` of vertical padding as headroom, and the margin drops from `1.5em` to `1.1em`, so the distance to the neighbouring blocks is unchanged.

## Scope

No change to the math pipeline, the delimiters or the renderer options. The test is a source assertion, deliberately: vitest and node both dedupe the two copies, so the split is visible only in a production build. `scripts/katexContribFlavour.test.ts` fails on master and passes here. The padding has no test — a layout fact, checked on a build.

## Verification

```
npm run check       831 files, 0 errors
npm test            1029 pass
npm run test:vitest 434 pass
vite build          one KaTeX 0.18.4 chunk, imported by both the preview and mhchem
```

On a macOS build: both display formulas from the issue render, the arrow label is whole. The clipping was seen on the build before the second commit and is gone after it.