### PR TITLE
The label on an mhchem arrow is no longer clipped

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -176,7 +176,14 @@ body {
 
 /* KaTeX Adjustment */
 .katex-display {
-	margin: 1.5em 0 !important;
+	/* `overflow-y: hidden` keeps a wide formula's horizontal scrollbar from
+	   bringing a vertical one, but it also clips at the padding edge. KaTeX
+	   sizes the block from its own font metrics, and a glyph it has no metrics
+	   for — the CJK label on an mhchem arrow, `->[燃烧]` — draws taller than
+	   the box, so its top was cut off. The padding is that headroom; the margin
+	   gives it back, so the block still sits 1.5em from its neighbours. */
+	margin: 1.1em 0 !important;
+	padding: 0.4em 0;
 	overflow-x: auto;
 	overflow-y: hidden;
 	text-align: center;


### PR DESCRIPTION
## What this is

Follow-up to #747, which I pushed to that branch after it had been merged, so it never landed. Once `\ce` rendered, the reporter's second example `\ce{CH4 + 2O2 ->[燃烧] CO2 + 2H2O}` showed the label above the arrow with its top cut off (seen by @PathGao on a build; ref #745).

## Mechanism

`.katex-display` sets `overflow-y: hidden` so a wide formula's horizontal scrollbar does not bring a vertical one, and hidden overflow clips at the padding edge. KaTeX sizes the block from its own font metrics and has none for CJK, so a CJK label is set in the fallback font and draws taller than the box. The block now carries `0.4em` of vertical padding as headroom, and the margin drops from `1.5em` to `1.1em`, so the distance to the neighbouring blocks is unchanged.

## Scope

One CSS rule. No test — a layout fact, checked on a build: clipped on the build before this change, whole after it.

## Verification

```
npm run check       831 files, 0 errors
```