### PR TITLE
fix(windows): let Explorer offer Markpad in "Open with"

### DIFF
--- a/scripts/nsisInstallerHooks.test.ts
+++ b/scripts/nsisInstallerHooks.test.ts
@@ -99,3 +99,64 @@ test('installer hooks write through the install-mode hive, not a hardcoded one',
 			`${[...new Set(hardcoded)].join('/')}.`
 	);
 });
+
+// `.md`'s default value is not what decides which app opens a Markdown file:
+// since Windows 8 an existing `.md\UserChoice` outranks it, and no installer is
+// allowed to write UserChoice. When that happens the user's only way back is
+// Explorer's Open With dialog, which reads `OpenWithProgids` on the extension
+// and `Software\Classes\Applications\<exe>\SupportedTypes` -- neither of which
+// APP_ASSOCIATE writes. #756 is what that looks like from the outside: Markpad
+// is not the default and cannot be picked as one either.
+//
+// The hook fills that gap, and it has to name both the ProgID and the
+// extensions as literals, because the bundler exports neither as a define. This
+// pins them to the config the template actually expands.
+test('the hook offers every associated extension to the Open With dialog', () => {
+	if (installerHooks === undefined) return;
+	// A `;` comment quoting a key would satisfy any of the assertions below.
+	const hooks = readSource(`src-tauri/${installerHooks}`)
+		.replace(/^[ \t]*[;#].*$/gm, '')
+		.replace(/[ \t];.*$/gm, '');
+
+	const associations = (
+		config as unknown as { bundle: { fileAssociations?: Array<{ ext: string[]; name?: string }> } }
+	).bundle.fileAssociations;
+	if (associations === undefined) return;
+
+	for (const association of associations) {
+		// The template expands `{{or association.name ext}}` into the
+		// APP_ASSOCIATE FILECLASS argument, so this is the ProgID it creates.
+		const progId = association.name ?? association.ext[0];
+		assert.match(
+			hooks,
+			new RegExp(`!define\\s+MARKPAD_PROGID\\s+"${progId}"`),
+			`hooks.nsi must define MARKPAD_PROGID as ${JSON.stringify(progId)}, the ProgID the bundler ` +
+				'template derives from bundle.fileAssociations[].name. A mismatch registers an Open With ' +
+				'entry pointing at a ProgID that does not exist.'
+		);
+
+		for (const ext of association.ext) {
+			assert.match(
+				hooks,
+				new RegExp(
+					`WriteRegStr\\s+SHCTX\\s+"Software\\\\Classes\\\\\\.${ext}\\\\OpenWithProgids"\\s+"\\$\\{MARKPAD_PROGID\\}"`
+				),
+				`.${ext} is in bundle.fileAssociations but hooks.nsi never adds it to OpenWithProgids, ` +
+					'so Markpad stays out of the Open With dialog for it.'
+			);
+			assert.match(
+				hooks,
+				new RegExp(`SupportedTypes"\\s+"\\.${ext}"`),
+				`.${ext} is in bundle.fileAssociations but is missing from the Applications SupportedTypes ` +
+					'entry, which is what filters Markpad into the dialog for a given extension.'
+			);
+			assert.match(
+				hooks,
+				new RegExp(
+					`DeleteRegValue\\s+SHCTX\\s+"Software\\\\Classes\\\\\\.${ext}\\\\OpenWithProgids"\\s+"\\$\\{MARKPAD_PROGID\\}"`
+				),
+				`hooks.nsi adds .${ext} to OpenWithProgids on install but never removes it on uninstall.`
+			);
+		}
+	}
+});

--- a/src-tauri/hooks.nsi
+++ b/src-tauri/hooks.nsi
@@ -38,12 +38,69 @@
   Pop $0
 !macroend
 
+; The ProgID the bundler template registers `.md` and `.markdown` under. It is
+; `bundle.fileAssociations[].name` from tauri.conf.json verbatim -- the template
+; expands `{{or association.name ext}}` into the APP_ASSOCIATE FILECLASS
+; argument -- and nothing in the build exports it as a define, so it is repeated
+; here. scripts/nsisInstallerHooks.test.ts fails if the two ever disagree.
+!define MARKPAD_PROGID "Markdown File"
+
+; Make Markpad selectable from Explorer's "Open with" list (#756).
+;
+; APP_ASSOCIATE writes one thing: `.md`'s default value, meaning "Markpad is the
+; handler for .md". Since Windows 8 that value is not the handler -- an existing
+; `.md\UserChoice`, written by the shell when the user or another installer last
+; picked something, wins over it, and no installer may write UserChoice itself.
+; So on a machine that already had a Markdown handler the association silently
+; loses, which is the whole of what the reporter sees.
+;
+; The way back is the Open With dialog, and that dialog does not enumerate
+; default-value handlers. It reads `OpenWithProgids` on the extension and
+; `Software\Classes\Applications\<exe>` entries carrying a matching
+; SupportedTypes. The template writes neither, so Markpad appears in that list
+; only while it already is the default -- exactly when it is not needed. These
+; four keys are what put it there in the case that matters.
+;
+; SupportedTypes is what filters the Applications entry into the list for a
+; given extension; FriendlyAppName is the label, without which the row reads
+; "Markpad.exe".
+!macro MARKPAD_REGISTER_OPEN_WITH
+  WriteRegStr SHCTX "Software\Classes\Applications\${MAINBINARYNAME}.exe" "FriendlyAppName" "${PRODUCTNAME}"
+  WriteRegStr SHCTX "Software\Classes\Applications\${MAINBINARYNAME}.exe\shell\open\command" "" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"%1$\""
+  WriteRegStr SHCTX "Software\Classes\Applications\${MAINBINARYNAME}.exe\SupportedTypes" ".md" ""
+  WriteRegStr SHCTX "Software\Classes\Applications\${MAINBINARYNAME}.exe\SupportedTypes" ".markdown" ""
+  WriteRegStr SHCTX "Software\Classes\.md\OpenWithProgids" "${MARKPAD_PROGID}" ""
+  WriteRegStr SHCTX "Software\Classes\.markdown\OpenWithProgids" "${MARKPAD_PROGID}" ""
+!macroend
+
+; And hand them back. The Applications key is addressed by executable *name*,
+; not path, so a portable copy the user pointed Explorer at by hand owns the
+; same key -- deleting it outright would take that association down with this
+; install. Matching the command against $INSTDIR first is what the template
+; already does for deep links, and it is the same rule #255 asked for.
+;
+; The OpenWithProgids values name ${MARKPAD_PROGID}, a ProgID APP_UNASSOCIATE
+; has just deleted, so they point at nothing by the time this runs either way.
+!macro MARKPAD_UNREGISTER_OPEN_WITH
+  Push $0
+  ReadRegStr $0 SHCTX "Software\Classes\Applications\${MAINBINARYNAME}.exe\shell\open\command" ""
+  ${If} $0 == "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"%1$\""
+    DeleteRegKey SHCTX "Software\Classes\Applications\${MAINBINARYNAME}.exe"
+  ${EndIf}
+  Pop $0
+  DeleteRegValue SHCTX "Software\Classes\.md\OpenWithProgids" "${MARKPAD_PROGID}"
+  DeleteRegValue SHCTX "Software\Classes\.markdown\OpenWithProgids" "${MARKPAD_PROGID}"
+!macroend
+
 !macro NSIS_HOOK_POSTINSTALL
+  !insertmacro MARKPAD_REGISTER_OPEN_WITH
+
   ; The template registers the file associations through FileAssociation.nsh but
   ; never inserts that header's own UPDATEFILEASSOC, so Explorer can go on
   ; serving the previous handler and icon for `.md` until the next logon.
   ; Broadcasting SHCNE_ASSOCCHANGED (0x08000000) with SHCNF_IDLIST (0) and two
-  ; null items is the documented way to tell it to re-read them.
+  ; null items is the documented way to tell it to re-read them. It covers the
+  ; keys above too.
   System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
 
   ; Section Install has already written the good value into SHCTX by the time
@@ -53,6 +110,8 @@
 !macroend
 
 !macro NSIS_HOOK_POSTUNINSTALL
+  !insertmacro MARKPAD_UNREGISTER_OPEN_WITH
+
   ; And again once APP_UNASSOCIATE has handed `.md` back.
   System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
 !macroend


### PR DESCRIPTION
## What this is

Windows install now registers Markpad in Explorer's *Open with* list for `.md` and `.markdown`, not only as their default handler. Reported by @dvukovic in #756.

## Mechanism

`APP_ASSOCIATE` in the bundler template writes one thing: the extension's default value. Since Windows 8 that value loses to `.md\UserChoice`, written by the shell when a user or another installer last picked a handler, and no installer is permitted to write UserChoice itself. On a machine that already had a Markdown handler, the association is ignored in silence.

The supported way back is the Open With dialog, and it does not enumerate default-value handlers. It reads `OpenWithProgids` on the extension and `Software\Classes\Applications\<exe>` entries carrying a matching `SupportedTypes`. The template writes neither, so Markpad appears in that dialog only while it already is the default — precisely when it doesn't need to. Both doors shut at once, which is the report.

The hook writes those keys through SHCTX so they follow `installMode`, same as the rest of the installer.

## Scope

Uninstall matches the command string against `$INSTDIR` before deleting the `Applications\Markpad.exe` key. That key is addressed by executable *name*, not path, so a portable copy the user pointed Explorer at by hand owns the same key; deleting it outright would take that association down with this install (#255).

`Refs #756` rather than `Closes`: the reporter hasn't said yet whether he installed `-setup.exe` or the portable `x64.exe`. If it was the portable build, nothing registered anything on his machine and this doesn't reach him.

The ProgID is repeated as a literal in `hooks.nsi` because the bundler exports no define for it. The test below is what keeps it equal to `bundle.fileAssociations[].name`.

## Tests

`scripts/nsisInstallerHooks.test.ts` gains one test. It matches source text, so the anchors are the config contract, not a call site: the ProgID literal against `bundle.fileAssociations[].name`, and one install-side plus one uninstall-side registry write per extension in that array. Adding an extension to the config without adding it to the hook goes red.

NSIS comments are stripped before matching — a `;` line quoting a key would otherwise satisfy every assertion.

Five mutations, each red: ProgID typo; `.markdown` `OpenWithProgids` write deleted; `SupportedTypes` naming the wrong extension; `.md` uninstall cleanup deleted; the `.md` write commented out.

## Verification

macOS 15.6, Node 24.16.

```
npm run check
```
```
npm test
```

831 files, 0 errors. 1030/1030 tests.

Not verified: `makensis` cannot run here, so the macro is compiled for the first time in the Windows build leg. No Rust changed and `cargo test` was not run. Nobody has yet confirmed the four keys land as intended on a real Windows 11 install — the behaviour is from the documented Open With sources, not from a run.

## Refs

- #756
- #255
