### PR TITLE
An in-app update reviews unsaved tabs and writes the session before it installs

### DIFF
--- a/scripts/packageManagedUpdate.test.ts
+++ b/scripts/packageManagedUpdate.test.ts
@@ -19,7 +19,7 @@ test('the updater asks whether it can install before it checks', () => {
 	// The whole defect is a sequence: check first, discover the impossibility
 	// second. Asserting that both calls exist would pass on the broken order,
 	// so the assertion is where they sit relative to each other.
-	const runCheck = sliceBetween(store, 'async runCheck()', 'async startDownload()');
+	const runCheck = sliceBetween(store, 'async runCheck()', 'async startDownload(');
 	const gate = runCheck.indexOf("invoke<boolean>('self_update_supported')");
 	const checkCall = runCheck.indexOf('await check()');
 	assert.ok(gate !== -1, 'runCheck must ask self_update_supported');

--- a/scripts/updateSettlesBeforeInstall.spec.ts
+++ b/scripts/updateSettlesBeforeInstall.spec.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+
+import { test, vi } from 'vitest';
+
+// #761. An install ends the process without closing the window — the Windows
+// updater exits inside `downloadAndInstall`, `relaunch()` requests an exit
+// elsewhere — so CloseRequested never fires and nothing reviews unsaved tabs or
+// writes the restore snapshot unless the store asks for it first.
+const { log } = vi.hoisted(() => ({ log: [] as string[] }));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: async () => true }));
+vi.mock('@tauri-apps/api/app', () => ({ getVersion: async () => '2.7.6' }));
+vi.mock('@tauri-apps/plugin-updater', () => ({
+	check: async () => ({ version: '2.7.7', body: '', downloadAndInstall: async () => void log.push('install') }),
+}));
+vi.mock('@tauri-apps/plugin-process', () => ({
+	relaunch: async () => {
+		log.push('relaunch');
+		// A real relaunch never returns. Failing here puts the store in a phase
+		// `close()` can leave, so the next test starts from a clean offer.
+		throw new Error('no process to restart');
+	},
+}));
+
+const { updateStore } = await import('../src/lib/stores/update.svelte.js');
+
+async function offered() {
+	updateStore.close();
+	log.length = 0;
+	await updateStore.runCheck();
+	assert.equal(updateStore.phase, 'available');
+}
+
+function settleAnswering(answer: boolean) {
+	return async () => {
+		// Resolves a macrotask later, so a store that starts the install without
+		// waiting would log it first.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		log.push('settled');
+		return answer;
+	};
+}
+
+test('the install starts only once the window has settled', async () => {
+	await offered();
+	await updateStore.startDownload(settleAnswering(true));
+	assert.deepEqual(log, ['settled', 'install', 'relaunch']);
+});
+
+test('backing out of the review installs nothing, and leaves the update on offer', async () => {
+	await offered();
+	await updateStore.startDownload(settleAnswering(false));
+	assert.deepEqual(log, ['settled']);
+	assert.equal(updateStore.phase, 'available');
+
+	await updateStore.startDownload(settleAnswering(true));
+	assert.deepEqual(log, ['settled', 'settled', 'install', 'relaunch'], 'and it can still be installed');
+});

--- a/scripts/viewModeWithoutSaving.spec.ts
+++ b/scripts/viewModeWithoutSaving.spec.ts
@@ -425,7 +425,8 @@ test('closing the window still reviews unsaved tabs', () => {
 	assert.match(exit, /if \(\w+ !== 'discard'\) return;/, "an answer other than 'discard' stops the exit");
 
 	const closeHandler = sliceBetween(viewer, 'appWindow.onCloseRequested', 'onDragDropEvent');
-	assert.match(closeHandler, /canCloseTab,\n/, 'the walk still runs the per-tab dialog');
+	assert.match(closeHandler, /await settleForExit\(\)/, 'the close still runs the review');
+	assert.match(pluck('settleForExit'), /canCloseTab,\n/, 'the walk still runs the per-tab dialog');
 });
 
 test('the view toggles no longer re-read the file to leave an editable pane', () => {

--- a/scripts/windowClosePerTab.test.ts
+++ b/scripts/windowClosePerTab.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import test from 'node:test';
 
 import { reviewDirtyTabs, type ReviewTab } from '../src/lib/sessions/closeReview.js';
-import { offsetOf, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
+import { functionSource, offsetOf, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
 const viewer = readSource('src/lib/MarkdownViewer.svelte');
 const documentSessionPath = 'src/lib/sessions/documentSession.svelte.ts';
@@ -17,6 +17,11 @@ const documentSession = existsSync(documentSessionPath) ? readSource(documentSes
 
 function closeHandler(): string {
 	return sliceBetween(viewer, 'appWindow.onCloseRequested', 'onDragDropEvent');
+}
+
+/** The walk and the snapshot, which the in-app update runs too (#761). */
+function settle(): string {
+	return functionSource(viewer, 'settleForExit');
 }
 
 /**
@@ -49,14 +54,15 @@ function window_(paths: string[], answers: Record<string, boolean> = {}) {
 }
 
 test('the aggregate unsaved-files modal is gone from the close handler', () => {
-	const handler = closeHandler();
-	assert.doesNotMatch(handler, /youHaveUnsavedFiles/);
-	// and the old "clear all dirty flags then close" discard path with it.
-	// Pinned as the assignment rather than as the `forEach` one-liner it was
-	// written in: the same silent discard spelled `for (const t of
-	// tabManager.tabs) t.isDirty = false;` passed the old regex, and the walk
-	// below then found nothing to review.
-	assert.doesNotMatch(handler, /\.isDirty\s*=\s*false/);
+	for (const scope of [closeHandler(), settle()]) {
+		assert.doesNotMatch(scope, /youHaveUnsavedFiles/);
+		// and the old "clear all dirty flags then close" discard path with it.
+		// Pinned as the assignment rather than as the `forEach` one-liner it was
+		// written in: the same silent discard spelled `for (const t of
+		// tabManager.tabs) t.isDirty = false;` passed the old regex, and the walk
+		// below then found nothing to review.
+		assert.doesNotMatch(scope, /\.isDirty\s*=\s*false/);
+	}
 });
 
 test('every dirty tab is activated, asked about, and then closed, one at a time', async () => {
@@ -116,44 +122,49 @@ test('a resolved tab is kept open when the window state is about to be snapshott
 
 test('the close is prevented synchronously before the walk starts', () => {
 	const handler = closeHandler();
-	const branchStart = offsetOf(handler, 'if (dirtyTabs.length > 0) {');
-	const prevent = offsetOf(handler, 'event.preventDefault()', branchStart);
-	const walk = offsetOf(handler, 'reviewDirtyTabs({', branchStart);
-	assert.ok(prevent < walk, 'the close is prevented before the walk starts');
+	// Not the re-entry guard's `preventDefault`: the one between that guard and
+	// the walk.
+	const guardEnd = offsetOf(handler, 'return;', offsetOf(handler, 'if (isCloseWalkActive)'));
+	const walk = offsetOf(handler, 'await settleForExit()');
+	const prevent = handler.lastIndexOf('event.preventDefault()', walk);
+	assert.ok(guardEnd < prevent, 'the close is prevented before the walk starts');
+	assert.match(settle(), /reviewDirtyTabs\(\{/, 'and the walk is what settleForExit runs');
 });
 
 test('the window closes only after every dirty tab is resolved', () => {
 	const handler = closeHandler();
-	const walk = offsetOf(handler, 'reviewDirtyTabs({');
+	const walk = offsetOf(handler, 'await settleForExit()');
 	const close = offsetOf(handler, 'appWindow.close()', walk);
 	assert.ok(walk < close, 'the window closes after the walk, not during it');
 });
 
 test('a cancelled walk stops the handler before it persists or closes', () => {
+	const body = settle();
+	const walk = offsetOf(body, 'reviewDirtyTabs({');
+	const bail = offsetOf(body, 'if (!resolved) return false;', walk);
+	assert.ok(bail < offsetOf(body, 'persistWindowState()', walk), 'cancel returns before the snapshot');
+
 	const handler = closeHandler();
-	const walk = offsetOf(handler, 'reviewDirtyTabs({');
-	const bail = offsetOf(handler, 'if (!resolved) return;', walk);
-	assert.ok(bail < offsetOf(handler, 'persistWindowState()', walk), 'cancel returns before the snapshot');
-	assert.ok(bail < offsetOf(handler, 'appWindow.close()', walk), 'and before the close is re-triggered');
+	const stop = offsetOf(handler, 'if (!(await settleForExit())) return;');
+	assert.ok(stop < offsetOf(handler, 'appWindow.close()', stop), 'and before the close is re-triggered');
 });
 
 test('a second close request cannot start a competing walk', () => {
-	const handler = closeHandler();
 	// The native red button bypasses the dialog overlay; re-entry must be
 	// swallowed while a walk is active, or two walks fight over setActive
 	// and the highlighted tab stops matching the dialog.
-	assert.match(handler, /if \(isCloseWalkActive\) \{\s*event\.preventDefault\(\);\s*return;\s*\}/);
+	assert.match(closeHandler(), /if \(isCloseWalkActive\) \{\s*event\.preventDefault\(\);\s*return;\s*\}/);
 	// and the flag is always released, even when the user cancels mid-walk
-	assert.match(handler, /finally \{\s*isCloseWalkActive = false;\s*\}/);
+	assert.match(settle(), /finally \{\s*isCloseWalkActive = false;\s*\}/);
 });
 
 test('the walk proceeds in strict tab-strip order', () => {
 	// Which tab is next is the component's half of the walk: the order comes
 	// from the tab array, and an active-first shortcut made the sequence look
 	// random to the reader. The walking itself is covered above.
-	const handler = closeHandler();
-	assert.match(handler, /nextDirtyTab: \(\) => tabManager\.tabs\.find\(\(t\) => t\.isDirty\)/);
-	assert.doesNotMatch(handler, /active\?\.isDirty/);
+	const body = settle();
+	assert.match(body, /nextDirtyTab: \(\) => tabManager\.tabs\.find\(\(t\) => t\.isDirty\)/);
+	assert.doesNotMatch(body, /active\?\.isDirty/);
 });
 
 test('the untitled save dialog prefills the numbered tab title', () => {
@@ -170,8 +181,7 @@ test('save-as writes a snapshot rather than the buffer as it stands', () => {
 });
 
 test('the restore-on-reopen branch persists window state via the shared helper', () => {
-	const handler = closeHandler();
-	assert.match(handler, /persistWindowState\(\);/);
+	assert.match(settle(), /persistWindowState\(\);/);
 	// no durable-write experiment left behind
 	assert.doesNotMatch(viewer, /saveSessionState|sessionState\.js/);
 });

--- a/scripts/windowStateRestore.spec.ts
+++ b/scripts/windowStateRestore.spec.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 
 import { test } from 'vitest';
 
-import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
+import { functionSource, offsetOf, readSource, sliceBetween } from './sourceTree.js';
 
 // The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
 // Svelte plugin, so the store and the session run under real reactivity, and jsdom
@@ -26,9 +26,9 @@ const session = readSource('src/lib/sessions/windowSession.svelte.ts');
 // always lives on disk — the snapshot never carries rawContent, so unsaved
 // changes are handled exclusively by the per-tab close dialogs.
 
-/** The `onCloseRequested` registration, up to the next window listener. */
-function closeHandler(): string {
-	return sliceBetween(viewer, 'appWindow.onCloseRequested', 'onDragDropEvent');
+/** What the close handler and the in-app update run before the window goes away. */
+function settleForExit(): string {
+	return functionSource(viewer, 'settleForExit');
 }
 
 test('the snapshot carries window state and no document content', () => {
@@ -136,9 +136,9 @@ test('startup restore reads content from disk, not from the snapshot', () => {
 });
 
 test('the close flow resolves dirty tabs before serializing window state', () => {
-	const handler = closeHandler();
-	const walk = offsetOf(handler, 'reviewDirtyTabs({');
-	const persist = offsetOf(handler, 'persistWindowState()');
+	const body = settleForExit();
+	const walk = offsetOf(body, 'reviewDirtyTabs({');
+	const persist = offsetOf(body, 'persistWindowState()');
 	assert.ok(walk < persist, 'dirty tabs must be resolved before the snapshot is written');
 });
 
@@ -193,7 +193,7 @@ test('exit discards the snapshot only once startup has finished', () => {
 });
 
 test('with restore enabled resolved titled tabs stay open for the snapshot', () => {
-	const handler = closeHandler();
+	const handler = settleForExit();
 	// tabs are closed one-by-one only when restore is off (or untitled).
 	// The walk itself is covered by windowClosePerTab, which runs it; what is
 	// asserted here is the policy the component hands it.
@@ -201,7 +201,7 @@ test('with restore enabled resolved titled tabs stay open for the snapshot', () 
 });
 
 test('auto-save fast path silently saves titled tabs before the walk', () => {
-	const handler = closeHandler();
+	const handler = settleForExit();
 	const fastPath = offsetOf(handler, 'if (settings.autoSave) {');
 	const walk = offsetOf(handler, 'reviewDirtyTabs({');
 	assert.ok(fastPath < walk, 'the silent save runs before the per-tab walk');

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -952,6 +952,80 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		await windowSession.persistState();
 	}
 
+	/**
+	 * Resolve this window's unsaved tabs, then write the restore snapshot: the
+	 * work that has to happen before the window goes away. False when the reader
+	 * cancelled, and nothing has been written.
+	 *
+	 * The close button and the in-app update both run it. An update ends the
+	 * process without closing a window — the Windows updater exits inside
+	 * `downloadAndInstall`, `relaunch()` requests an exit elsewhere — so
+	 * CloseRequested never fires, and both jobs used to go down with it (#761).
+	 */
+	async function settleForExit(): Promise<boolean> {
+		// Unsaved content and session restore are separate concerns: dirty tabs
+		// are resolved FIRST through the per-tab dialogs, then the restore
+		// snapshot records window state only (open files, active tab, edit mode,
+		// split, scroll) — it never carries document content.
+		const dirtyTabs = tabManager.tabs.filter((t) => t.isDirty);
+		if (dirtyTabs.length > 0) {
+			isCloseWalkActive = true;
+			// The walk's dialogs are in-app modals inside THIS window: with
+			// multiple windows, another window may be covering it and the review
+			// would be invisible. Bring the reviewing window to the front first.
+			invoke('show_window').catch(console.error);
+			try {
+				// Auto-save without confirmation: silently save every dirty tab
+				// that has a real path. Untitled tabs need a Save dialog, so the
+				// walk below handles them. A failed silent save is surfaced and its
+				// tab also goes to the walk. `saveContent` cancels each tab's pending
+				// timer itself, so no writer here can be raced by its own debounce.
+				if (settings.autoSave) {
+					for (const tab of dirtyTabs.filter((t) => t.path !== '')) {
+						const ok = await saveContent(tab.id);
+						if (!ok) {
+							addToast(t('toast.autoSaveFailed', settings.language), 'error');
+							break;
+						}
+					}
+				}
+
+				// Close review (issue #189): walk the remaining dirty tabs one at a
+				// time — activate each and run the same localized unsaved-changes
+				// dialog a single tab close shows. Cancel stops the walk and keeps
+				// the window open. Strict tab-strip order (left to right) so the
+				// sequence is predictable; numbered untitled titles let the dialog
+				// name each tab. Re-find every round — a save can leave a tab dirty
+				// again (TOCTOU) and tabs can change while a dialog is up.
+				const resolved = await reviewDirtyTabs({
+					nextDirtyTab: () => tabManager.tabs.find((t) => t.isDirty),
+					setActive: (id) => tabManager.setActive(id),
+					settle: tick,
+					canCloseTab,
+					closeTab: (id) => tabManager.closeTab(id),
+					// Resolved tabs (saved, or reverted by Don't Save) stay open for
+					// the window-state snapshot when restore is enabled; untitled
+					// tabs have nothing to restore, and with restore off the red
+					// button closes tabs one by one.
+					shouldCloseAfterResolving: (tab) =>
+						!settings.restoreStateOnReopen || tab.path === '',
+				});
+				if (!resolved) return false;
+			} finally {
+				isCloseWalkActive = false;
+			}
+		}
+
+		// Session is clean now; record the window state for restore. Awaited:
+		// the caller holds the exit until the Rust write returns, so the process
+		// cannot exit under the snapshot.
+		await savePinnedTagIfNeeded();
+		if (settings.restoreStateOnReopen) {
+			await persistWindowState();
+		}
+		return true;
+	}
+
 	// Exit discards the snapshot on purpose — it is how "quit" differs from
 	// closing the window — but only once startup is over. Until `init` sets
 	// `mode` to 'app', the file on disk is still the only complete record of
@@ -3659,80 +3733,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 						return;
 					}
 
-					// Unsaved content and session restore are separate concerns:
-					// dirty tabs are resolved FIRST through the per-tab dialogs,
-					// then the restore snapshot records window state only (open
-					// files, active tab, edit mode, split, scroll) — it never
-					// carries document content.
-					const dirtyTabs = tabManager.tabs.filter((t) => t.isDirty);
-					if (dirtyTabs.length > 0) {
-						event.preventDefault();
-						isCloseWalkActive = true;
-						// The walk's dialogs are in-app modals inside THIS
-						// window: with multiple windows, another window may be
-						// covering it and the review would be invisible. Bring
-						// the reviewing window to the front first.
-						invoke('show_window').catch(console.error);
-						try {
-							// Auto-save without confirmation: silently save every
-							// dirty tab that has a real path. Untitled tabs need a
-							// Save dialog, so the walk below handles them. A failed
-							// silent save is surfaced and its tab also goes to the
-							// walk. `saveContent` cancels each tab's pending timer
-							// itself, so no writer here can be raced by its own
-							// debounce.
-							if (settings.autoSave) {
-								for (const tab of dirtyTabs.filter((t) => t.path !== '')) {
-									const ok = await saveContent(tab.id);
-									if (!ok) {
-										addToast(t('toast.autoSaveFailed', settings.language), 'error');
-										break;
-									}
-								}
-							}
-
-							// Close review (issue #189): walk the remaining dirty
-							// tabs one at a time — activate each and run the same
-							// localized unsaved-changes dialog a single tab close
-							// shows. Cancel stops the walk and keeps the window
-							// open. Strict tab-strip order (left to right) so the
-							// sequence is predictable; numbered untitled titles
-							// let the dialog name each tab. Re-find every round —
-							// a save can leave a tab dirty again (TOCTOU) and
-							// tabs can change while a dialog is up.
-							const resolved = await reviewDirtyTabs({
-								nextDirtyTab: () => tabManager.tabs.find((t) => t.isDirty),
-								setActive: (id) => tabManager.setActive(id),
-								settle: tick,
-								canCloseTab,
-								closeTab: (id) => tabManager.closeTab(id),
-								// Resolved tabs (saved, or reverted by Don't Save)
-								// stay open for the window-state snapshot when
-								// restore is enabled; untitled tabs have nothing to
-								// restore, and with restore off the red button
-								// closes tabs one by one.
-								shouldCloseAfterResolving: (tab) =>
-									!settings.restoreStateOnReopen || tab.path === '',
-							});
-							if (!resolved) return;
-						} finally {
-							isCloseWalkActive = false;
-						}
-					}
-
-					// Session is clean now; record the window state for restore.
-					// Awaited: the close-requested handler holds the close open
-					// until the Rust write returns, so the process cannot exit
-					// under the snapshot.
-					await savePinnedTagIfNeeded();
-					if (settings.restoreStateOnReopen) {
-						await persistWindowState();
-					}
-
-					// If we intercepted the close to run the review, re-trigger
-					// it: the handler re-enters, finds nothing dirty, and the
-					// close proceeds.
-					if (dirtyTabs.length > 0) appWindow.close();
+					// With tabs to review the close is held open while their
+					// dialogs are up, then re-triggered: the handler re-enters,
+					// finds nothing dirty, and the close proceeds.
+					const hadDirtyTabs = tabManager.tabs.some((t) => t.isDirty);
+					if (hadDirtyTabs) event.preventDefault();
+					if (!(await settleForExit())) return;
+					if (hadDirtyTabs) appWindow.close();
 				}),
 			);
 
@@ -4328,6 +4335,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		{/if}
 	</div>
 
+	<!-- Before the modals: installing runs the unsaved-tab review, whose dialogs
+	     share this z-index, so they have to come later to be on top. -->
+	<UpdateDialog {settleForExit} />
+
 	<Modal
 		show={modalState.show}
 		title={modalState.title}
@@ -4347,8 +4358,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		bind:inputValue={promptModal.value}
 		onconfirm={handlePromptConfirm}
 		oncancel={handlePromptCancel} />
-
-	<UpdateDialog />
 
 	{#if identifyFlash}
 		<div class="identify-flash" transition:fade={{ duration: 150 }}>

--- a/src/lib/components/UpdateDialog.svelte
+++ b/src/lib/components/UpdateDialog.svelte
@@ -4,6 +4,8 @@
 	import { settings } from '../stores/settings.svelte.js';
 	import { t } from '../utils/i18n.js';
 
+	let { settleForExit } = $props<{ settleForExit: () => Promise<boolean> }>();
+
 	let dialogEl = $state<HTMLDivElement>();
 	let previousActiveElement: HTMLElement | null = null;
 
@@ -42,7 +44,7 @@
 	}
 
 	function startDownload() {
-		updateStore.startDownload();
+		updateStore.startDownload(settleForExit);
 	}
 
 	function handleKeydown(e: KeyboardEvent) {

--- a/src/lib/stores/update.svelte.ts
+++ b/src/lib/stores/update.svelte.ts
@@ -134,7 +134,7 @@ class UpdateStore {
 		}
 	}
 
-	async startDownload() {
+	async startDownload(settleForExit: () => Promise<boolean>) {
 		if (this.phase !== 'available' || !this.#pending) return;
 
 		const update = this.#pending;
@@ -142,6 +142,14 @@ class UpdateStore {
 		this.phase = 'downloading';
 		this.downloaded = 0;
 		this.total = 0;
+
+		// Installing ends the process without closing the window, so the close
+		// path's work — unsaved tabs, the restore snapshot — runs first (#761).
+		// Cancelling it keeps the update on offer.
+		if (!(await settleForExit())) {
+			this.phase = 'available';
+			return;
+		}
 
 		// Two separate try blocks so the error attribution is precise:
 		// downloadAndInstall failures map to errorSource='download' (the


### PR DESCRIPTION
## What this is

Starting an update from the dialog now runs the same unsaved-tab review and session snapshot as closing the window, before anything is installed. cikeyz reported untitled tabs gone after updating to 2.7.6 in #761. `UpdateDialog` moves above the two modals in the markup so the review's dialogs, which share its z-index, draw on top.

## Mechanism

Both jobs lived only in `onCloseRequested`, and an install never raises it. The Windows updater calls `std::process::exit(0)` inside `downloadAndInstall` (tauri-plugin-updater 2.10.1, `updater.rs:865`). `relaunch()` elsewhere sends `RequestExit`, which tauri-runtime-wry turns into `ExitRequested` and an exit without closing any window. Unsaved tabs were dropped unasked, and the next launch restored an older snapshot.

## Scope

Only the window the update starts from is reviewed, as Quit does today (#390). The legacy `savedTabsData` half of #761 is left alone: that migration runs once, and everyone on 2.6.13 or later has already been through it.

## Tests

`updateSettlesBeforeInstall.spec.ts` drives the store with the plugins mocked: the install waits for the review, and a cancelled review installs nothing and keeps the update on offer. Both go red with the call removed. The close-handler shape tests now read `settleForExit` and check the handler still calls it.

## Verification

macOS 26.6, arm64.

```
npm run check
```
```
npm test
```
```
npm run test:vitest
```

0 errors, 1030/1030, 436/436. No Rust changed and `cargo test` was not run. Not run: a real install on any platform. Both exit paths are read from the plugin and runtime source.

## Refs

- #761
