### PR TITLE
Sticky scroll pins the headings the viewport is under

### DIFF
--- a/scripts/headingLinkCompletion.test.ts
+++ b/scripts/headingLinkCompletion.test.ts
@@ -92,8 +92,9 @@ test('the list is read from Rust, and re-read only when the buffer changes', () 
 	assert.match(editorSource, /invoke\("list_heading_anchors", \{\s*\n?\s*markdown: model\.getValue\(\),/);
 	assert.match(rustSource, /async fn list_heading_anchors\(markdown: String\)/);
 	// Completion fires per keystroke while the dropdown is open; the headings
-	// cannot have moved between two keystrokes of one edit.
-	assert.match(editorSource, /if \(anchorCache\?\.version === version\) return anchorCache\.anchors;/);
+	// cannot have moved between two keystrokes of one edit. Keyed on the model
+	// too, because version ids are counted per model and each tab has its own.
+	assert.match(editorSource, /if \(anchorCache\?\.model === model && anchorCache\.version === version\) return anchorCache\.anchors;/);
 });
 
 test('the Rust side numbers repeated headings the way the renderer does', () => {

--- a/scripts/headingSymbols.test.ts
+++ b/scripts/headingSymbols.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type * as Monaco from 'monaco-editor';
+
+import { headingSymbols } from '../src/lib/utils/headingSymbols.js';
+
+const heading = (line: number, level: number, text: string) => ({ line, level, text, slug: '' });
+
+/** One row per symbol, indented by depth: `name start-end`. */
+function outline(symbols: Monaco.languages.DocumentSymbol[], depth = 0): string[] {
+	return symbols.flatMap((symbol) => [
+		`${'  '.repeat(depth)}${symbol.name} ${symbol.range.startLineNumber}-${symbol.range.endLineNumber}`,
+		...outline(symbol.children ?? [], depth + 1),
+	]);
+}
+
+test('#759: a section nests under the heading above it, and ends where a peer or a parent starts', () => {
+	// The document from the issue, with a second H2 so a section has to close.
+	const symbols = headingSymbols(
+		[heading(1, 1, 'H1'), heading(3, 2, 'H2'), heading(5, 3, 'H3'), heading(10, 3, 'Second H3'), heading(14, 2, 'Another H2')],
+		16,
+		0,
+	);
+	assert.deepEqual(outline(symbols), [
+		'H1 1-16',
+		'  H2 3-13',
+		'    H3 5-9',
+		'    Second H3 10-13',
+		'  Another H2 14-16',
+	]);
+});
+
+test('a skipped level still nests, and a shallower heading closes every deeper section', () => {
+	const symbols = headingSymbols([heading(1, 1, 'A'), heading(2, 3, 'deep'), heading(4, 2, 'B'), heading(6, 1, 'C')], 8, 0);
+	assert.deepEqual(outline(symbols), ['A 1-5', '  deep 2-3', '  B 4-5', 'C 6-8']);
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -25,6 +25,7 @@
 		headingQueryStart,
 		type HeadingAnchor,
 	} from '../utils/headingCompletion.js';
+	import { headingSymbols } from '../utils/headingSymbols.js';
 	import {
 		getLineAtVerticalOffset,
 		getScrollSyncPositionFromPixels,
@@ -600,18 +601,21 @@
 	 * Asked of Rust rather than derived here: the ids come out of comrak's
 	 * anchorizer, and a second implementation in TypeScript would drift from
 	 * it silently, producing links that look right and land nowhere.
+	 *
+	 * Keyed on the model as well: each tab has its own, and version ids are
+	 * counted per model, so two tabs can stand at the same one.
 	 */
-	let anchorCache: { version: number; anchors: HeadingAnchor[] } | null = null;
+	let anchorCache: { model: Monaco.editor.ITextModel; version: number; anchors: HeadingAnchor[] } | null = null;
 
 	async function headingAnchors(model: Monaco.editor.ITextModel): Promise<HeadingAnchor[]> {
 		const version = model.getVersionId();
-		if (anchorCache?.version === version) return anchorCache.anchors;
+		if (anchorCache?.model === model && anchorCache.version === version) return anchorCache.anchors;
 
 		try {
 			const anchors = (await invoke("list_heading_anchors", {
 				markdown: model.getValue(),
 			})) as HeadingAnchor[];
-			anchorCache = { version, anchors };
+			anchorCache = { model, version, anchors };
 			return anchors;
 		} catch {
 			return [];
@@ -626,6 +630,15 @@
 		MARKDOWN_LANGUAGE_ID,
 		semanticTokensProvider,
 	);
+
+	// What sticky scroll pins (#759), from the same heading list link completion
+	// uses.
+	const documentSymbols = monaco.languages.registerDocumentSymbolProvider(MARKDOWN_LANGUAGE_ID, {
+		provideDocumentSymbols: async (model) => {
+			const lineCount = model.getLineCount();
+			return headingSymbols(await headingAnchors(model), lineCount, monaco.languages.SymbolKind.String);
+		},
+	});
 
 	const completionProvider = monaco.languages.registerCompletionItemProvider(
 			"markdown",
@@ -850,6 +863,7 @@
 			container.removeEventListener("wheel", wheelListener, { capture: true });
 			completionProvider.dispose();
 			semanticTokens.dispose();
+			documentSymbols.dispose();
 			// The keybinding rules are global to the Monaco module, not to this
 			// editor, so they are disposed with it rather than left to pile up one
 			// copy per mount — this component is rebuilt every time a tab goes to

--- a/src/lib/utils/headingSymbols.ts
+++ b/src/lib/utils/headingSymbols.ts
@@ -1,0 +1,40 @@
+import type * as Monaco from 'monaco-editor';
+
+import type { HeadingAnchor } from './headingCompletion.js';
+
+/**
+ * The document's headings as nested sections, for Monaco's sticky scroll (#759).
+ *
+ * Sticky scroll pins the symbols the viewport is inside, and asks the document
+ * symbol provider first. Markdown had none, so it fell back to indentation,
+ * which pins a wrapped list item and never a heading. A section runs from its
+ * heading to the line before the next heading at the same level or above, and
+ * sits inside the nearest heading above it with a lower level — the outline
+ * VS Code's Markdown extension hands the same editor.
+ */
+export function headingSymbols(
+	anchors: HeadingAnchor[],
+	lineCount: number,
+	kind: Monaco.languages.SymbolKind,
+): Monaco.languages.DocumentSymbol[] {
+	const roots: Monaco.languages.DocumentSymbol[] = [];
+	const open: { level: number; children: Monaco.languages.DocumentSymbol[] }[] = [];
+	anchors.forEach((anchor, i) => {
+		const next = anchors.slice(i + 1).find((later) => later.level <= anchor.level);
+		const children: Monaco.languages.DocumentSymbol[] = [];
+		const line = { startLineNumber: anchor.line, startColumn: 1, endLineNumber: anchor.line, endColumn: 1 };
+		const symbol = {
+			name: anchor.text,
+			detail: '',
+			kind,
+			tags: [],
+			range: { ...line, endLineNumber: next ? next.line - 1 : lineCount },
+			selectionRange: line,
+			children,
+		};
+		while (open.length > 0 && open[open.length - 1].level >= anchor.level) open.pop();
+		(open[open.length - 1]?.children ?? roots).push(symbol);
+		open.push({ level: anchor.level, children });
+	});
+	return roots;
+}


### PR DESCRIPTION
## What this is

The editor's sticky scroll now shows the headings the viewport is inside, H1 above H2 above H3, the way VS Code does for Markdown. netricsa asked for it in #759. Markdown gets a document symbol provider built on `list_heading_anchors`, the heading list link completion already reads.

## Mechanism

Sticky scroll asks the document symbol provider first (`stickyScroll.defaultModel` is `outlineModel`). Nothing registered one for Markdown, so it fell back to indentation, which pins a wrapped list item and never a heading.

## Scope

The heading cache is now keyed on the model as well as its version. Version ids are counted per model and each tab has its own, so two tabs at the same version could be handed one tab's headings. Documents without headings keep the indentation fallback. Go to Symbol now lists headings too, because it reads the same provider.

## Tests

`headingSymbols.test.ts` runs the nesting on the document from the issue and on a skipped level. It goes red with the pop condition loosened. The cache assertion in `headingLinkCompletion.test.ts` follows the new key.

## Verification

macOS 26.6, arm64.

```
npm run check
```
```
npm test
```
```
npm run test:vitest
```

0 errors, 1032/1032, 434/434. Not run yet: sticky scroll on a build, and anything on Windows or Linux.

## Refs

- #759
