### PR TITLE
Word wrap reaches the window edge in proportional fonts

### DIFF
--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -157,9 +157,22 @@ test('editor options are applied by a single updateOptions effect', () => {
 			'smoothScrolling',
 			'wordWrap',
 			'wordWrapColumn',
+			'wrappingStrategy',
 		],
 		'and the set is exactly the options both call sites share',
 	);
+});
+
+test('a proportional font wraps on measured widths, a monospace font keeps the fast path', () => {
+	// #758: 'simple' wrapped Times New Roman and Roboto lines well short of the
+	// window edge. Both values are asserted because 'advanced' everywhere would
+	// also fix the report, and would make every large file pay for it.
+	assert.equal(editorOptionsFromSettings(SETTINGS, 100, true).wrappingStrategy, 'simple');
+	assert.equal(editorOptionsFromSettings(SETTINGS, 100, false).wrappingStrategy, 'advanced');
+
+	// The measurement only helps if the update effect passes it: its stub is
+	// false, so a call that drops the argument falls back to 'simple' here.
+	assert.equal(optionsPassedTo('editor.updateOptions', SETTINGS).wrappingStrategy, 'advanced');
 });
 
 test('tab cycling avoids Cmd+Tab, which macOS never delivers to the app', () => {
@@ -332,7 +345,7 @@ function optionsPassedTo(callee: string, settings: Record<string, unknown> = {})
 		compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
 	}).outputText;
 
-	// The literals close over six locals and one import, stubbed rather than
+	// The literals close over seven locals and one import, stubbed rather than
 	// reconstructed — except the import, which is the real function: the
 	// settings-derived options live there now, and stubbing them would leave
 	// the evaluated object missing exactly what these tests read.
@@ -340,6 +353,8 @@ function optionsPassedTo(callee: string, settings: Record<string, unknown> = {})
 	// model (or `value`/`language` when there is no tab); an empty object is the
 	// right stub because nothing it can contain is an option this file asserts
 	// on. `zoomLevel` is 100, the neutral factor, for the same reason.
+	// `fontIsMonospace` is false, the opposite of the parameter's default, so a
+	// literal that forgets to pass it is visible.
 	return new Function(
 		'settings',
 		'value',
@@ -347,9 +362,10 @@ function optionsPassedTo(callee: string, settings: Record<string, unknown> = {})
 		'getTheme',
 		'documentOptions',
 		'zoomLevel',
+		'fontIsMonospace',
 		'editorOptionsFromSettings',
 		`return ${js};`,
-	)(settings, '', 'markdown', () => 'app-theme-dark', {}, 100, editorOptionsFromSettings) as Record<
+	)(settings, '', 'markdown', () => 'app-theme-dark', {}, 100, false, editorOptionsFromSettings) as Record<
 		string,
 		unknown
 	>;

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -161,6 +161,7 @@
 	// the editor has to gate on this flag, or it runs once against a missing
 	// editor and never runs again.
 	let editorReady = $state(false);
+	let fontIsMonospace = $state(true);
 	let localizedActions: Monaco.IDisposable[] = [];
 
 	// `settings.osType` is resolved asynchronously from the Rust side, so it can
@@ -571,6 +572,16 @@
 				);
 			} else {
 				selectionCount = 0;
+			}
+		});
+
+		// Feeds the wrapping strategy in `editorOptionsFromSettings`. `fontInfo`
+		// changes with the font setting and when Monaco remeasures after a font
+		// finishes loading.
+		fontIsMonospace = editor.getOption(monaco.editor.EditorOption.fontInfo).isMonospace;
+		editor.onDidChangeConfiguration((e) => {
+			if (e.hasChanged(monaco.editor.EditorOption.fontInfo)) {
+				fontIsMonospace = editor.getOption(monaco.editor.EditorOption.fontInfo).isMonospace;
 			}
 		});
 
@@ -2231,7 +2242,7 @@
 
 	$effect(() => {
 		if (editorReady && editor) {
-			editor.updateOptions(editorOptionsFromSettings(settings, zoomLevel));
+			editor.updateOptions(editorOptionsFromSettings(settings, zoomLevel, fontIsMonospace));
 		}
 	});
 

--- a/src/lib/utils/editorOptions.ts
+++ b/src/lib/utils/editorOptions.ts
@@ -24,16 +24,23 @@ import { animatesCursor, animatesJumpScroll } from "./motion.js";
  *
  * `zoomPercent` is a parameter rather than another settings field because the
  * two call sites genuinely pass different things — see the note at the
- * creation site.
+ * creation site. `fontIsMonospace` is Monaco's own measurement of the chosen
+ * font, which only exists once an editor has rendered with it.
  */
 export function editorOptionsFromSettings(
 	settings: EditorOptionSettings,
 	zoomPercent: number,
+	fontIsMonospace = true,
 ): MonacoEditor.IEditorOptions {
 	return {
 		minimap: { enabled: settings.minimap },
 		wordWrap: settings.wordWrap as "on" | "off" | "wordWrapColumn" | "bounded",
 		wordWrapColumn: settings.editorMaxWidth,
+		// 'simple' counts every character as wide as `n`, which only holds for a
+		// monospace font: in Times New Roman or Roboto a line wrapped well short
+		// of the window edge (#758). 'advanced' measures in the DOM and is slow
+		// on large files, so only a proportional font pays for it.
+		wrappingStrategy: fontIsMonospace ? "simple" : "advanced",
 		lineNumbers: settings.lineNumbers as "on" | "off" | "relative" | "interval",
 		// A Monaco string enum, not a flag. Any non-empty string is truthy, so
 		// a ternary on it can only ever produce "line" — which defeats both the


### PR DESCRIPTION
## What this is

With Word Wrap set to Window, lines in a proportional font such as Times New Roman or Roboto wrapped well before the window edge. Reported by @Fallgrim in #758. The Roboto ş/ğ rendering in the same issue is a separate question and is not touched here.

## Mechanism

Markpad never set `wrappingStrategy`, so Monaco used `simple`, which counts every character as wide as `n`. That only holds for monospace fonts. `advanced` measures in the DOM, and Monaco warns it is slow on large files, so it is used only when Monaco's own `fontInfo.isMonospace` is false. The measurement goes through `editorOptionsFromSettings`, so the single `updateOptions` effect stays the only call site.

Standalone Monaco 0.55.1 in Chromium, 630px content width, right edge of each wrapped row:

- Times New Roman, `simple`: 396–481px
- Times New Roman, `advanced`: 596–607px
- Menlo (`isMonospace` true, unchanged): up to 607px

## Tests

`editorOptionWiring.test.ts` asserts both strategies and that the update effect passes the measurement. It goes red with the ternary hard-coded to `simple`, and red with the effect dropping the argument.

## Verification

macOS 26.6, arm64.

```
npm run check
```
```
npm test
```
```
npm run test:vitest
```

0 errors, 1033/1033, 436/436. The wrap numbers come from a standalone Monaco page, not the app. Not run: Windows, and a large file in a proportional font.

## Refs

- #758
