### PR TITLE
An in-app update asks for the other windows to be closed first

### DIFF
--- a/scripts/lastWindowWritesSession.spec.ts
+++ b/scripts/lastWindowWritesSession.spec.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+// #767. There is one snapshot slot, and startup restores it into main whoever
+// wrote it. A detached window left on its own used to skip writing it, so the
+// next launch brought back main's older tabs instead of the ones on screen.
+
+let viewerWindows: Array<{ label: string }> = [];
+let saved: string | null = null;
+
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: {
+		currentWindow: { label: 'window-abc' },
+		currentWebview: { windowLabel: 'window-abc', label: 'window-abc' },
+	},
+	invoke: (cmd: string, args: any) => {
+		switch (cmd) {
+			case 'get_os_type':
+				return Promise.resolve('macos');
+			case 'list_viewer_windows':
+				return Promise.resolve(viewerWindows);
+			case 'save_window_state':
+				saved = args.json;
+				return Promise.resolve(null);
+			default:
+				return Promise.resolve(null);
+		}
+	},
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createWindowSession } = await import('../src/lib/sessions/windowSession.svelte.js');
+
+async function persistFromDetachedWindow(open: string[]) {
+	tabManager.closeAll();
+	tabManager.addTab('/notes/a.md', '# a');
+	viewerWindows = open.map((label) => ({ label }));
+	saved = null;
+	await createWindowSession({
+		isMainWindow: false,
+		windowStateKey: 'savedTabsDataV2',
+		legacyStateKey: 'savedTabsData',
+		restoreInProgressKey: 'markpad-window-restore-in-progress',
+		serializeState: () => tabManager.serializeState(),
+		shouldRestoreState: () => true,
+		isDisposed: () => false,
+		restoreState: () => {},
+		restoredTabs: () => [],
+		applyRestoredContent: async () => {},
+		dropRestoredTab: () => {},
+		canTransfer: () => true,
+		canDetach: () => true,
+		transferPayload: () => '',
+		onTransferClaimed: () => {},
+		acceptTransferredTab: async () => true,
+		onError: () => {},
+		onWarning: () => {},
+		onInterrupted: () => {},
+	}).persistState();
+}
+
+test('the last window left writes the session, though it is not main', async () => {
+	await persistFromDetachedWindow(['window-abc']);
+	assert.deepEqual(
+		JSON.parse(saved ?? '{"tabs":[]}').tabs.map((tab: { path: string }) => tab.path),
+		['/notes/a.md'],
+	);
+});
+
+test('while another window is open, a detached window leaves the session alone', async () => {
+	await persistFromDetachedWindow(['main', 'window-abc']);
+	assert.equal(saved, null);
+});
+
+test('a registry that has not heard from this window yet does not make it the last one', async () => {
+	await persistFromDetachedWindow(['main']);
+	assert.equal(saved, null);
+});

--- a/scripts/updateSettlesBeforeInstall.spec.ts
+++ b/scripts/updateSettlesBeforeInstall.spec.ts
@@ -6,9 +6,12 @@ import { test, vi } from 'vitest';
 // updater exits inside `downloadAndInstall`, `relaunch()` requests an exit
 // elsewhere — so CloseRequested never fires and nothing reviews unsaved tabs or
 // writes the restore snapshot unless the store asks for it first.
-const { log } = vi.hoisted(() => ({ log: [] as string[] }));
+const { log, windows } = vi.hoisted(() => ({ log: [] as string[], windows: [{ label: 'main' }] }));
 
-vi.mock('@tauri-apps/api/core', () => ({ invoke: async () => true }));
+vi.mock('@tauri-apps/api/core', () => ({
+	invoke: async (cmd: string) => (cmd === 'list_viewer_windows' ? windows : true),
+}));
+vi.mock('@tauri-apps/api/window', () => ({ getCurrentWindow: () => ({ label: 'main' }) }));
 vi.mock('@tauri-apps/api/app', () => ({ getVersion: async () => '2.7.6' }));
 vi.mock('@tauri-apps/plugin-updater', () => ({
 	check: async () => ({ version: '2.7.7', body: '', downloadAndInstall: async () => void log.push('install') }),
@@ -55,4 +58,27 @@ test('backing out of the review installs nothing, and leaves the update on offer
 
 	await updateStore.startDownload(settleAnswering(true));
 	assert.deepEqual(log, ['settled', 'settled', 'install', 'relaunch'], 'and it can still be installed');
+});
+
+// #767. The install ends every window, and only the one it starts from reviews
+// its tabs, so another open window has to close first.
+test('with another window open, nothing is reviewed or installed until it has closed', async () => {
+	await offered();
+	windows.push({ label: 'window-abc' });
+	try {
+		await updateStore.startDownload(settleAnswering(true));
+		assert.deepEqual(log, []);
+		assert.equal(updateStore.phase, 'available', 'the update stays on offer');
+		assert.deepEqual(
+			updateStore.otherWindows.map((window) => window.label),
+			['window-abc'],
+			'and the dialog can name the window in the way',
+		);
+	} finally {
+		windows.pop();
+	}
+
+	await updateStore.startDownload(settleAnswering(true));
+	assert.deepEqual(log, ['settled', 'install', 'relaunch'], 'once it has closed, the install goes ahead');
+	assert.equal(updateStore.otherWindows.length, 0);
 });

--- a/scripts/windowStateRestore.spec.ts
+++ b/scripts/windowStateRestore.spec.ts
@@ -156,9 +156,6 @@ test('v2 snapshots are invisible to legacy builds (Rust file, localStorage keys 
 	assert.match(scope, /removeItem\(options\.windowStateKey\)/);
 	assert.match(scope, /removeItem\(options\.legacyStateKey\)/);
 	assert.match(viewer, /const WINDOW_STATE_KEY = 'savedTabsDataV2';/);
-	// only the main window persists: secondary labels are per-session, and a
-	// shared write slot would let the last window closed overwrite the rest
-	assert.match(scope, /if \(!options\.isMainWindow\) return;/);
 	// startup prefers the Rust file and falls back to the localStorage keys
 	// (v2 first, then legacy) for one-time migration of older snapshots
 	assert.match(session, /invoke\('load_window_state'\)/);

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -9,6 +9,7 @@
 	import { getTabFileActions, hasRealFilePath } from '../utils/tabFileActions.js';
 	import { isHomePath } from '../utils/homeTab.js';
 	import { modifierFor, shortcutLabel } from '../utils/shortcuts.js';
+	import { windowDisplay, type ViewerWindowEntry } from '../utils/viewerWindows.js';
 
 	let { tab, folderSuffix, isActive, isLast, onclick, onclose } = $props<{
 		tab: Tab;
@@ -74,19 +75,6 @@
 	function openTabFileLocation() {
 		if (!hasRealFilePath(tab.path)) return;
 		invoke('open_file_folder', { path: tab.path }).catch(console.error);
-	}
-
-	type ViewerWindowEntry = {
-		label: string;
-		number: number;
-		tag_name: string | null;
-		active_tab_title: string;
-		tab_count: number;
-	};
-
-	function windowDisplay(window: ViewerWindowEntry, lang: typeof settings.language): string {
-		const identity = window.tag_name ?? `${t('menu.window', lang)} ${window.number}`;
-		return window.active_tab_title ? `${identity} · ${window.active_tab_title}` : identity;
 	}
 
 	async function handleContextMenu(e: MouseEvent) {

--- a/src/lib/components/UpdateDialog.svelte
+++ b/src/lib/components/UpdateDialog.svelte
@@ -3,6 +3,7 @@
 	import { updateStore } from '../stores/update.svelte.js';
 	import { settings } from '../stores/settings.svelte.js';
 	import { t } from '../utils/i18n.js';
+	import { windowDisplay } from '../utils/viewerWindows.js';
 
 	let { settleForExit } = $props<{ settleForExit: () => Promise<boolean> }>();
 
@@ -199,6 +200,16 @@
 							<pre>{updateStore.notes}</pre>
 						</details>
 					{/if}
+					{#if updateStore.otherWindows.length > 0}
+						<div class="other-windows" role="alert">
+							<p>{tk('closeOtherWindows')}</p>
+							<ul>
+								{#each updateStore.otherWindows as other (other.label)}
+									<li>{windowDisplay(other, settings.language)}</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
 				{:else if updateStore.phase === 'package-managed'}
 					<p>{tk('packageManagedBody')}</p>
 				{:else if updateStore.phase === 'downloading'}
@@ -371,6 +382,22 @@
 		white-space: pre-wrap;
 		word-break: break-word;
 		color: var(--color-fg-muted);
+	}
+
+	.other-windows {
+		margin-top: 12px;
+		padding: 8px 12px;
+		background: var(--color-canvas-subtle);
+		border: 1px solid var(--color-border-muted);
+		border-radius: 6px;
+		color: var(--color-fg-default);
+	}
+	.other-windows p {
+		margin: 0;
+	}
+	.other-windows ul {
+		margin: 4px 0 0 0;
+		padding-left: 20px;
 	}
 
 	.centered-row {

--- a/src/lib/sessions/windowSession.svelte.ts
+++ b/src/lib/sessions/windowSession.svelte.ts
@@ -173,8 +173,20 @@ export function createWindowSession(options: WindowSessionOptions) {
 		await writeProgress({ ...progress, deferred });
 	}
 
+	/**
+	 * Main writes the snapshot, and so does the last window left. Startup
+	 * restores the one slot into main whoever wrote it, so a lone detached
+	 * window overwrites nobody, and skipping it brought back main's older tabs
+	 * instead of the ones on screen (#767).
+	 */
+	async function ownsSnapshot(): Promise<boolean> {
+		if (options.isMainWindow) return true;
+		const windows = ((await invoke('list_viewer_windows').catch(() => null)) ?? []) as Array<{ label: string }>;
+		return windows.length === 1 && windows[0].label === appWindow.label;
+	}
+
 	async function persistState() {
-		if (!options.isMainWindow) return;
+		if (!(await ownsSnapshot())) return;
 		await releaseReadableDeferrals();
 		try {
 			await invoke('save_window_state', { json: options.serializeState() });

--- a/src/lib/stores/update.svelte.ts
+++ b/src/lib/stores/update.svelte.ts
@@ -2,6 +2,8 @@ import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { getVersion } from '@tauri-apps/api/app';
 import { invoke } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import type { ViewerWindowEntry } from '../utils/viewerWindows.js';
 
 type UpdatePhase =
 	| 'idle'
@@ -46,6 +48,8 @@ class UpdateStore {
 	// when this is true.
 	errorIsNotConfigured = $state(false);
 	notes = $state('');
+	/** Windows open beside this one when an install was last asked for (#767). */
+	otherWindows = $state<ViewerWindowEntry[]>([]);
 	#pending: Update | null = null;
 	#checkToken = 0;
 
@@ -67,6 +71,7 @@ class UpdateStore {
 		this.latest = '';
 		this.downloaded = 0;
 		this.total = 0;
+		this.otherWindows = [];
 		this.#pending = null;
 	}
 
@@ -82,6 +87,7 @@ class UpdateStore {
 		this.latest = '';
 		this.downloaded = 0;
 		this.total = 0;
+		this.otherWindows = [];
 		this.#pending = null;
 
 		try {
@@ -142,6 +148,17 @@ class UpdateStore {
 		this.phase = 'downloading';
 		this.downloaded = 0;
 		this.total = 0;
+
+		// An install ends every window at once, and only this one reviews its
+		// unsaved tabs and writes the session. So the others close first, each
+		// through its own close review, and the update waits on offer (#767).
+		// No list to go on is how this behaved before it asked.
+		const windows = (await invoke<ViewerWindowEntry[]>('list_viewer_windows').catch(() => null)) ?? [];
+		this.otherWindows = windows.filter((window) => window.label !== getCurrentWindow().label);
+		if (this.otherWindows.length > 0) {
+			this.phase = 'available';
+			return;
+		}
 
 		// Installing ends the process without closing the window, so the close
 		// path's work — unsaved tabs, the restore snapshot — runs first (#761).

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -352,6 +352,7 @@ export const translations: Record<LanguageCode, Translation> = {
             cancel: 'Cancel',
             ok: 'OK',
             downloadInstall: 'Download & Install',
+            closeOtherWindows: 'Close these windows first, or move their tabs here with Merge All Windows Here. After the update, Markpad reopens the tabs in this window.',
             close: 'Close',
             retry: 'Retry'
         },
@@ -725,6 +726,7 @@ export const translations: Record<LanguageCode, Translation> = {
             cancel: '取消',
             ok: '确定',
             downloadInstall: '下载并安装',
+            closeOtherWindows: '请先关闭这些窗口，或用“将所有窗口合并到此处”把它们的标签页移到这里。更新后，Markpad 会重新打开此窗口中的标签页。',
             close: '关闭',
             retry: '重试'
         },
@@ -1380,6 +1382,7 @@ export const translations: Record<LanguageCode, Translation> = {
             cancel: '取消',
             ok: '確定',
             downloadInstall: '下載並安裝',
+            closeOtherWindows: '請先關閉這些視窗，或使用「將所有視窗合併至此」把它們的分頁移到這裡。更新後，Markpad 會重新開啟此視窗中的分頁。',
             close: '關閉',
             retry: '重試'
         },
@@ -1725,6 +1728,7 @@ export const translations: Record<LanguageCode, Translation> = {
             cancel: '취소',
             ok: '확인',
             downloadInstall: '다운로드 및 설치',
+            closeOtherWindows: '먼저 이 창들을 닫거나 Merge All Windows Here로 탭을 이 창으로 옮기세요. 업데이트 후 Markpad는 이 창의 탭을 다시 엽니다.',
             close: '닫기',
             retry: '재시도'
         },

--- a/src/lib/utils/viewerWindows.ts
+++ b/src/lib/utils/viewerWindows.ts
@@ -1,0 +1,15 @@
+import { t, type LanguageCode } from './i18n.js';
+
+/** One row of `list_viewer_windows`. */
+export type ViewerWindowEntry = {
+	label: string;
+	number: number;
+	tag_name: string | null;
+	active_tab_title: string;
+	tab_count: number;
+};
+
+export function windowDisplay(window: ViewerWindowEntry, lang: LanguageCode): string {
+	const identity = window.tag_name ?? `${t('menu.window', lang)} ${window.number}`;
+	return window.active_tab_title ? `${identity} · ${window.active_tab_title}` : identity;
+}


### PR DESCRIPTION
## What this is

Download & Install no longer starts while another Markpad window is open. The dialog names those windows and asks the user to close them or use Merge All Windows Here first. Each one closes through its own unsaved-tab review. SamHasler reported in #767 that an update brought back only one window. This does not try to reopen every window.

## Mechanism

An install ends every window at once, and #763 only settles the window the update starts from, so the others lost unsaved tabs unasked. Updating from a detached window was worse: `persistState` returned early for anything but `main`, and the next launch restored main's older tabs instead of the ones on screen. The last window left now writes the snapshot too. Startup restores the one slot into main whoever wrote it, so a lone window overwrites nobody.

## Scope

The same guard runs when a detached window is closed last with the red X, so that also keeps its tabs now. Korean has no "Merge All Windows Here" string yet, so its notice quotes the English label.

## Tests

`updateSettlesBeforeInstall.spec.ts`: with a second window open nothing is reviewed or installed and the update stays on offer. `lastWindowWritesSession.spec.ts` persists from a detached window: it writes when alone, and not while main is open or before the registry lists it. Reverting either fix turns its tests red. The shape assertion on the old `isMainWindow` line is gone, since the new spec checks both directions.

## Verification

macOS 26.6.2, arm64.

```
npm run check
```
```
npm test
```
```
npm run test:vitest
```

0 errors, 1032/1032, 440/440. No Rust changed and `cargo test` was not run. Not run: a real install, or the dialog on Windows and Linux.

## Refs

- #767
