### PR TITLE
Files dragged onto the window on Windows are accepted again

### DIFF
--- a/scripts/coldStartDoesNotStealFocus.test.ts
+++ b/scripts/coldStartDoesNotStealFocus.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { readRustBackend, readSource } from './sourceTree.js';
+import { readRustBackend } from './sourceTree.js';
 
 const backend = readRustBackend();
 
@@ -33,20 +33,12 @@ test('the main window is shown without being activated on a cold start', () => {
 	assert.ok(guard > 0 && guard < focus, 'the cold-start path falls through to set_focus');
 });
 
-test('the main window builder carries the Windows half of the fix', () => {
-	const app = readSource('src-tauri/src/app.rs');
-
-	// `show()` maps to `SW_SHOW` on Windows, which activates: skipping
-	// `set_focus` does not by itself keep the first show quiet there.
-	// `.focused(false)` sets tao's one-shot `MARKER_DONT_FOCUS` so that show
-	// uses `SW_SHOWNOACTIVATE` instead.
-	assert.match(app, /\.focused\(false\)/);
-
-	// The comment on that line, and its no-op status on macOS and Linux, both
-	// depend on the window still being built hidden.
-	assert.match(app, /\.visible\(false\)/);
-
-	// Detached tab windows are built hidden too, and they SHOULD activate when
-	// revealed — the user just asked for them. Exactly one builder opts out.
-	assert.equal(backend.match(/\.focused\(false\)/g)?.length, 1);
+test('no window builder opts out of focus', () => {
+	// `.focused(false)` on a window built hidden leaves WebView2 on Windows with
+	// no drop target, so every file dragged onto the window is refused (#768,
+	// tauri-apps/wry#1639). Comments are stripped first: the builder explains
+	// why the call is absent by naming it.
+	const code = backend.replace(/\/\/.*$/gm, '');
+	const found = code.match(/\.focused\(false\)/g)?.length ?? 0;
+	assert.equal(found, 0, `found ${found} .focused(false) in the Rust backend`);
 });

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -82,15 +82,10 @@ pub fn run() {
             .inner_size(900.0, 650.0)
             .min_inner_size(400.0, 300.0)
             .visible(false)
-            // Half of "a cold start does not steal focus"; the other half is
-            // `show_window`. Windows maps `show()` to `SW_SHOW`, which
-            // activates, so dropping the `set_focus` call there is not enough
-            // on its own. This sets tao's one-shot `MARKER_DONT_FOCUS`, which
-            // makes the FIRST show use `SW_SHOWNOACTIVATE` and is then cleared,
-            // so every later show still comes to the front. On macOS and Linux
-            // it is a no-op: tao only reads `focused` for a window that is
-            // built visible, and this one is not.
-            .focused(false)
+            // Not `.focused(false)`: on a window built hidden it leaves WebView2
+            // on Windows with no drop target, so every file dragged in is
+            // refused (#768, tauri-apps/wry#1639). `show_window` skipping
+            // `set_focus` is what keeps a cold start from stealing focus.
             .resizable(true)
             .shadow(false)
             .center();


### PR DESCRIPTION
## What this is

On Windows, dragging a file onto Markpad shows a no-entry cursor and inserts nothing, reported by BrunoX66 in #768 on 2.7.6. This removes the `.focused(false)` that #704 added to the main window builder in 2.7.5.

## Mechanism

wry registers its drop target on WebView2's child windows once, while the webview is built, and turns WebView2's own drop handling off. On a window built hidden with an unfocused webview that registration does not take, so nothing accepts the drop (tauri-apps/wry#1639). The upstream fix, tauri-apps/wry#1638, is unmerged, and `drag_drop.rs` is unchanged in wry 0.57.0.

## Scope

`show_window` still skips `set_focus` on the first show, so the synthesized Alt press from #702 stays gone. That show is now a plain `SW_SHOW`, which Windows' foreground lock should refuse once the user is working in another app. Calling `ShowWindow(SW_SHOWNOACTIVATE)` directly was not taken: tao keeps visibility in its own flags, and a window shown behind its back is hidden again by the next maximize (`window_state.rs:420`).

## Tests

`coldStartDoesNotStealFocus.test.ts` now asserts the backend has no `.focused(false)`, with comments stripped. With the call put back it fails with `found 1`.

## Verification

macOS 26.6, arm64.

```
npm run check
```
```
npm test
```
```
cargo test
```

0 errors, 1032/1032, 164 passed. Not run: anything on Windows. Both the drop failure and the first-show behaviour are read from wry, tao and the upstream threads.

## Refs

- #768
- #702
