### PR TITLE
Pasting an image file copied in Explorer or Finder inserts it

### DIFF
--- a/scripts/imageUndoKeepsFile.spec.ts
+++ b/scripts/imageUndoKeepsFile.spec.ts
@@ -67,6 +67,7 @@ const { countWords } = await import('../src/lib/utils/wordCount.js');
 const { documentParentDir, imageEmbed, resolveImageDirectory } = await import(
 	'../src/lib/utils/imageEmbed.js'
 );
+const { routeDroppedFile } = await import('../src/lib/utils/fileDrop.js');
 
 // ------------------------------------------------- the component, as written
 
@@ -198,13 +199,15 @@ type Backend = {
 	commandsSince: (mark: number) => string[];
 };
 
-function createBackend(clipboardImage: string | null): Backend {
+function createBackend(clipboardImage: string | null, clipboardFiles: string[] | null): Backend {
 	const calls: { cmd: string; args: Record<string, any> }[] = [];
 	return {
 		calls,
 		invoke: async (cmd: string, args: Record<string, any> = {}) => {
 			calls.push({ cmd, args });
 			switch (cmd) {
+				case 'clipboard_read_file_list':
+					return clipboardFiles;
 				case 'clipboard_read_image':
 					return clipboardImage;
 				case 'clipboard_read_text':
@@ -238,7 +241,7 @@ type Component = {
  * the statements that run are the component's own.
  */
 const factorySource = ts.transpileModule(
-	`const __component = (invoke, settings, tabManager, monaco, editor, lineEndingLabel, countWords, resolveImageDirectory, documentParentDir, imageEmbed) => {
+	`const __component = (invoke, settings, tabManager, monaco, editor, lineEndingLabel, countWords, resolveImageDirectory, documentParentDir, imageEmbed, routeDroppedFile) => {
 		let wordCount = 0;
 		let currentLanguage = 'markdown';
 		let lineEnding = 'LF';
@@ -312,6 +315,7 @@ function createComponent(backend: Backend, editor: unknown): Component {
 		resolveImageDir: unknown,
 		parentDir: unknown,
 		embed: unknown,
+		routeDroppedFile: unknown,
 	) => Component;
 
 	return factory(
@@ -325,14 +329,17 @@ function createComponent(backend: Backend, editor: unknown): Component {
 		resolveImageDirectory,
 		documentParentDir,
 		imageEmbed,
+		routeDroppedFile,
 	);
 }
 
 const PASTED_IMAGE = 'iVBORw0KGgo=';
 
-function setup(options: { clipboardImage?: string | null; initial?: string } = {}) {
+function setup(
+	options: { clipboardImage?: string | null; clipboardFiles?: string[] | null; initial?: string } = {},
+) {
 	tabManager.closeAll();
-	const backend = createBackend(options.clipboardImage ?? null);
+	const backend = createBackend(options.clipboardImage ?? null, options.clipboardFiles ?? null);
 	const doc = createDocument(options.initial ?? '');
 	const component = createComponent(backend, doc.editor);
 	doc.listeners.push(...component.contentChange);
@@ -448,6 +455,25 @@ test('pasting an image still copies it and inserts the embed', async () => {
 	assert.equal(save!.args.imageDirectory, 'img');
 	assert.equal(save!.args.base64Data, PASTED_IMAGE);
 	assert.match(doc.text(), /^!\[alt\]\(img\/paste_\d+\.png\)$/);
+});
+
+test('pasting image files copied in a file manager copies them as a drop does (#768)', async () => {
+	// Finder can put a preview image on the clipboard beside the files; the
+	// files are what the user copied, so they win and the preview is not read.
+	const { backend, doc, component } = setup({
+		clipboardFiles: ['/Users/me/pictures/a.png', '/Users/me/notes/other.md', '/Users/me/pictures/b.JPG'],
+		clipboardImage: PASTED_IMAGE,
+	});
+	openTab('/Users/me/notes/report.md');
+
+	await component.paste();
+
+	assert.deepEqual(
+		backend.calls.filter((call) => call.cmd === 'copy_file_to_img').map((call) => call.args.srcPath),
+		['/Users/me/pictures/a.png', '/Users/me/pictures/b.JPG'],
+	);
+	assert.equal(backend.calls.filter((call) => call.cmd === 'save_image').length, 0);
+	assert.equal(doc.text(), '![alt](img/a.png)\n![alt](img/b.JPG)');
 });
 
 test('dropping a file still copies it and inserts the embed', async () => {

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -226,6 +226,7 @@ pub fn run() {
             commands::clipboard_write_text,
             commands::clipboard_read_text,
             commands::clipboard_read_image,
+            commands::clipboard_read_file_list,
             commands::open_markdown_preview,
             commands::render_markdown,
             commands::markdown_semantic_spans,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -724,6 +724,19 @@ pub fn clipboard_read_text() -> Result<String, String> {
     clipboard.get_text().map_err(|e| e.to_string())
 }
 
+/// Files copied in Explorer or Finder: the clipboard holds their paths, not
+/// their pixels (#768). A path that is not valid UTF-8 is skipped, since the
+/// frontend could not hand it back to `copy_file_to_img`.
+#[tauri::command]
+pub fn clipboard_read_file_list() -> Result<Vec<String>, String> {
+    let mut clipboard = arboard::Clipboard::new().map_err(|e| e.to_string())?;
+    let paths = clipboard.get().file_list().map_err(|e| e.to_string())?;
+    Ok(paths
+        .into_iter()
+        .filter_map(|path| path.into_os_string().into_string().ok())
+        .collect())
+}
+
 #[tauri::command]
 pub fn clipboard_read_image(macos_image_scaling: bool) -> Result<String, String> {
     #[cfg(not(target_os = "macos"))]

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -45,6 +45,7 @@
 		imageEmbed,
 		resolveImageDirectory,
 	} from '../utils/imageEmbed.js';
+	import { routeDroppedFile } from '../utils/fileDrop.js';
 
 	// Monaco is ~86% of the startup JavaScript (a 4.4 MB chunk, ~360ms of
 	// parse+eval, paid once per window because every window is its own webview)
@@ -1950,50 +1951,67 @@
 		// A no-op on the ⌘V path, where the editor is focused by definition.
 		editor?.focus();
 			try {
-				// check for image in clipboard via Rust
-				const base64Image = await invoke("clipboard_read_image", { macosImageScaling: settings.macosImageScaling }).catch(() => null) as string | null;
-				if (base64Image && tabManager.activeTab?.path) {
-					const ext = "png"; // output of Rust command is always PNG
-					const filename = `paste_${Date.now()}.${ext}`;
+				const tabPath = tabManager.activeTab?.path;
+				const parentDir = tabPath ? documentParentDir(tabPath) : null;
+				if (tabPath && parentDir !== null) {
+					const imgDirName = resolveImageDirectory(
+						settings.imageDirectory,
+						tabPath,
+					);
+					const embeds: string[] = [];
 
-					const tabPath = tabManager.activeTab.path;
-					const parentDir = documentParentDir(tabPath);
-					if (parentDir !== null) {
-						const imgDirName = resolveImageDirectory(
-							settings.imageDirectory,
-							tabPath,
-						);
-						const relPath = (await invoke("save_image", {
+					// A file copied in Explorer or Finder is a path on the clipboard,
+					// not pixels (#768). Read it first and copy it as a drop does, so
+					// it keeps its own name and bytes rather than whatever preview the
+					// file manager put beside it.
+					const files = await invoke("clipboard_read_file_list").catch(() => null) as string[] | null;
+					for (const srcPath of files ?? []) {
+						if (routeDroppedFile(srcPath, "editor") !== "insert") continue;
+						const relPath = (await invoke("copy_file_to_img", {
+							srcPath,
 							parentDir,
-							filename,
-							base64Data: base64Image,
 							imageDirectory: imgDirName,
 						})) as string;
-						const embed = imageEmbed(relPath);
+						embeds.push(imageEmbed(relPath));
+					}
 
-						const position = editor.getPosition();
-						if (position) {
-							const selection = editor.getSelection();
-							const range =
-								selection && !selection.isEmpty()
-									? selection
-									: new monaco.Range(
-											position.lineNumber,
-											position.column,
-											position.lineNumber,
-											position.column,
-										);
-
-							editor.executeEdits("paste-image", [
-								{
-									range,
-									text: embed,
-									forceMoveMarkers: true,
-								},
-							]);
-
-							return;
+					if (embeds.length === 0) {
+						// check for image in clipboard via Rust
+						const base64Image = await invoke("clipboard_read_image", { macosImageScaling: settings.macosImageScaling }).catch(() => null) as string | null;
+						if (base64Image) {
+							const filename = `paste_${Date.now()}.png`; // output of Rust command is always PNG
+							const relPath = (await invoke("save_image", {
+								parentDir,
+								filename,
+								base64Data: base64Image,
+								imageDirectory: imgDirName,
+							})) as string;
+							embeds.push(imageEmbed(relPath));
 						}
+					}
+
+					const position = editor.getPosition();
+					if (embeds.length > 0 && position) {
+						const selection = editor.getSelection();
+						const range =
+							selection && !selection.isEmpty()
+								? selection
+								: new monaco.Range(
+										position.lineNumber,
+										position.column,
+										position.lineNumber,
+										position.column,
+									);
+
+						editor.executeEdits("paste-image", [
+							{
+								range,
+								text: embeds.join("\n"),
+								forceMoveMarkers: true,
+							},
+						]);
+
+						return;
 					}
 				}
 


### PR DESCRIPTION
## What this is

Copying an image file in Explorer and pressing Ctrl+V in the editor did nothing, reported by BrunoX66 in #768. Paste now reads the clipboard's file list first and copies each image into the image folder the way a drop does. Without image files it falls back to the clipboard image and text as before.

## Mechanism

A copied file is a list of paths on the clipboard (`CF_HDROP` on Windows), not pixels. `pasteFromClipboard` asked only for image data and then for text, got neither, and returned. The new `clipboard_read_file_list` command wraps arboard's `file_list()`, already a dependency. Files are read before image data so the copy keeps its name and bytes, and so a preview image a file manager may put beside the files is not pasted instead.

## Scope

Images only, filtered by `routeDroppedFile`, so paste and drop accept the same files. An untitled tab still inserts nothing, as pasted screenshots and drops already do there.

## Tests

One case in `imageUndoKeepsFile.spec.ts`: two images and a `.md` on the clipboard copy the two images, skip the `.md`, and never read the clipboard image. With `Editor.svelte` reverted it fails.

## Verification

macOS 26.6, arm64.

```
npm run check
```
```
npm test
```
```
npm run test:vitest
```
```
cargo test
```

0 errors, 1032/1032, 437/437, 164 passed. Not run: Explorer on Windows. A manual Finder paste on macOS is still pending.

## Refs

- #768
