### PR TITLE
A drag-selection in a narrow window no longer stops after two lines

### DIFF
--- a/scripts/statusBarHeight.test.ts
+++ b/scripts/statusBarHeight.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource, sliceBetween } from './sourceTree.js';
+
+// The status bar sits directly above the editor, and Monaco cancels an
+// in-progress drag-selection whenever the editor's height changes
+// (`MouseHandler.onConfigurationChanged` -> `stopMonitoring`). So anything that
+// lets this bar's height follow its content ends a drag the user is still
+// making: in a narrow window the items wrapped their text the moment a
+// selection added the "N selected" item, and the selection froze two lines in
+// (#762). A rule about a height nothing computes is not a type; this is the
+// only thing that fails when someone drops `nowrap` again.
+const statusBar = sliceBetween(readSource('src/lib/components/Editor.svelte'), '\t.status-bar {', '\t}');
+
+test('the status bar keeps its items on one line', () => {
+	assert.match(statusBar, /white-space:\s*nowrap;/);
+});
+
+test('the status bar clips what does not fit rather than growing', () => {
+	assert.match(statusBar, /overflow:\s*hidden;/);
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -2709,6 +2709,13 @@
 		min-height: 20px;
 	}
 
+	/* This bar's height must not depend on its content. Monaco cancels an
+	   in-progress drag-selection whenever the editor's height changes
+	   (`MouseHandler.onConfigurationChanged` -> `stopMonitoring`), and the bar
+	   sits directly above the editor. Without `nowrap` the items wrapped their
+	   text in a narrow window the moment a selection added the "N selected"
+	   item, the bar grew a line, the editor lost one, and the drag the user was
+	   still making died where it stood (#762). */
 	.status-bar {
 		padding: 0 10px;
 		font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
@@ -2718,10 +2725,19 @@
 		color: var(--text-primary);
 		display: flex;
 		align-items: center;
-		justify-content: flex-end;
 		min-height: 22px;
 		gap: 20px;
 		user-select: none;
+		white-space: nowrap;
+		overflow: hidden;
+	}
+
+	/* Right-aligns the row while it fits, and drops the overflow off the right
+	   end when it does not. `justify-content: flex-end` would clip the other
+	   end, taking the cursor position — the one reading that changes as you
+	   work — before the encoding, which never changes at all. */
+	.status-bar > .status-item:first-child {
+		margin-left: auto;
 	}
 
 	.status-item {


### PR DESCRIPTION
## What this is

In a small window, Alt+Shift+drag stops selecting after two lines while the pointer keeps moving, reported by netricsa in #762 on 2.7.6. The status bar no longer changes height when its contents change, and the drag runs to wherever the pointer goes.

## Mechanism

The bar sits directly above the editor and had no `white-space` rule. In a narrow window its items wrapped their text the moment a selection added the "N selected" item: the bar grew from 23px to 30px, the editor lost those 7px, and Monaco cancels an in-progress drag-selection on any editor height change (`MouseHandler.onConfigurationChanged` -> `onHeightChanged` -> `stopMonitoring`). Measured in the dev server at 384x586, English, word count on: with the old CSS the trace is `2, 2, 2, 2, 2, 2` selections over six pointer moves; with `nowrap` it is `2, 3, 4, 5, 6, 7`. Ordinary drag-selection died the same way, one character in.

`justify-content: flex-end` goes with it. With the overflow now clipped, flex-end cuts the left end of the row — the cursor position — so the first item gets `margin-left: auto` instead: right-aligned while it fits, and `UTF-8` falls off the right when it does not.

## Scope

The report's first half is Monaco doing column selection on screen lines rather than file lines, which VS Code also does; nothing here changes it. The vim status bar has the same shape but a single text node, so it cannot wrap into a second line.

## Tests

`statusBarHeight.test.ts` reads the `.status-bar` block and asserts `white-space: nowrap` and `overflow: hidden`. Both go red with the two declarations removed. A source-text test because the invariant is about a height nothing computes.

## Verification

macOS 26.6, arm64.

```
npm run check
```
```
npm test
```
```
npm run test:vitest
```
```
npm audit
```

0 errors, 1035/1035, 441/441, 0 vulnerabilities. `cargo test` not run — no Rust touched. Not verified: Windows 11, where the report came from, and any locale whose status bar is narrower than English.

## Refs

- #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)