### PR TITLE
fix(links): a link to a local file no longer leaves the app on a 404 page

### DIFF
--- a/scripts/localFileLinks.test.ts
+++ b/scripts/localFileLinks.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import ts from 'typescript';
+
+import { getMarkdownLinkTarget } from '../src/lib/utils/markdownLinks.js';
 import { resolveLocalFileLinkPath } from '../src/lib/utils/localFileLinks.js';
 import { functionSource, offsetOf, readSource } from './sourceTree.js';
 
@@ -168,4 +171,80 @@ test('an asset URL is never treated as a link to a local file', () => {
 	// Ordinary links keep working: this guard must not swallow them.
 	assert.equal(resolveLocalFileLinkPath('./data.csv', CURRENT), '/notes/data.csv');
 	assert.equal(resolveLocalFileLinkPath('https://example.com/page', CURRENT), null);
+});
+
+// --- the preview claims the click before the router does ----------------------
+
+/*
+ * #772: `[PDF_1](Files/PDF_1.pdf)` opened the file AND left the app on a 404
+ * page that could only be closed from Task Manager.
+ *
+ * Both, from one click, because three listeners see it in this order:
+ *
+ *   <article>            handleLinkClick      — declined a non-markdown link
+ *   document.documentElement   SvelteKit's router  — `if (event.defaultPrevented) return`
+ *   document             handleDocumentClick  — resolves the path, calls openPath
+ *
+ * The router claimed the undecided click and navigated client-side to a route
+ * an SPA does not have, so its 404 page replaced the app — the title bar with
+ * it, which on Windows (`decorations(false)`) is the only way to close the
+ * window. `handleDocumentClick` then ran and opened the PDF, its own
+ * `preventDefault()` two listeners too late.
+ *
+ * A markdown link never had the bug because its branch calls
+ * `stopPropagation()`, so the event never reaches the router at all.
+ */
+
+const linkClick = ts.transpileModule(functionSource(viewer, 'handleLinkClick'), {
+	compilerOptions: { target: ts.ScriptTarget.ES2022 },
+}).outputText;
+
+const handleLinkClick = new Function(
+	'deps',
+	`"use strict";
+	const {
+		tooltip, foldHost, toggleFoldFromClick, getRelativeMarkdownTarget, opensInNewTab,
+		settings, openMarkdownTargetInNewTab, openRelativeMarkdownTarget, scrollToAnchorWhenReady,
+	} = deps;
+	let zoomData;
+	${linkClick}
+	return handleLinkClick;`,
+)({
+	tooltip: { show: true },
+	foldHost: null,
+	toggleFoldFromClick: () => false,
+	getRelativeMarkdownTarget: getMarkdownLinkTarget,
+	opensInNewTab: () => false,
+	settings: { osType: 'macos', linksOpenInNewTab: false },
+	openMarkdownTargetInNewTab: async () => {},
+	openRelativeMarkdownTarget: async () => {},
+	scrollToAnchorWhenReady: async () => {},
+}) as (e: unknown) => Promise<void>;
+
+async function clickLink(href: string) {
+	const anchor = { getAttribute: () => href };
+	const result = { defaultPrevented: false, propagationStopped: false };
+	await handleLinkClick({
+		detail: 1,
+		target: { closest: (selector: string) => (selector === 'a' ? anchor : null) },
+		preventDefault: () => { result.defaultPrevented = true; },
+		stopPropagation: () => { result.propagationStopped = true; },
+	});
+	return result;
+}
+
+test('a link the document handler opens leaves the preview already claimed', async () => {
+	for (const href of ['Files/PDF_1.pdf', './Files/MP4_1.mp4', '/srv/data.csv', 'https://example.com']) {
+		const { defaultPrevented, propagationStopped } = await clickLink(href);
+		assert.equal(defaultPrevented, true, `${href} must not reach the router undecided`);
+		// Claimed, not swallowed: `handleDocumentClick` is one listener further
+		// up and is the thing that opens it.
+		assert.equal(propagationStopped, false, `${href} must still reach the document handler`);
+	}
+});
+
+test('a markdown link is handled here and goes no further', async () => {
+	const { defaultPrevented, propagationStopped } = await clickLink('./other.md');
+	assert.equal(defaultPrevented, true);
+	assert.equal(propagationStopped, true);
 });

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1967,6 +1967,15 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				return;
 			}
 
+			// Every other link is opened by `handleDocumentClick` on `document`,
+			// and SvelteKit's router sits in between (on
+			// `document.documentElement`), claiming any same-origin href whose
+			// click nobody else has: `[a](Files/a.pdf)` became a client-side
+			// navigation to a route that does not exist, and its 404 page
+			// replaced the app — including the title bar it draws, which on
+			// Windows is the only way to close the window (#772). The router
+			// bails on `event.defaultPrevented`.
+			e.preventDefault();
 			return;
 		}
 


### PR DESCRIPTION
## What this is

Clicking a link to a local file in the preview — `[PDF_1](Files/PDF_1.pdf)` — opened the file *and* replaced the app with a 404 page. On Windows the window is `decorations(false)`, so the title bar it drew went with it and the only way out was Task Manager. Reported by @Zman199 in #772, with a screen recording that shows both happening on one click. #111 was the same defect for `.md` links.

Closes #772.

## Mechanism

Three listeners see that click, in this order:

```
<article>                  handleLinkClick       declines anything that is not a markdown target
document.documentElement   SvelteKit's router    if (event.defaultPrevented) return
document                   handleDocumentClick   resolves the path, calls openPath()
```

`handleLinkClick` returned without calling `preventDefault()`, so the router saw an unclaimed same-origin href and navigated client-side to a route the SPA does not have, rendering its 404. `handleDocumentClick` then ran and opened the file — its own `preventDefault()` two listeners too late. A `.md` link was never affected because that branch calls `stopPropagation()` and the event never reaches the router.

## Scope

The document-level handler keeps doing the opening; this only puts the claim in front of the router. `openPath`/`openUrl` resolution (#409, #415) is unchanged.

## Tests

`scripts/localFileLinks.test.ts` now plucks the real `handleLinkClick` out of the component and clicks a pdf, an mp4, an absolute path and an https link through it: each must come back `defaultPrevented` and *not* `propagationStopped`, since the document handler is what opens it. Revert the one line and that test fails; the markdown case stays green either way.

## Verification

macOS 26.6, Apple silicon.

```
npm test
```

1037 pass, 0 fail.

```
npm run test:vitest
```

441 pass, 0 fail.

```
npm run check
```

0 errors, 0 warnings.

Not run: `cargo test` and `npm audit` — no Rust and no dependency change. Not tried by hand on Windows; the router is the same on every platform, but the fatal half of the symptom (no title bar left) is Windows only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
